### PR TITLE
Adopt skainet-docs-ui v1.1.1 (#53)

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -18,7 +18,12 @@ asciidoc:
 
 ui:
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    # SKaiNET-branded UI bundle from the shared skainet-docs-ui repo:
+    #   https://github.com/SKaiNET-developers/skainet-docs-ui
+    # Pinned to a specific tag for reproducible builds. Bumping
+    # this URL to a newer version is a one-line PR. Mainline
+    # SKaiNET pins the same bundle in its own playbook.
+    url: https://github.com/SKaiNET-developers/skainet-docs-ui/releases/download/v1.1.1/ui-bundle.zip
     snapshot: true
 
 output:


### PR DESCRIPTION
Closes #53.

Visual alignment with mainline SKaiNET. Bumps \`docs/antora-playbook.yml\`'s
\`ui.bundle.url\` to the new shared SKaiNET-branded Antora UI bundle from
[\`SKaiNET-developers/skainet-docs-ui\`](https://github.com/SKaiNET-developers/skainet-docs-ui),
pinned to \`v1.1.1\`. Mainline SKaiNET pins the same bundle in
[SKaiNET#502](https://github.com/SKaiNET-developers/SKaiNET/pull/502).

## Two-line scope

\`\`\`diff
 ui:
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    url: https://github.com/SKaiNET-developers/skainet-docs-ui/releases/download/v1.1.1/ui-bundle.zip
     snapshot: true
\`\`\`

## What you'll see in the rebuilt site

- **Brand color**: SKaiNET red \`#dc2626\` instead of upstream Antora blue
- **Typography**: Orbitron headings, Inter body, Fira Code monospace (was Roboto everywhere)
- **Dark mode toggle** in the navbar (🌓 button), persists via \`localStorage\`, defaults from \`prefers-color-scheme\`, FOUC-safe via inline head bootstrap
- **Code blocks**: GitHub-light \`#f6f8fa\` in light mode, GitHub-dark \`#0d1117\` in dark mode, 8px rounded corners, 1px border
- **Scrollbar**: 6px thin
- **Focus glow**: primary-red on \`:focus-visible\` for links / buttons / nav items
- **Footer**: replaces upstream \"Antora default UI / MPL-2.0\" boilerplate with SKaiNET attribution + cross-repo links to mainline + skainet-docs-ui
- **Mobile**: responsive hamburger nav (preserved from upstream)
- **\`.card-grid\` CSS**: available but unused on this site (the existing Key Features / Supported Model Families landing content is preserved)

## Compatibility notes

- The new UI bundle does NOT touch asciidoctor extensions. The existing \`asciidoctor-kroki\` extension and \`kroki-fetch-diagram: true\` config in this playbook continue to work unchanged — mermaid rendering follows the same pipeline as before.
- The bundle is content-neutral: nav entries, page content, and per-page metadata still come from this repo's modules and playbook. Only visual chrome (CSS, JS, partials) comes from the bundle.

## Out of scope

- Rewriting the landing page with a Diátaxis card-grid. The transformers landing has substantial real content (Key Features, Supported Model Families table) and shouldn't be replaced wholesale. A future PR can add a card-grid SECTION above or below the existing content if useful.
- Self-hosted fonts. v1.1.1 still loads Orbitron / Inter / Fira Code from Google Fonts; can move to bundled \`@font-face\` files when skainet-docs-ui v1.2 ships.
- Search wiring (\`SITE_SEARCH_PROVIDER\` env var still unset; the UI ships an input box already, just needs a search backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)