### PR TITLE
feat(#69): kgemma --tools flag + real-E2B tool-call smoke test

### DIFF
--- a/PLAN-tool-calling.md
+++ b/PLAN-tool-calling.md
@@ -29,11 +29,11 @@ Status tracking for wrapping up the Phase 6b tool-calling work. Groups below map
 - [x] `AgentLoop`: new `AgentListener.onThinking(text)` fires per block; thinking stripped from the ASSISTANT `ChatMessage` persisted to conversation history so it never feeds back into subsequent prompts; tool-call parsing still operates on the raw response.
 - [x] Test coverage: 6 template-level tests (single / multiple / interleaved with tool_call / strip / idempotent no-op / unterminated block dropped) + one AgentLoop integration test proving the listener sees the block and the message doesn't.
 
-### Group 4 — kgemma CLI tools + E2B smoke test · `feature/ISSUE-<N>-kgemma-tools-e2b`
-**Issue repo**: SKaiNET-transformers. **Goal**: drive tool calling from the CLI against a real checkpoint.
+### Group 4 — kgemma CLI tools + E2B smoke test · `feature/ISSUE-69-kgemma-tools-e2b` ✅
+**Issue**: [#69](https://github.com/SKaiNET-developers/SKaiNET-transformers/issues/69). **Goal**: drive tool calling from the CLI against a real checkpoint.
 
-- [ ] (a) `kgemma` `--tools=<name1>,<name2>` flag + default tool registry (calculator, file-read, time — keep set minimal). Wire through `Main.kt` to `ChatSession`.
-- [ ] (g) Real-E2B smoke test: load actual Gemma 4 E2B checkpoint (not synthetic weights), run prompt that should elicit a tool call, assert model natively emits `<|tool_call>` format and round-trip completes. Gate test behind env var (checkpoint path) so CI stays green without the weights.
+- [x] (a) `kgemma --tools=<names>` flag parses a comma-separated list against a new `DefaultTools` factory (`calculator`, `list_files`). Default (flag absent) keeps prior behavior of calculator-only. Unknown names print an error with the available set. `--tools` without `--agent` is rejected early. `ListFilesTool` promoted from `internal` to `public` in kllama (api baseline refreshed).
+- [x] (g) `Gemma4E2BToolCallSmokeTest` in `kgemma/jvmTest` — gated on `GEMMA4_E2B_MODEL_PATH`. Loads the real GGUF via DSL NATIVE_OPTIMIZED, runs a calculator-prompt round, asserts the raw output contains `<|tool_call>` / `<tool_call|>` and that `Gemma4ChatTemplate.parseToolCalls` recovers a `calculator` call. Skips cleanly when the env var is unset so CI stays green. If the test surfaces a grammar mismatch, that's the signal to write `gemma4-research/findings/tool_calling.md` (Group 5) before adjusting the template.
 
 ### Group 5 — Research spec doc · no GH issue (local `gemma4-research`) ✅
 **Location**: `gemma4-research/findings/tool_calling.md` (committed as root commit `a609e46` of the research repo).

--- a/llm-runtime/kgemma/build.gradle.kts
+++ b/llm-runtime/kgemma/build.gradle.kts
@@ -128,6 +128,10 @@ kotlin {
 
 tasks.withType<Test>().configureEach {
     jvmArgs("--enable-preview", "--add-modules", "jdk.incubator.vector")
+    // Gemma4E2BToolCallSmokeTest dequantizes Q4_K → FP32 and wants ~20 GB.
+    // The 4g default keeps the fast suite cheap; real-checkpoint runs can
+    // override with -PkgemmaTestMaxHeap=20g.
+    maxHeapSize = (findProperty("kgemmaTestMaxHeap") as? String) ?: "4g"
 }
 
 tasks.withType<JavaExec>().configureEach {

--- a/llm-runtime/kgemma/build.gradle.kts
+++ b/llm-runtime/kgemma/build.gradle.kts
@@ -102,6 +102,9 @@ kotlin {
                 implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.skainet.backend.cpu)
+                // Needed by Gemma4E2BToolCallSmokeTest for building
+                // ToolDefinition parameter schemas inline.
+                implementation(libs.kotlinx.serialization.json)
             }
         }
         if (!project.hasProperty("buildFatJar")) {

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/cli/DefaultTools.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/cli/DefaultTools.kt
@@ -1,0 +1,46 @@
+package sk.ainet.apps.kgemma.cli
+
+import sk.ainet.apps.kllama.chat.Tool
+import sk.ainet.apps.kllama.cli.CalculatorTool
+import sk.ainet.apps.kllama.cli.ListFilesTool
+
+/**
+ * Named built-in tools available to `kgemma --agent --tools=…`.
+ *
+ * Keeps the CLI surface small: adding a new tool is one entry here, and the
+ * `--tools` flag parser can validate names against [names] to fail fast on
+ * typos.
+ */
+internal object DefaultTools {
+
+    private val factories: Map<String, () -> Tool> = linkedMapOf(
+        "calculator" to ::CalculatorTool,
+        "list_files" to ::ListFilesTool
+    )
+
+    val names: Set<String> = factories.keys
+
+    fun byName(name: String): Tool? = factories[name]?.invoke()
+
+    /**
+     * Parse a comma-separated list of tool names and return the instantiated
+     * tools in the order given. Unknown names are reported through [onUnknown].
+     * Returns `null` if any name is unknown (caller should surface usage).
+     */
+    fun parse(spec: String?, onUnknown: (String) -> Unit): List<Tool>? {
+        if (spec.isNullOrBlank()) return emptyList()
+        val tokens = spec.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        val result = mutableListOf<Tool>()
+        var ok = true
+        for (name in tokens) {
+            val tool = byName(name)
+            if (tool == null) {
+                onUnknown(name)
+                ok = false
+            } else {
+                result += tool
+            }
+        }
+        return if (ok) result else null
+    }
+}

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/cli/Main.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/cli/Main.kt
@@ -86,7 +86,8 @@ private data class CliArgs(
     val prompt: String,
     val steps: Int,
     val temperature: Float,
-    val agent: Boolean = false
+    val agent: Boolean = false,
+    val toolsSpec: String? = null
 )
 
 private fun usage(errorMessage: String? = null): Nothing {
@@ -101,8 +102,11 @@ private fun usage(errorMessage: String? = null): Nothing {
     println("  steps               Generation steps (default: 32)")
     println("  temperature         Sampling temperature (default: 0.8)")
     println("  --agent             Route through ChatSession with the model-appropriate")
-    println("                      chat template and default tool registry (calculator +")
-    println("                      list_files). Default off (raw runtime.generate).")
+    println("                      chat template and an agent tool registry. Default off")
+    println("                      (raw runtime.generate).")
+    println("  --tools=LIST        Comma-separated tool names to register when --agent is set.")
+    println("                      Available: ${DefaultTools.names.joinToString(", ")}.")
+    println("                      Default: calculator.")
     println()
     println("Runtime: gemmaNetwork() + OptimizedLLMRuntime (DSL, NATIVE_OPTIMIZED Q4_0/Q8_0 +")
     println("         dequant K-series to FP32 until a K-kernel lands).")
@@ -110,6 +114,7 @@ private fun usage(errorMessage: String? = null): Nothing {
     println("Example:")
     println("  kgemma models/gemma-3-270m-it-Q8_0.gguf \"Hello, how are you?\" 32 0.8")
     println("  kgemma model.gguf \"What is 3+4?\" 64 0.0 --agent")
+    println("  kgemma model.gguf \"List /tmp\" 64 0.0 --agent --tools=list_files")
     exitProcess(if (errorMessage == null) 0 else 1)
 }
 
@@ -127,15 +132,21 @@ private fun parseArgs(args: Array<String>): CliArgs {
     val temperature = positional.getOrElse(3) { "0.8" }.toFloatOrNull() ?: usage("Invalid temperature '${positional[3]}'.")
 
     var agent = false
+    var toolsSpec: String? = null
     for (flag in flags) {
         when {
             flag == "--agent" -> agent = true
+            flag.startsWith("--tools=") -> toolsSpec = flag.substringAfter("=")
             flag == "--help" || flag == "-h" -> usage()
             else -> usage("Unknown flag '$flag'.")
         }
     }
 
-    return CliArgs(modelPath, prompt, steps, temperature, agent)
+    if (toolsSpec != null && !agent) {
+        usage("--tools has no effect without --agent.")
+    }
+
+    return CliArgs(modelPath, prompt, steps, temperature, agent, toolsSpec)
 }
 
 private fun detectFormat(path: Path): ModelFormat {
@@ -270,8 +281,21 @@ fun main(args: Array<String>) {
                 }
             )
             val session = ChatSession(runtime, tokenizer, metadata)
+
+            // Resolve --tools=… spec. Default (no flag) registers the
+            // calculator — enough to exercise the full template + parse +
+            // dispatch loop on Gemma 4 and matches skainet-cli's default.
+            val tools = if (cliArgs.toolsSpec.isNullOrBlank()) {
+                listOf(sk.ainet.apps.kllama.cli.CalculatorTool())
+            } else {
+                DefaultTools.parse(cliArgs.toolsSpec) { name ->
+                    System.err.println("Error: unknown tool '$name'. Available: ${DefaultTools.names.joinToString(", ")}.")
+                } ?: exitProcess(1)
+            }
+
             println("Agent mode: chat template = ${session.chatTemplate::class.simpleName}, " +
-                "tool-calling provider = ${session.providerFamily}")
+                "tool-calling provider = ${session.providerFamily}, " +
+                "tools = [${tools.joinToString(", ") { it.definition.name }}]")
             println("Generating up to ${cliArgs.steps} tokens/round at temperature=${cliArgs.temperature}...")
             println("---")
             print(cliArgs.prompt)
@@ -279,10 +303,7 @@ fun main(args: Array<String>) {
             val elapsed = measureTime {
                 val response = session.runSingleTurn(
                     prompt = cliArgs.prompt,
-                    // Default agent-mode tool registry matches skainet-cli's:
-                    // a calculator is enough to exercise the full template +
-                    // parse + dispatch loop on Gemma 4.
-                    tools = listOf(sk.ainet.apps.kllama.cli.CalculatorTool()),
+                    tools = tools,
                     maxTokens = cliArgs.steps,
                     temperature = cliArgs.temperature
                 )

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/cli/Gemma4E2BToolCallSmokeTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/cli/Gemma4E2BToolCallSmokeTest.kt
@@ -1,0 +1,202 @@
+package sk.ainet.apps.kgemma.cli
+
+import java.io.File
+import java.lang.foreign.Arena
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import sk.ainet.apps.kgemma.Gemma4Ingestion
+import sk.ainet.apps.kgemma.Gemma4LoadConfig
+import sk.ainet.apps.kgemma.loadDslRuntimeNativeStreaming
+import sk.ainet.apps.kllama.GGUFTokenizer
+import sk.ainet.apps.kllama.chat.AgentListener
+import sk.ainet.apps.kllama.chat.ChatSession
+import sk.ainet.apps.kllama.chat.ModelMetadata
+import sk.ainet.apps.kllama.chat.Tool
+import sk.ainet.apps.kllama.chat.ToolCall
+import sk.ainet.apps.kllama.chat.ToolDefinition
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.tensor.data.MemorySegmentTensorDataFactory
+import sk.ainet.lang.types.FP32
+
+/**
+ * End-to-end smoke test for Gemma 4 tool calling against a **real** E2B
+ * checkpoint. Gated on the `GEMMA4_E2B_MODEL_PATH` env var so CI stays green
+ * without the ~3 GB weights on disk.
+ *
+ * Purpose: this is the first test that empirically pins down whether the
+ * trained Gemma 4 model natively emits `<|tool_call>...<tool_call|>` against
+ * our [sk.ainet.apps.kllama.chat.Gemma4ChatTemplate]. Every other test in
+ * this repo uses synthetic weights or a mock runtime with a scripted token
+ * stream, so the grammar choices in the template (including the paired
+ * `<|think>` / `<think|>` convention introduced for thinking mode) rest on
+ * spec reading, not observed behavior. A pass here closes that gap.
+ *
+ * To run locally:
+ * ```
+ * export GEMMA4_E2B_MODEL_PATH=/path/to/gemma-4-e2b.gguf
+ * ./gradlew :llm-runtime:kgemma:jvmTest --tests '*Gemma4E2BToolCallSmokeTest*'
+ * ```
+ *
+ * If the test finds the model but the model does NOT produce a parseable
+ * tool call, it fails with the raw response captured so the grammar
+ * mismatch can be diagnosed and written up in
+ * `gemma4-research/findings/tool_calling.md` (tracked as Group 5 in
+ * `PLAN-tool-calling.md`).
+ */
+class Gemma4E2BToolCallSmokeTest {
+
+    private class CalculatorTool : Tool {
+        var invoked = false
+            private set
+        var receivedExpression: String? = null
+            private set
+        override val definition: ToolDefinition = ToolDefinition(
+            name = "calculator",
+            description = "Evaluate a mathematical expression. Supports +, -, *, / and parentheses.",
+            parameters = buildJsonObject {
+                put("type", "object")
+                putJsonObject("properties") {
+                    putJsonObject("expression") {
+                        put("type", "string")
+                        put("description", "The mathematical expression to evaluate, e.g. '17 * 23'")
+                    }
+                }
+            }
+        )
+        override fun execute(arguments: JsonObject): String {
+            invoked = true
+            receivedExpression = arguments["expression"]?.jsonPrimitive?.content
+            // Compute a plausible answer so the model can carry on if it wants to.
+            val expr = receivedExpression ?: return "error: no expression"
+            return try {
+                // This test only asks for a single multiplication — trivial parse.
+                val parts = expr.split("*", " ").map { it.trim() }.filter { it.isNotEmpty() }
+                if (parts.size == 2) {
+                    val a = parts[0].toLong()
+                    val b = parts[1].toLong()
+                    (a * b).toString()
+                } else {
+                    "error: unexpected expression shape"
+                }
+            } catch (e: Exception) {
+                "error: ${e.message}"
+            }
+        }
+    }
+
+    @Test
+    fun `real Gemma 4 E2B emits parseable tool_call against Gemma4ChatTemplate`() {
+        val modelPath = System.getenv("GEMMA4_E2B_MODEL_PATH")?.trim().orEmpty()
+        if (modelPath.isEmpty()) {
+            println("[skip] GEMMA4_E2B_MODEL_PATH not set — skipping real-checkpoint smoke test.")
+            return
+        }
+        val path = Path.of(modelPath)
+        if (!path.exists()) {
+            println("[skip] GEMMA4_E2B_MODEL_PATH=$modelPath does not exist — skipping.")
+            return
+        }
+        // GGUF-only for this smoke test; SafeTensors models need a different
+        // loader wiring and aren't required to verify the template grammar.
+        val isGguf = !path.isDirectory() && path.toString().endsWith(".gguf")
+        if (!isGguf) {
+            println("[skip] GEMMA4_E2B_MODEL_PATH=$modelPath is not a .gguf file — skipping (this test only exercises the GGUF DSL path).")
+            return
+        }
+
+        runBlocking {
+            val memSegFactory = MemorySegmentTensorDataFactory()
+            val ctx = DirectCpuExecutionContext(tensorDataFactory = memSegFactory)
+            val quantArena = Arena.ofShared()
+            try {
+                val ingestion = Gemma4Ingestion<FP32>(
+                    ctx = ctx,
+                    dtype = FP32::class,
+                    config = Gemma4LoadConfig(
+                        quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+                        allowQuantized = true
+                    )
+                )
+
+                println("Loading Gemma 4 from $path via DSL NATIVE_OPTIMIZED...")
+                val runtime = ingestion.loadDslRuntimeNativeStreaming(
+                    randomAccessProvider = { JvmRandomAccessSource.open(path.toString()) },
+                    ctx = ctx,
+                    dtype = FP32::class,
+                    arena = quantArena
+                )
+
+                val tokenizer = JvmRandomAccessSource.open(path.toString()).use { source ->
+                    GGUFTokenizer.fromRandomAccessSource(source)
+                }
+
+                val metadata = ModelMetadata(
+                    family = "gemma",
+                    architecture = "gemma4",
+                    sourceFormat = "gguf"
+                )
+                val session = ChatSession(runtime, tokenizer, metadata)
+
+                val tool = CalculatorTool()
+                val rawResponses = mutableListOf<String>()
+                val toolCallsHeard = mutableListOf<ToolCall>()
+                val listener = object : AgentListener {
+                    override fun onAssistantMessage(text: String) { rawResponses += text }
+                    override fun onToolCalls(calls: List<ToolCall>) { toolCallsHeard += calls }
+                }
+
+                val prompt = "What is 17 * 23? Use the calculator tool."
+                val response = session.runSingleTurn(
+                    prompt = prompt,
+                    tools = listOf(tool),
+                    maxTokens = 256,
+                    temperature = 0.0f,
+                    listener = listener
+                )
+
+                val allText = rawResponses.joinToString("\n")
+                println("--- raw round 1 response ---\n$allText\n---")
+                println("final response: $response")
+
+                assertTrue(
+                    allText.contains("<|tool_call>"),
+                    "real Gemma 4 E2B did not emit a <|tool_call> marker — the template grammar " +
+                        "may not match the trained model. Raw response captured above. Record findings in " +
+                        "gemma4-research/findings/tool_calling.md before adjusting the template."
+                )
+                assertTrue(
+                    allText.contains("<tool_call|>"),
+                    "found opener but no closer <tool_call|> — check if the model uses a different " +
+                        "closing delimiter."
+                )
+                assertTrue(
+                    toolCallsHeard.any { it.name == "calculator" },
+                    "Gemma4ChatTemplate.parseToolCalls did not recover a 'calculator' call from the " +
+                        "model output. Raw response above."
+                )
+            } finally {
+                quantArena.close()
+                memSegFactory.close()
+            }
+        }
+    }
+
+    companion object {
+        @Suppress("unused") // referenced from KDoc
+        private val modelPathHelp: String = "Set GEMMA4_E2B_MODEL_PATH=/path/to/gemma-4-e2b.gguf to enable."
+    }
+}

--- a/llm-runtime/kllama/api/jvm/kllama.api
+++ b/llm-runtime/kllama/api/jvm/kllama.api
@@ -200,6 +200,12 @@ public final class sk/ainet/apps/kllama/cli/CalculatorTool : sk/ainet/apps/kllam
 	public fun getDefinition ()Lsk/ainet/apps/kllama/chat/ToolDefinition;
 }
 
+public final class sk/ainet/apps/kllama/cli/ListFilesTool : sk/ainet/apps/kllama/chat/Tool {
+	public fun <init> ()V
+	public fun execute (Lkotlinx/serialization/json/JsonObject;)Ljava/lang/String;
+	public fun getDefinition ()Lsk/ainet/apps/kllama/chat/ToolDefinition;
+}
+
 public final class sk/ainet/apps/kllama/cli/MainKt {
 	public static final fun main ([Ljava/lang/String;)V
 }

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/ToolCallingDemo.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/ToolCallingDemo.kt
@@ -194,8 +194,11 @@ Always use a tool when one is relevant — do not guess file listings."""
  *
  * Returns file names, sizes, and whether each entry is a directory.
  * Restricted to readable directories and limits output to 50 entries.
+ *
+ * Public so `kgemma --tools=list_files` can register it alongside the
+ * calculator.
  */
-internal class ListFilesTool : Tool {
+public class ListFilesTool : Tool {
 
     override val definition: ToolDefinition = ToolDefinition(
         name = "list_files",


### PR DESCRIPTION
Closes #69.

## Summary
- **\`kgemma --tools=calculator,list_files\`**: new flag wires a named tool set into agent mode. Default (flag absent) keeps prior calculator-only behavior. Unknown name exits 1 with the available list. \`--tools\` without \`--agent\` is rejected early.
- **\`DefaultTools\`** factory in kgemma/cli — single source of truth for built-in tool names.
- **\`ListFilesTool\`** promoted \`internal → public\` in kllama so kgemma can register it. \`kllama.api\` baseline refreshed via \`:llm-runtime:kllama:apiDump\`.
- **\`Gemma4E2BToolCallSmokeTest\`** in kgemma/jvmTest — gated on \`GEMMA4_E2B_MODEL_PATH\`. Skips cleanly without the weights; when the env var is set, it loads the real E2B checkpoint via the DSL NATIVE_OPTIMIZED path and asserts the model natively emits \`<|tool_call>\` markers our \`Gemma4ChatTemplate\` can parse.

Net diff: **+295 / −14** across 7 files.

## Why the smoke test matters
Every existing e2e test in this repo uses synthetic weights or a scripted mock runtime. This is the first test that empirically pins down whether the trained Gemma 4 E2B model actually emits tool calls in the form our template expects. If the assertion fails, the test's output captures the raw response so the grammar mismatch can be documented in \`gemma4-research/findings/tool_calling.md\` (Group 5) before any reactive template change.

## Base branch
\`feature/gemma4\`.

## Interaction with other open PRs
- **#64** (ChatSession polish) removes the \`RuntimeKind\` enum and \`--runtime=\` flag from \`Main.kt\`. This PR adds \`--tools=\` handling in the same \`parseArgs\` function. The two are orthogonal in intent but overlap on lines — whichever merges first, the other will need a small rebase.
- **#66** (robustness) and **#68** (thinking mode) don't touch \`kgemma\` or \`kllama\` — no conflict expected.

## Test plan
- [x] \`./gradlew :llm-runtime:kgemma:jvmTest --tests '*Gemma4E2BToolCallSmokeTest*'\` — passes via skip path when env var unset.
- [x] \`./gradlew :llm-runtime:kgemma:jvmJar\` — CLI builds.
- [x] \`./gradlew :llm-runtime:kllama:apiCheck\` — binary API baseline refreshed to include \`ListFilesTool\`.
- [ ] **Manual** (when a local E2B checkpoint is available): \`GEMMA4_E2B_MODEL_PATH=/path/to/gemma-4-e2b.gguf ./gradlew :llm-runtime:kgemma:jvmTest --tests '*Gemma4E2BToolCallSmokeTest*'\` — will either pass (template grammar verified against the trained model) or surface a concrete mismatch to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)