### PR TITLE
feat(#67): Gemma 4 thinking mode (<|think>...<think|>)

### DIFF
--- a/PLAN-tool-calling.md
+++ b/PLAN-tool-calling.md
@@ -22,12 +22,12 @@ Status tracking for wrapping up the Phase 6b tool-calling work. Groups below map
 - [x] (d) Parameterize system prompt on `ChatSession` — `runSingleTurn(systemPrompt = ...)` + constructor-level `defaultSystemPrompt` default (`ChatSession.DEFAULT_SYSTEM_PROMPT`).
 - [x] (e) Remove deprecated `Gemma4Runtime`: deleted `Gemma4Runtime.kt` + `GemmaRuntimeParityTest.kt`; pruned `loadRuntime*` / `buildRuntime` from `Gemma4Ingestion`; removed `--runtime=handcoded` and the `RuntimeKind` enum from `kgemma` CLI.
 
-### Group 3 — Thinking mode · `feature/ISSUE-<N>-thinking-mode`
-**Issue repo**: SKaiNET-transformers. **Goal**: emit/consume `<|think|>...<think|>` blocks.
+### Group 3 — Thinking mode · `feature/ISSUE-67-thinking-mode` ✅
+**Issue**: [#67](https://github.com/SKaiNET-developers/SKaiNET-transformers/issues/67). **Goal**: emit/consume `<|think>...<think|>` blocks.
 
-- [ ] (b) `Gemma4ChatTemplate`: parse `<|think|>` blocks alongside tool calls; buffer separately from user-visible content.
-- [ ] `AgentLoop`: expose thinking output via an `AgentListener` callback (no leak into assistant message).
-- [ ] Update `GemmaDslToolCallIntegrationTest` (or add a sibling test) to exercise a scripted `<|think|>` → `<|tool_call>` sequence.
+- [x] (b) `Gemma4ChatTemplate.parseThinkingBlocks` / `stripThinking`; paired `<|think>` / `<think|>` delimiters (matching the Gemma 4 `<|NAME>` / `<NAME|>` convention — real-E2B smoke test in Group 4 will verify against the live model).
+- [x] `AgentLoop`: new `AgentListener.onThinking(text)` fires per block; thinking stripped from the ASSISTANT `ChatMessage` persisted to conversation history so it never feeds back into subsequent prompts; tool-call parsing still operates on the raw response.
+- [x] Test coverage: 6 template-level tests (single / multiple / interleaved with tool_call / strip / idempotent no-op / unterminated block dropped) + one AgentLoop integration test proving the listener sees the block and the message doesn't.
 
 ### Group 4 — kgemma CLI tools + E2B smoke test · `feature/ISSUE-<N>-kgemma-tools-e2b`
 **Issue repo**: SKaiNET-transformers. **Goal**: drive tool calling from the CLI against a real checkpoint.

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/AgentLoop.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/AgentLoop.kt
@@ -31,6 +31,14 @@ public interface AgentListener {
     /** Called when the model's full response for a round is available. */
     public fun onAssistantMessage(text: String) {}
 
+    /**
+     * Called once for each thinking block (e.g. Gemma 4 `<|think>...<think|>`)
+     * emitted by the model this round. Thinking blocks are stripped before
+     * being persisted to the conversation so they do not leak into the next
+     * prompt; this callback is the only way to observe them.
+     */
+    public fun onThinking(text: String) {}
+
     /** Called when tool calls are detected in the model's response. */
     public fun onToolCalls(calls: List<ToolCall>) {}
 
@@ -89,6 +97,7 @@ public class AgentLoop<T : DType>(
         val tools = toolRegistry.definitions()
         val toolsByName = tools.associateBy { it.name }
         var lastResponse = ""
+        var lastVisibleResponse = ""
 
         for (round in 0 until config.maxToolRounds) {
             // Reset runtime state for each round (re-process full context)
@@ -112,14 +121,22 @@ public class AgentLoop<T : DType>(
             lastResponse = result.text
             listener?.onAssistantMessage(lastResponse)
 
-            // Parse for tool calls
+            // Extract thinking blocks first so the listener sees them, and
+            // strip them out of the text we persist to the conversation.
+            template.parseThinkingBlocks(lastResponse).forEach { block ->
+                listener?.onThinking(block)
+            }
+            lastVisibleResponse = template.stripThinking(lastResponse)
+
+            // Parse tool calls from the RAW text so a model can emit thinking
+            // and tool_call in the same response.
             val toolCalls = template.parseToolCalls(lastResponse)
 
             if (toolCalls.isEmpty()) {
                 // No tool calls — this is the final response
-                messages.add(ChatMessage(role = ChatRole.ASSISTANT, content = lastResponse))
-                listener?.onComplete(lastResponse)
-                return lastResponse
+                messages.add(ChatMessage(role = ChatRole.ASSISTANT, content = lastVisibleResponse))
+                listener?.onComplete(lastVisibleResponse)
+                return lastVisibleResponse
             }
 
             // Tool calls found — execute them
@@ -127,7 +144,7 @@ public class AgentLoop<T : DType>(
             messages.add(
                 ChatMessage(
                     role = ChatRole.ASSISTANT,
-                    content = lastResponse,
+                    content = lastVisibleResponse,
                     toolCalls = toolCalls
                 )
             )
@@ -146,8 +163,8 @@ public class AgentLoop<T : DType>(
         }
 
         // Max rounds exhausted — return last response
-        listener?.onComplete(lastResponse)
-        return lastResponse
+        listener?.onComplete(lastVisibleResponse)
+        return lastVisibleResponse
     }
 
     /**
@@ -204,6 +221,7 @@ public class AgentLoop<T : DType>(
         val tools = toolRegistry.definitions()
         val toolsByName = tools.associateBy { it.name }
         var lastResponse = ""
+        var lastVisibleResponse = ""
 
         for (round in 0 until config.maxToolRounds) {
             runtime.reset()
@@ -224,19 +242,24 @@ public class AgentLoop<T : DType>(
             lastResponse = result.text
             listener?.onAssistantMessage(lastResponse)
 
+            template.parseThinkingBlocks(lastResponse).forEach { block ->
+                listener?.onThinking(block)
+            }
+            lastVisibleResponse = template.stripThinking(lastResponse)
+
             val toolCalls = template.parseToolCalls(lastResponse)
 
             if (toolCalls.isEmpty()) {
-                messages.add(ChatMessage(role = ChatRole.ASSISTANT, content = lastResponse))
-                listener?.onComplete(lastResponse)
-                return lastResponse
+                messages.add(ChatMessage(role = ChatRole.ASSISTANT, content = lastVisibleResponse))
+                listener?.onComplete(lastVisibleResponse)
+                return lastVisibleResponse
             }
 
             listener?.onToolCalls(toolCalls)
             messages.add(
                 ChatMessage(
                     role = ChatRole.ASSISTANT,
-                    content = lastResponse,
+                    content = lastVisibleResponse,
                     toolCalls = toolCalls
                 )
             )
@@ -254,7 +277,7 @@ public class AgentLoop<T : DType>(
             }
         }
 
-        listener?.onComplete(lastResponse)
-        return lastResponse
+        listener?.onComplete(lastVisibleResponse)
+        return lastVisibleResponse
     }
 }

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ChatTemplate.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ChatTemplate.kt
@@ -37,4 +37,20 @@ public interface ChatTemplate {
      * The default implementation delegates to [ToolCallParser].
      */
     public fun containsToolCall(text: String): Boolean = ToolCallParser.containsToolCall(text)
+
+    /**
+     * Extract "thinking" blocks from model output — reasoning text the model
+     * is allowed to emit but that must not be fed back into subsequent prompts
+     * or shown to the end user by default. Templates whose models support a
+     * thinking mode (e.g. Gemma 4's `<|think|>...<think|>`) should override.
+     *
+     * @return Contents of each thinking block in order of appearance; empty if none.
+     */
+    public fun parseThinkingBlocks(text: String): List<String> = emptyList()
+
+    /**
+     * Return [text] with every thinking block removed. Templates without a
+     * thinking mode return [text] unchanged.
+     */
+    public fun stripThinking(text: String): String = text
 }

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Gemma4ChatTemplate.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Gemma4ChatTemplate.kt
@@ -18,7 +18,11 @@ import kotlinx.serialization.json.put
  * - Tool definitions wrapped in `<|tool>...<tool|>` delimiters
  * - Tool calls use `<|tool_call>...<tool_call|>` delimiters
  * - Tool responses use `<|tool_response>...<tool_response|>` delimiters
- * - Thinking mode via `<|think|>` token in system prompt
+ * - Thinking mode: `<|think>...<think|>` blocks in model output (same paired-
+ *   delimiter convention as the other markers). These are reasoning traces
+ *   the model is allowed to emit; the agent loop consumes them separately
+ *   and does not feed them back into subsequent prompts or persist them in
+ *   the assistant message.
  *
  * Turn format:
  * ```
@@ -140,6 +144,44 @@ public class Gemma4ChatTemplate : ChatTemplate {
         return text.contains("<|tool_call>") || text.contains("\"functionCall\"")
     }
 
+    override fun parseThinkingBlocks(text: String): List<String> {
+        val blocks = mutableListOf<String>()
+        var searchFrom = 0
+        while (searchFrom < text.length) {
+            val start = text.indexOf(THINK_OPEN, searchFrom)
+            if (start == -1) break
+            val contentStart = start + THINK_OPEN.length
+            val end = text.indexOf(THINK_CLOSE, contentStart)
+            if (end == -1) break
+            blocks += text.substring(contentStart, end)
+            searchFrom = end + THINK_CLOSE.length
+        }
+        return blocks
+    }
+
+    override fun stripThinking(text: String): String {
+        if (!text.contains(THINK_OPEN)) return text
+        val sb = StringBuilder(text.length)
+        var cursor = 0
+        while (cursor < text.length) {
+            val start = text.indexOf(THINK_OPEN, cursor)
+            if (start == -1) {
+                sb.append(text, cursor, text.length)
+                break
+            }
+            sb.append(text, cursor, start)
+            val end = text.indexOf(THINK_CLOSE, start + THINK_OPEN.length)
+            if (end == -1) {
+                // Unterminated block — drop everything from the opener on so the
+                // thinking text doesn't leak into conversation history.
+                break
+            }
+            cursor = end + THINK_CLOSE.length
+        }
+        // Collapse the whitespace we may have just created around the removed block.
+        return sb.toString().replace(Regex("""[\t ]*\n[\t ]*\n[\t ]*\n+"""), "\n\n").trim('\n', ' ', '\t')
+    }
+
     private fun parseFunctionCall(content: String): ToolCall? {
         return try {
             val obj = json.parseToJsonElement(content).jsonObject
@@ -169,6 +211,11 @@ public class Gemma4ChatTemplate : ChatTemplate {
         } catch (_: Exception) {
             null
         }
+    }
+
+    private companion object {
+        const val THINK_OPEN = "<|think>"
+        const val THINK_CLOSE = "<think|>"
     }
 
     private fun extractJsonObject(text: String, start: Int): String? {

--- a/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ChatSessionAgentIntegrationTest.kt
+++ b/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ChatSessionAgentIntegrationTest.kt
@@ -366,4 +366,72 @@ class ChatSessionAgentIntegrationTest {
         // Tool's execute() must never run when validation fails.
         assertFalse(tool.invoked, "tool.execute() must not run when validation fails")
     }
+
+    @Test
+    fun `AgentLoop surfaces thinking blocks to listener and strips them from persisted messages`() {
+        val tokenizer = ByteTokenizer()
+        val template = Gemma4ChatTemplate()
+        val tool = FixedCalculatorTool(expected = "3+4", result = "7")
+
+        val round1Messages = listOf(
+            ChatMessage(ChatRole.SYSTEM, "You are a helpful assistant with access to tools."),
+            ChatMessage(ChatRole.USER, "what is 3 + 4?")
+        )
+        val round1Prompt = template.apply(
+            round1Messages,
+            listOf(tool.definition),
+            addGenerationPrompt = true
+        )
+        val round1PromptLen = tokenizer.encode(round1Prompt).size
+
+        // Scripted output: thinking block followed by a tool call — the model
+        // reasons, then decides to call the calculator.
+        val scriptedText =
+            "<|think>I should use the calculator for this.<think|>\n" +
+            "<|tool_call>{\"name\":\"calculator\",\"args\":{\"expression\":\"3+4\"}}<tool_call|>"
+        val scriptedOutput = tokenizer.encode(scriptedText)
+
+        val mock = MockRuntime(
+            promptLen = round1PromptLen,
+            scriptedOutput = scriptedOutput,
+            eosTokenId = tokenizer.eosTokenId,
+            vocabSize = tokenizer.vocabSize
+        )
+
+        val registry = ToolRegistry().also { it.register(tool) }
+        val loop = AgentLoop<FP32>(
+            runtime = mock,
+            template = template,
+            toolRegistry = registry,
+            eosTokenId = tokenizer.eosTokenId,
+            config = AgentConfig(
+                maxToolRounds = 1,
+                maxTokensPerRound = scriptedOutput.size + 4,
+                temperature = 0.0f
+            ),
+            decode = { tokenizer.decode(it) }
+        )
+
+        val thinkingHeard = mutableListOf<String>()
+        val listener = object : AgentListener {
+            override fun onThinking(text: String) { thinkingHeard += text }
+        }
+
+        val messages = round1Messages.toMutableList()
+        loop.runWithEncoder(messages, encode = { tokenizer.encode(it) }, listener = listener)
+
+        // Listener saw the thinking content.
+        assertEquals(1, thinkingHeard.size)
+        assertEquals("I should use the calculator for this.", thinkingHeard[0])
+
+        // Thinking must not leak into the persisted assistant message.
+        val assistantMsg = messages.firstOrNull { it.role == ChatRole.ASSISTANT }
+            ?: error("expected an assistant message in conversation")
+        assertFalse(assistantMsg.content.contains("<|think>"), "thinking opener leaked into assistant message")
+        assertFalse(assistantMsg.content.contains("I should use the calculator"), "thinking text leaked into assistant message")
+
+        // Tool still fired based on the raw text.
+        assertTrue(tool.invoked, "calculator tool should still run — tool_call parsing operates on the raw response")
+        assertEquals("3+4", tool.receivedExpression)
+    }
 }

--- a/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/Gemma4ChatTemplateTest.kt
+++ b/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/Gemma4ChatTemplateTest.kt
@@ -210,6 +210,69 @@ class Gemma4ChatTemplateTest {
         assertEquals("2", parsed[0].arguments["precision"]?.toString())
     }
 
+    @Test
+    fun parseSingleThinkingBlock() {
+        val template = Gemma4ChatTemplate()
+        val text = "Sure.\n<|think>Let me work this out: 1 + 1 = 2.<think|>\nThe answer is 2."
+        val blocks = template.parseThinkingBlocks(text)
+        assertEquals(1, blocks.size)
+        assertEquals("Let me work this out: 1 + 1 = 2.", blocks[0])
+    }
+
+    @Test
+    fun parseMultipleThinkingBlocks() {
+        val template = Gemma4ChatTemplate()
+        val text = "<|think>first<think|> between <|think>second<think|>"
+        val blocks = template.parseThinkingBlocks(text)
+        assertEquals(listOf("first", "second"), blocks)
+    }
+
+    @Test
+    fun parseInterleavedThinkAndToolCall() {
+        val template = Gemma4ChatTemplate()
+        val text = "<|think>plan: use the calculator<think|>\n" +
+            "<|tool_call>{\"name\":\"calculator\",\"args\":{\"expression\":\"3+4\"}}<tool_call|>"
+
+        val thinks = template.parseThinkingBlocks(text)
+        val calls = template.parseToolCalls(text)
+
+        assertEquals(1, thinks.size)
+        assertEquals("plan: use the calculator", thinks[0])
+        assertEquals(1, calls.size)
+        assertEquals("calculator", calls[0].name)
+    }
+
+    @Test
+    fun stripThinkingRemovesBlockAndLeavesVisibleText() {
+        val template = Gemma4ChatTemplate()
+        val text = "Here's the answer.\n<|think>hidden reasoning<think|>\nThe result is 7."
+        val stripped = template.stripThinking(text)
+        assertFalse(stripped.contains("<|think>"))
+        assertFalse(stripped.contains("<think|>"))
+        assertFalse(stripped.contains("hidden reasoning"))
+        assertContains(stripped, "Here's the answer.")
+        assertContains(stripped, "The result is 7.")
+    }
+
+    @Test
+    fun stripThinkingIdempotentWhenNoBlock() {
+        val template = Gemma4ChatTemplate()
+        val text = "Plain output with no thinking at all."
+        assertEquals(text, template.stripThinking(text))
+    }
+
+    @Test
+    fun stripThinkingDropsUnterminatedBlock() {
+        val template = Gemma4ChatTemplate()
+        // Generation truncation may cut a thinking block mid-sentence. Must
+        // not leak the partial thinking into conversation history.
+        val text = "Looking at it:\n<|think>I should reason about"
+        val stripped = template.stripThinking(text)
+        assertFalse(stripped.contains("I should reason about"))
+        assertFalse(stripped.contains("<|think>"))
+        assertContains(stripped, "Looking at it:")
+    }
+
     private fun countOf(haystack: String, needle: String): Int {
         var count = 0
         var idx = 0


### PR DESCRIPTION
Closes #67.

## Summary
- `Gemma4ChatTemplate` now parses paired `<|think>...<think|>` blocks (matching the `<|NAME>` / `<NAME|>` convention of all other Gemma 4 markers). Unterminated blocks (generation truncation) are dropped wholesale so partial reasoning can't leak into history.
- `AgentListener.onThinking(text)` callback (default no-op) fires for each parsed block.
- `AgentLoop.run` / `runWithEncoder`: thinking is stripped from the ASSISTANT `ChatMessage` persisted to conversation history AND from the returned final response. Tool-call parsing still operates on the raw text so a model can emit thinking + tool_call in the same round.
- `ChatTemplate` interface gains default no-op `parseThinkingBlocks` / `stripThinking` so non-thinking templates inherit safe behavior.

Net diff: **+237 / −19** across 6 files.

## Grammar choice
Paired `<|think>` (open) / `<think|>` (close) is used to match every other Gemma 4 delimiter family in the template. The existing docstring mentioned `<|think|>` without specifying whether that was the full token or shorthand for a pair — the real-E2B smoke test in Group 4 will verify against the live model and we can revise if needed.

## Base branch
`feature/gemma4` (the Gemma 4 integration branch; `develop` is 47 commits behind).

## Test plan
- [x] `./gradlew :llm-agent:jvmTest` green. New tests:
  - `Gemma4ChatTemplateTest`: single block, multiple blocks, interleaved with tool_call, strip removes block, strip no-op without block, strip drops unterminated block.
  - `ChatSessionAgentIntegrationTest`: AgentLoop end-to-end — listener sees thinking, assistant message doesn't, tool still fires.
- [x] Non-Gemma templates (Qwen, Llama) inherit the no-op defaults and continue to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)