### PR TITLE
Llama 3 tool calling: fix GGUF special-token encoding + Meta-aligned template

### DIFF
--- a/docs/llama3-tool-calling.md
+++ b/docs/llama3-tool-calling.md
@@ -1,0 +1,166 @@
+# Llama 3 / 3.1 / 3.2 tool calling
+
+This page describes how `kllama` formats tool-calling prompts for the
+Llama 3 family and how it parses the model's responses. It also explains
+the two response formats Meta has documented and which one to pick for
+which model.
+
+> **TL;DR** — for Llama 3.2 1B / 3B (and any Llama 3.x in 2025) leave the
+> defaults alone. The default format is `Llama3ToolFormat.JSON`, which is
+> what Llama 3.2 was fine-tuned on for custom tools. Switch to
+> `Llama3ToolFormat.FUNCTION_TAG` only if you are running an older
+> Llama 3.1 prompt that expects the tag-wrapped form.
+
+## Quick start
+
+```sh
+# Build
+./gradlew :llm-apps:kllama-cli:shadowJar
+
+# Run the demo against a Llama 3.x GGUF (auto-detects the family)
+java --enable-preview --add-modules jdk.incubator.vector \
+     -jar llm-apps/kllama-cli/build/libs/kllama-all.jar \
+     -m models/Llama-3.2-1B-Instruct-Q8_0.gguf \
+     --demo --template=llama3 \
+     -s 256 -k 0.0 \
+     "What files are in /tmp?"
+```
+
+The demo registers two tools (`list_files`, `calculator`) and runs the
+agent loop until the model produces a final assistant message.
+
+## The two formats
+
+Llama 3.x supports two response shapes for custom tool calls. They are
+**not auto-negotiated** between the model and the harness — the system
+prompt declares which one the model should emit, and the parser must be
+told to look for the same one. `Llama3ChatTemplate` and
+`Llama3ToolCallingSupport` take a single [`Llama3ToolFormat`][fmt] that
+both sides share.
+
+### `Llama3ToolFormat.JSON` (default)
+
+What Llama 3.2 1B / 3B was fine-tuned on for **custom** tool calling.
+Meta documents this in `llama-models/models/llama3_2/text_prompt_format.md`.
+
+Model emits a single JSON object on one line (no surrounding prose):
+
+```
+{"name": "list_files", "parameters": {"path": "/tmp"}}
+```
+
+System prompt the template builds:
+
+```
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+
+You are a helpful assistant with tool calling capabilities.
+When you receive a tool call response, use the output to format an answer to the original user question.
+
+You have access to the following functions:
+
+{"name":"list_files","description":"...","parameters":{...}}
+
+If you choose to call a function, your reply MUST be a single JSON object on one line in the following format and nothing else:
+{"name": <function-name>, "parameters": <arguments-object>}
+Do not write the function definition. Do not include any prose. Do not use variables.<|eot_id|>
+<|start_header_id|>user<|end_header_id|>
+
+What files are in /tmp?<|eot_id|>
+<|start_header_id|>assistant<|end_header_id|>
+
+```
+
+Parser ([`Llama31ToolCallParserStrategy`][p1]) accepts:
+- The Meta-documented `"parameters"` key, or `"arguments"` (Hermes-style alias).
+- A leading `<|python_tag|>` marker (used by Llama 3.2's built-in tools; tolerated here too).
+- Trailing prose after the JSON object (small models often append "I hope that helps!").
+
+### `Llama3ToolFormat.FUNCTION_TAG` (Llama 3.1 legacy)
+
+Tag-wrapped JSON. Documented in early Llama 3.1 prompt-format material.
+Llama 3.2 will follow this format if asked, but Meta no longer recommends
+it for custom tools on 3.2.
+
+Model emits:
+
+```
+<function=list_files>{"path": "/tmp"}</function>
+```
+
+System prompt the template builds:
+
+```
+...
+If you choose to call a function, ONLY reply in the format below and nothing else:
+<function=function_name>{"arg_name": "arg_value"}</function>
+Function calls MUST be on a single line. Required parameters MUST be specified.
+...
+```
+
+Parser: [`Llama3FunctionTagParserStrategy`][p2]. Multiple `<function=...>`
+blocks in a single response are extracted in order.
+
+## Picking a format programmatically
+
+```kotlin
+val support = Llama3ToolCallingSupport(format = Llama3ToolFormat.JSON)
+val template = support.createChatTemplate()           // Llama3ChatTemplate(JSON)
+val calls    = support.parseToolCalls(modelOutput)     // tries Hermes → function-tag → JSON
+```
+
+`ToolCallParser.parse` tries every registered strategy and returns the
+first non-empty hit. The three default strategies are disjoint by surface
+form, so you never get a double-parse:
+
+| Surface form                                    | Strategy                                 |
+|-------------------------------------------------|------------------------------------------|
+| `<tool_call>{...}</tool_call>`                  | `HermesToolCallParserStrategy`           |
+| `<function=name>{...}</function>`               | `Llama3FunctionTagParserStrategy`        |
+| Bare `{"name": ..., "arguments"\|"parameters": ...}` | `Llama31ToolCallParserStrategy`     |
+
+That means you can safely select either Llama 3 format on the prompt side
+without touching the parser registration — the parser will pick up
+whichever the model actually emits.
+
+## Why two formats exist
+
+- **Llama 3.1** shipped with the `<function=...>...</function>` tag form
+  in the early prompt-format docs. Meta later updated the docs to also
+  show the bare-JSON format alongside it.
+- **Llama 3.2** released in late 2024 with built-in tools (`brave_search`,
+  `wolfram_alpha`, `code_interpreter`) that use the `<|python_tag|>`-prefixed
+  bare-JSON format; for custom tools the docs canonicalise plain bare JSON
+  with `"parameters"`. The 1B and 3B Instruct variants are fine-tuned for
+  this format.
+
+So: if you're running Llama 3.2, default JSON is the trained-on format
+and gives the best chance of a clean call. If you're running an older
+Llama 3.1 prompt or you have prompt material specifically calling for
+the tag form, switch to `FUNCTION_TAG`.
+
+## Model-size caveat
+
+Llama 3.2 1B is a **small** model. Even with the correct format and
+prompt it can:
+- Echo back the tool schema instead of producing a call (treat with a
+  few-shot example added to the system prompt).
+- Hallucinate a tool *result* directly without calling the tool.
+- Append commentary after the JSON (the parser handles this).
+
+3B is meaningfully better; 8B (Llama 3.1) is the sweet spot for tool
+calling on commodity hardware. Drop the temperature to `0.0` for
+deterministic tool-call generation.
+
+## Related files
+
+- `llm-agent/.../chat/Llama3ChatTemplate.kt` — prompt builder.
+- `llm-agent/.../chat/Llama3ToolFormat.kt` — format enum.
+- `llm-agent/.../chat/ToolCallParser.kt` — both Llama 3 parser strategies + Hermes.
+- `llm-agent/.../chat/ToolCallingSupport.kt` — `Llama3ToolCallingSupport`
+  pulls everything together.
+- `llm-runtime/kllama/.../cli/ToolCallingDemo.kt` — the `--demo` runner.
+
+[fmt]: ../llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Llama3ToolFormat.kt
+[p1]: ../llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallParser.kt
+[p2]: ../llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallParser.kt

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Llama3ChatTemplate.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Llama3ChatTemplate.kt
@@ -6,21 +6,33 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 /**
- * Chat template for Llama 3 / 3.1 / 3.2 family models.
+ * Chat template for the Llama 3 / 3.1 / 3.2 family.
  *
- * Format:
+ * Without tools the template emits the standard Llama 3 turn structure:
+ *
  * ```
  * <|begin_of_text|><|start_header_id|>system<|end_header_id|>
  *
- * {content}<|eot_id|>
+ * {system content}<|eot_id|>
  * <|start_header_id|>user<|end_header_id|>
  *
- * {content}<|eot_id|>
+ * {user content}<|eot_id|>
  * <|start_header_id|>assistant<|end_header_id|>
  *
  * ```
+ *
+ * With tools the template emits Meta's documented tool-calling system
+ * prompt — see [Llama3ToolFormat] and `docs/llama3-tool-calling.md`. The
+ * shape of the system message *must* match the response format the
+ * parser expects, so the constructor takes a [format] that is the
+ * single source of truth for both.
+ *
+ * @param format Response format the model should emit when calling a tool.
+ *   Defaults to [Llama3ToolFormat.JSON] (Llama 3.2 default).
  */
-public class Llama3ChatTemplate : ChatTemplate {
+public class Llama3ChatTemplate(
+    private val format: Llama3ToolFormat = Llama3ToolFormat.JSON
+) : ChatTemplate {
 
     override fun apply(
         messages: List<ChatMessage>,
@@ -30,24 +42,12 @@ public class Llama3ChatTemplate : ChatTemplate {
         val sb = StringBuilder()
         sb.append("<|begin_of_text|>")
 
-        // If tools are provided, inject them into the system prompt
-        if (tools.isNotEmpty()) {
-            sb.append("<|start_header_id|>system<|end_header_id|>\n\n")
-            sb.append("You are a helpful assistant with access to the following tools:\n\n")
-            for (tool in tools) {
-                val toolJson = buildJsonObject {
-                    put("name", tool.name)
-                    put("description", tool.description)
-                    put("parameters", tool.parameters)
-                }
-                sb.append(Json.encodeToString(JsonObject.serializer(), toolJson))
-                sb.append("\n\n")
-            }
-            sb.append("To call a tool, respond with a JSON object: {\"name\": \"tool_name\", \"arguments\": {...}}")
-            sb.append("<|eot_id|>")
-        }
+        val toolSystem = if (tools.isNotEmpty()) buildToolSystemPrompt(tools) else null
 
-        for (msg in messages) {
+        // Merge any user-supplied system message with the tool-system block.
+        val mergedMessages = mergeToolSystem(messages, toolSystem)
+
+        for (msg in mergedMessages) {
             val role = when (msg.role) {
                 ChatRole.TOOL -> "tool"
                 else -> msg.role.roleName
@@ -62,5 +62,64 @@ public class Llama3ChatTemplate : ChatTemplate {
         }
 
         return sb.toString()
+    }
+
+    private fun buildToolSystemPrompt(tools: List<ToolDefinition>): String {
+        val toolsJson = tools.joinToString("\n\n") { tool ->
+            val obj = buildJsonObject {
+                put("name", tool.name)
+                put("description", tool.description)
+                put("parameters", tool.parameters)
+            }
+            Json.encodeToString(JsonObject.serializer(), obj)
+        }
+
+        return when (format) {
+            Llama3ToolFormat.JSON -> buildString {
+                append("You are a helpful assistant with tool calling capabilities.\n")
+                append("When you receive a tool call response, use the output to format an answer to the original user question.\n")
+                append("\n")
+                append("You have access to the following functions:\n\n")
+                append(toolsJson)
+                append("\n\n")
+                append("If you choose to call a function, your reply MUST be a single JSON object on one line in the following format and nothing else:\n")
+                append("{\"name\": <function-name>, \"parameters\": <arguments-object>}\n")
+                append("Do not write the function definition. Do not include any prose. Do not use variables.")
+            }
+            Llama3ToolFormat.FUNCTION_TAG -> buildString {
+                append("You are a helpful assistant with tool calling capabilities.\n")
+                append("When you receive a tool call response, use the output to format an answer to the original user question.\n")
+                append("\n")
+                append("You have access to the following functions:\n\n")
+                append(toolsJson)
+                append("\n\n")
+                append("If you choose to call a function, ONLY reply in the format below and nothing else:\n")
+                append("<function=function_name>{\"arg_name\": \"arg_value\"}</function>\n")
+                append("Function calls MUST be on a single line. Required parameters MUST be specified.")
+            }
+        }
+    }
+
+    /**
+     * Prepend the tool-system block to an existing system message (if any),
+     * otherwise insert it as the first message. This preserves any user-set
+     * system prompt instead of clobbering it.
+     */
+    private fun mergeToolSystem(
+        messages: List<ChatMessage>,
+        toolSystem: String?
+    ): List<ChatMessage> {
+        if (toolSystem == null) return messages
+        val firstIsSystem = messages.firstOrNull()?.role == ChatRole.SYSTEM
+        return if (firstIsSystem) {
+            val first = messages.first()
+            val merged = ChatMessage(
+                role = ChatRole.SYSTEM,
+                content = toolSystem + "\n\n" + first.content
+            )
+            listOf(merged) + messages.drop(1)
+        } else {
+            listOf(ChatMessage(role = ChatRole.SYSTEM, content = toolSystem)) + messages
+        }
     }
 }

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Llama3ToolFormat.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/Llama3ToolFormat.kt
@@ -1,0 +1,40 @@
+package sk.ainet.apps.kllama.chat
+
+/**
+ * Tool-calling output format for Llama 3 / 3.1 / 3.2 family models.
+ *
+ * Llama 3.x ships two formats Meta has documented for custom tool calling.
+ * The model expects a *specific* one based on how the system prompt is
+ * phrased — there is no auto-detection on the model side, so the prompt
+ * and the parser must agree.
+ *
+ * | Format         | Model response shape                                  | Recommended for                      |
+ * |----------------|-------------------------------------------------------|--------------------------------------|
+ * | [JSON]         | `{"name": "fn", "parameters": {"k": "v"}}`            | Llama **3.2** 1B/3B (default)        |
+ * | [FUNCTION_TAG] | `<function=fn>{"k": "v"}</function>`                  | Llama **3.1** legacy / fallback      |
+ *
+ * Pass the chosen format to [Llama3ChatTemplate] (and to
+ * [Llama3ToolCallingSupport] when constructing one explicitly). The
+ * default — what `kllama --demo --template=llama3` resolves to — is
+ * [JSON], because that is the format Llama 3.2 1B/3B was fine-tuned on
+ * for custom tools.
+ *
+ * See `docs/llama3-tool-calling.md` for the full prompt-template shape
+ * Meta publishes for each format.
+ */
+public enum class Llama3ToolFormat {
+    /**
+     * Bare JSON response: `{"name": "fn_name", "parameters": {...}}`.
+     * Default for Llama 3.2 custom tools (matches Meta's `llama3_2/text_prompt_format.md`).
+     * Also accepted on 3.1 — use this unless you specifically need 3.1 legacy compat.
+     */
+    JSON,
+
+    /**
+     * Tag-wrapped JSON response: `<function=fn_name>{"arg": "value"}</function>`.
+     * Llama 3.1 legacy format, kept selectable for compatibility with prompts
+     * trained against earlier 3.1 docs. Llama 3.2 will follow this format
+     * if asked, but Meta's 3.2 docs recommend [JSON].
+     */
+    FUNCTION_TAG
+}

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallParser.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallParser.kt
@@ -19,10 +19,12 @@ import kotlinx.serialization.json.jsonPrimitive
 public object ToolCallParser {
 
     private val hermesStrategy = HermesToolCallParserStrategy()
+    private val llama3FunctionTagStrategy = Llama3FunctionTagParserStrategy()
     private val llama31Strategy = Llama31ToolCallParserStrategy()
 
     private val defaultStrategies: List<ToolCallParserStrategy> = listOf(
         hermesStrategy,
+        llama3FunctionTagStrategy,
         llama31Strategy
     )
 
@@ -57,14 +59,19 @@ public object ToolCallParser {
     /**
      * Parse a single JSON object into a [ToolCall].
      *
-     * Expects `{"name": "...", "arguments": {...}}` with an optional `"id"` field.
+     * Accepts either `"arguments"` (Hermes / our internal shape) or `"parameters"`
+     * (Meta's Llama 3.x docs) as the argument-object key. The `"id"` field is
+     * optional and auto-generated when absent.
+     *
      * Returns `null` if parsing fails or the `"name"` field is missing.
      */
     public fun parseJsonToolCall(jsonStr: String): ToolCall? {
         return try {
             val obj = json.parseToJsonElement(jsonStr).jsonObject
             val name = obj["name"]?.jsonPrimitive?.content ?: return null
-            val arguments = obj["arguments"]?.jsonObject ?: JsonObject(emptyMap())
+            val arguments = obj["arguments"]?.jsonObject
+                ?: obj["parameters"]?.jsonObject
+                ?: JsonObject(emptyMap())
             val id = obj["id"]?.jsonPrimitive?.content ?: generateCallId()
             ToolCall(id = id, name = name, arguments = arguments)
         } catch (_: Exception) {
@@ -107,22 +114,100 @@ internal class HermesToolCallParserStrategy : ToolCallParserStrategy {
         text.contains("<tool_call>")
 }
 
-/** Parses bare JSON objects with a `"name"` key (Llama 3.1 style). */
+/**
+ * Parses bare JSON objects with a `"name"` key (Llama 3.1 / 3.2 JSON tool
+ * format — Meta's `text_prompt_format.md` for Llama 3.2 custom tools).
+ *
+ * Accepts:
+ * - `{"name": "fn", "parameters": {...}}` — Llama 3.x docs
+ * - `{"name": "fn", "arguments": {...}}` — Hermes / our internal shape
+ *
+ * Tolerates a leading `<|python_tag|>` marker (used in some Llama 3.2 variants
+ * for the built-in tool calls; harmless on custom tools) and stray prose
+ * before/after the JSON object — finds the first balanced `{...}` block that
+ * starts the assistant turn after stripping the marker.
+ */
 internal class Llama31ToolCallParserStrategy : ToolCallParserStrategy {
 
-    override val formatName: String = "llama31"
+    override val formatName: String = "llama3-json"
 
     override fun parse(text: String): List<ToolCall> {
-        val trimmed = text.trim()
-        if (trimmed.startsWith("{") && trimmed.contains("\"name\"")) {
-            val parsed = ToolCallParser.parseJsonToolCall(trimmed)
-            if (parsed != null) return listOf(parsed)
-        }
-        return emptyList()
+        val candidate = stripPythonTag(text).trim()
+        if (!candidate.startsWith("{") || !candidate.contains("\"name\"")) return emptyList()
+        val firstObject = extractFirstJsonObject(candidate) ?: return emptyList()
+        val parsed = ToolCallParser.parseJsonToolCall(firstObject) ?: return emptyList()
+        return listOf(parsed)
     }
 
     override fun containsToolCall(text: String): Boolean {
-        val trimmed = text.trim()
-        return trimmed.startsWith("{") && trimmed.contains("\"name\"") && trimmed.contains("\"arguments\"")
+        val candidate = stripPythonTag(text).trim()
+        return candidate.startsWith("{") &&
+            candidate.contains("\"name\"") &&
+            (candidate.contains("\"arguments\"") || candidate.contains("\"parameters\""))
     }
+
+    private fun stripPythonTag(text: String): String {
+        val trimmed = text.trimStart()
+        return if (trimmed.startsWith("<|python_tag|>")) trimmed.removePrefix("<|python_tag|>") else text
+    }
+
+    /** Find the first `{...}` block at the start of [text], respecting brace nesting and string literals. */
+    private fun extractFirstJsonObject(text: String): String? {
+        if (!text.startsWith("{")) return null
+        var depth = 0
+        var inString = false
+        var escape = false
+        for ((i, c) in text.withIndex()) {
+            if (escape) {
+                escape = false
+                continue
+            }
+            if (inString) {
+                when (c) {
+                    '\\' -> escape = true
+                    '"' -> inString = false
+                }
+                continue
+            }
+            when (c) {
+                '"' -> inString = true
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return text.substring(0, i + 1)
+                }
+            }
+        }
+        return null
+    }
+}
+
+/**
+ * Parses Llama 3.1 legacy `<function=name>{"arg": "value"}</function>` tool calls.
+ *
+ * This is the format `kllama --demo --template=llama3` emits when the
+ * `Llama3ChatTemplate` is constructed with `Llama3ToolFormat.FUNCTION_TAG`.
+ * Selectable rather than default because Meta's Llama 3.2 docs recommend
+ * the bare-JSON format ([Llama31ToolCallParserStrategy]).
+ */
+internal class Llama3FunctionTagParserStrategy : ToolCallParserStrategy {
+
+    override val formatName: String = "llama3-function-tag"
+
+    private val pattern = Regex("""<function=([A-Za-z_][A-Za-z0-9_]*)>\s*(\{[\s\S]*?\})\s*</function>""")
+
+    override fun parse(text: String): List<ToolCall> {
+        val matches = pattern.findAll(text).toList()
+        if (matches.isEmpty()) return emptyList()
+        return matches.mapNotNull { m ->
+            val name = m.groupValues[1]
+            val args = m.groupValues[2]
+            // Synthesize the JSON shape parseJsonToolCall expects so we get unified
+            // id-generation + arguments/parameters handling.
+            val synthesized = "{\"name\": \"$name\", \"arguments\": $args}"
+            ToolCallParser.parseJsonToolCall(synthesized)
+        }
+    }
+
+    override fun containsToolCall(text: String): Boolean = pattern.containsMatchIn(text)
 }

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallingSupport.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallingSupport.kt
@@ -41,8 +41,16 @@ public interface ToolCallingSupport {
 // Built-in providers
 // ---------------------------------------------------------------------------
 
-/** Tool-calling support for the Llama 3 / 3.1 / 3.2 family. */
-public class Llama3ToolCallingSupport : ToolCallingSupport {
+/**
+ * Tool-calling support for the Llama 3 / 3.1 / 3.2 family.
+ *
+ * @param format Tool-calling response format the chat template instructs the
+ *   model to emit. Defaults to [Llama3ToolFormat.JSON] (Llama 3.2 default).
+ *   See [Llama3ToolFormat] and `docs/llama3-tool-calling.md`.
+ */
+public class Llama3ToolCallingSupport(
+    private val format: Llama3ToolFormat = Llama3ToolFormat.JSON
+) : ToolCallingSupport {
     override val family: String = "llama3"
 
     override fun supports(metadata: ModelMetadata): Boolean {
@@ -52,7 +60,7 @@ public class Llama3ToolCallingSupport : ToolCallingSupport {
         return tpl.contains("<|start_header_id|>")
     }
 
-    override fun createChatTemplate(): ChatTemplate = Llama3ChatTemplate()
+    override fun createChatTemplate(): ChatTemplate = Llama3ChatTemplate(format)
 
     override fun parseToolCalls(content: String): List<ToolCall> =
         ToolCallParser.parse(content)

--- a/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ChatTemplateTest.kt
+++ b/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ChatTemplateTest.kt
@@ -72,6 +72,79 @@ class ChatTemplateTest {
         assertContains(result, "42")
     }
 
+    // --- Llama 3 Tool-Format Variants ---
+
+    @Test
+    fun llama3JsonFormatInstructsBareJsonResponse() {
+        val template = Llama3ChatTemplate(Llama3ToolFormat.JSON)
+        val tool = ToolDefinition(
+            name = "list_files",
+            description = "List files",
+            parameters = buildJsonObject { put("type", "object") }
+        )
+        val result = template.apply(listOf(userMsg), tools = listOf(tool))
+
+        // Tool definition is embedded
+        assertContains(result, "list_files")
+        // System prompt instructs the bare-JSON format using "parameters"
+        assertContains(result, "\"name\": <function-name>")
+        assertContains(result, "\"parameters\": <arguments-object>")
+        // Must NOT instruct the legacy <function=...> tag format
+        assertTrue(!result.contains("<function="), "JSON format must not mention <function=...> tag")
+    }
+
+    @Test
+    fun llama3FunctionTagFormatInstructsTaggedResponse() {
+        val template = Llama3ChatTemplate(Llama3ToolFormat.FUNCTION_TAG)
+        val tool = ToolDefinition(
+            name = "list_files",
+            description = "List files",
+            parameters = buildJsonObject { put("type", "object") }
+        )
+        val result = template.apply(listOf(userMsg), tools = listOf(tool))
+
+        assertContains(result, "list_files")
+        // System prompt instructs the <function=...>...</function> format
+        assertContains(result, "<function=function_name>")
+        assertContains(result, "</function>")
+    }
+
+    @Test
+    fun llama3MergesUserSystemPromptWithToolBlock() {
+        val template = Llama3ChatTemplate()
+        val tool = ToolDefinition(
+            name = "calculator",
+            description = "Math",
+            parameters = buildJsonObject { put("type", "object") }
+        )
+        val userSystem = ChatMessage(ChatRole.SYSTEM, "Be terse.")
+        val result = template.apply(listOf(userSystem, userMsg), tools = listOf(tool))
+
+        // Both the tool block AND the user system message must be preserved
+        assertContains(result, "calculator")
+        assertContains(result, "Be terse.")
+        // User system message comes after the tool block in the merged single
+        // system turn (so the tool instructions take precedence visually).
+        val toolIdx = result.indexOf("calculator")
+        val userIdx = result.indexOf("Be terse.")
+        assertTrue(toolIdx in 0 until userIdx, "tool block must precede user system text")
+    }
+
+    @Test
+    fun llama3DefaultFormatIsJson() {
+        // Regression guard: changing the default format silently would shift
+        // production behavior across every Llama 3 deployment.
+        val templateDefault = Llama3ChatTemplate()
+        val templateExplicit = Llama3ChatTemplate(Llama3ToolFormat.JSON)
+        val tool = ToolDefinition(
+            name = "x",
+            description = "y",
+            parameters = buildJsonObject { put("type", "object") }
+        )
+        val msgs = listOf(userMsg)
+        assertEquals(templateExplicit.apply(msgs, listOf(tool)), templateDefault.apply(msgs, listOf(tool)))
+    }
+
     // --- ChatML Template Tests ---
 
     @Test

--- a/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ToolCallParserTest.kt
+++ b/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ToolCallParserTest.kt
@@ -116,4 +116,79 @@ class ToolCallParserTest {
         val calls = ToolCallParser.parse(text)
         assertTrue(calls.isEmpty())
     }
+
+    // --- Llama 3.2 JSON: "parameters" key alias for "arguments" ---
+
+    @Test
+    fun parseLlama32JsonWithParametersKey() {
+        // Meta's Llama 3.2 docs use "parameters" as the argument-object key.
+        val text = """{"name": "list_files", "parameters": {"path": "/tmp"}}"""
+        val calls = ToolCallParser.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("list_files", calls[0].name)
+        assertEquals("/tmp", calls[0].arguments["path"]?.toString()?.trim('"'))
+    }
+
+    @Test
+    fun parseLlama32JsonStripsPythonTagPrefix() {
+        // Llama 3.2 sometimes emits <|python_tag|> before the JSON for built-in tools.
+        // The parser should tolerate it on custom tool calls too.
+        val text = """<|python_tag|>{"name": "calc", "parameters": {"x": 1}}"""
+        val calls = ToolCallParser.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("calc", calls[0].name)
+    }
+
+    @Test
+    fun parseLlama32JsonIgnoresTrailingProse() {
+        // Small models often append commentary after the JSON. The parser must
+        // grab the first balanced {...} and ignore the rest.
+        val text = """{"name": "list_files", "parameters": {"path": "/tmp"}} I hope that helps!"""
+        val calls = ToolCallParser.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("list_files", calls[0].name)
+    }
+
+    // --- Llama 3.1 legacy <function=...>...</function> ---
+
+    @Test
+    fun parseLlama31FunctionTagSingleCall() {
+        val text = """<function=list_files>{"path": "/tmp"}</function>"""
+        val calls = ToolCallParser.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("list_files", calls[0].name)
+        assertEquals("/tmp", calls[0].arguments["path"]?.toString()?.trim('"'))
+    }
+
+    @Test
+    fun parseLlama31FunctionTagMultipleCalls() {
+        val text = """
+            <function=search>{"q": "weather"}</function>
+            <function=calc>{"expression": "1+1"}</function>
+        """.trimIndent()
+        val calls = ToolCallParser.parse(text)
+        assertEquals(2, calls.size)
+        assertEquals("search", calls[0].name)
+        assertEquals("calc", calls[1].name)
+    }
+
+    @Test
+    fun parseLlama31FunctionTagWithSurroundingProse() {
+        val text = """Sure, let me check.
+            <function=list_files>{"path": "/tmp"}</function>
+            One moment."""
+        val calls = ToolCallParser.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("list_files", calls[0].name)
+    }
+
+    @Test
+    fun containsToolCallDetectsFunctionTag() {
+        assertTrue(ToolCallParser.containsToolCall("""<function=x>{}</function>"""))
+    }
+
+    @Test
+    fun containsToolCallDetectsParametersKey() {
+        assertTrue(ToolCallParser.containsToolCall("""{"name": "x", "parameters": {}}"""))
+    }
 }

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
@@ -23,13 +23,29 @@ class GGUFTokenizer private constructor(
     private val _bosTokenId: Int,
     private val _eosTokenId: Int,
     private val unkTokenId: Int,
-    private val strategy: TokenizerStrategy
+    private val strategy: TokenizerStrategy,
+    private val tokenTypes: IntArray? = null
 ) : Tokenizer {
 
     companion object {
         private const val DEFAULT_BOS_TOKEN_ID = 1
         private const val DEFAULT_EOS_TOKEN_ID = 2
         private const val DEFAULT_UNK_TOKEN_ID = 0
+
+        // GGUF token_type values (per llama.cpp convention).
+        // CONTROL marks atomic special tokens like <|begin_of_text|>, <|eot_id|>, <|im_start|>.
+        private const val TOKEN_TYPE_CONTROL = 3
+
+        /** Test-only factory; do not use from production code. */
+        internal fun forTesting(
+            vocab: List<String>,
+            scores: FloatArray,
+            bosTokenId: Int,
+            eosTokenId: Int,
+            unkTokenId: Int,
+            strategy: TokenizerStrategy,
+            tokenTypes: IntArray? = null
+        ): GGUFTokenizer = GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy, tokenTypes)
 
         /**
          * Create a tokenizer from a HuggingFace tokenizer.json string.
@@ -247,6 +263,9 @@ class GGUFTokenizer private constructor(
             val eosTokenId = fields["tokenizer.ggml.eos_token_id"]?.scalarInt() ?: DEFAULT_EOS_TOKEN_ID
             val unkTokenId = fields["tokenizer.ggml.unknown_token_id"]?.scalarInt() ?: DEFAULT_UNK_TOKEN_ID
 
+            // Per-token classification (CONTROL = atomic special tokens that must not be BPE-split).
+            val tokenTypes = fields["tokenizer.ggml.token_type"]?.let { extractIntArray(it) }
+
             // Detect tokenizer type from metadata
             val modelType = fields["tokenizer.ggml.model"]?.scalarString()
             val strategy = detectStrategy(modelType, vocab, debug)
@@ -260,7 +279,7 @@ class GGUFTokenizer private constructor(
                 println("DEBUG: Using tokenizer strategy: ${strategy.type}")
             }
 
-            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy)
+            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy, tokenTypes)
         }
 
         /**
@@ -315,6 +334,9 @@ class GGUFTokenizer private constructor(
             val eosTokenId = fields["tokenizer.ggml.eos_token_id"]?.toIntValue() ?: DEFAULT_EOS_TOKEN_ID
             val unkTokenId = fields["tokenizer.ggml.unknown_token_id"]?.toIntValue() ?: DEFAULT_UNK_TOKEN_ID
 
+            // Per-token classification (CONTROL = atomic special tokens that must not be BPE-split).
+            val tokenTypes = fields["tokenizer.ggml.token_type"]?.let { extractIntList(it) }
+
             // Detect tokenizer type from metadata
             val modelType = fields["tokenizer.ggml.model"]?.toString()
             val strategy = detectStrategy(modelType, vocab, debug)
@@ -328,7 +350,7 @@ class GGUFTokenizer private constructor(
                 println("DEBUG: Using tokenizer strategy: ${strategy.type}")
             }
 
-            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy)
+            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy, tokenTypes)
         }
 
         /**
@@ -482,6 +504,43 @@ class GGUFTokenizer private constructor(
             return floats.toFloatArray()
         }
 
+        private fun extractIntArray(field: ReaderField): IntArray {
+            val ints = mutableListOf<Int>()
+            for (idx in field.data) {
+                if (idx < 0 || idx >= field.parts.size) continue
+                val part = field.parts[idx]
+                for (value in part) {
+                    when (value) {
+                        is Int -> ints.add(value)
+                        is UInt -> ints.add(value.toInt())
+                        is Long -> ints.add(value.toInt())
+                        is ULong -> ints.add(value.toInt())
+                        is Number -> ints.add(value.toInt())
+                    }
+                }
+            }
+            return ints.toIntArray()
+        }
+
+        private fun extractIntList(value: Any): IntArray {
+            return when (value) {
+                is List<*> -> {
+                    val ints = mutableListOf<Int>()
+                    for (item in value) {
+                        when (item) {
+                            is Int -> ints.add(item)
+                            is UInt -> ints.add(item.toInt())
+                            is Long -> ints.add(item.toInt())
+                            is ULong -> ints.add(item.toInt())
+                            is Number -> ints.add(item.toInt())
+                        }
+                    }
+                    ints.toIntArray()
+                }
+                else -> error("Expected List<Number> for token_type field, got ${value::class.simpleName}")
+            }
+        }
+
         private fun ReaderField.scalarInt(): Int {
             val idx = data.firstOrNull() ?: 0
             val part = parts.getOrNull(idx) ?: return 0
@@ -536,19 +595,64 @@ class GGUFTokenizer private constructor(
             .sortedByDescending { (_, idx) -> scores.getOrElse(idx) { 0f } }
     }
 
+    // Atomic special tokens (GGUF token_type == CONTROL), longest-first for greedy matching.
+    // These must be emitted as a single ID even though greedy bottom-up BPE could never assemble
+    // their multi-character form from single-char starting tokens.
+    private val specialTokensByLength: List<Pair<String, Int>> by lazy {
+        if (tokenTypes == null) emptyList()
+        else vocab.asSequence()
+            .mapIndexedNotNull { id, str ->
+                if (id < tokenTypes.size && tokenTypes[id] == TOKEN_TYPE_CONTROL && str.isNotEmpty()) {
+                    str to id
+                } else null
+            }
+            .sortedByDescending { it.first.length }
+            .toList()
+    }
+
     override fun encode(text: String): IntArray {
         if (text.isEmpty()) return intArrayOf()
-
-        // Use strategy-specific preprocessing
-        val preprocessed = strategy.preprocess(text)
 
         // Handle WordPiece differently - it splits on whitespace first
         if (strategy.type == TokenizerType.WORDPIECE) {
             return encodeWordPiece(text)
         }
 
-        // Standard BPE encoding for SentencePiece and GPT-2 style tokenizers
-        return encodeBPE(preprocessed)
+        val specials = specialTokensByLength
+        if (specials.isEmpty()) {
+            // No CONTROL tokens registered — preserve legacy behavior.
+            return encodeBPE(strategy.preprocess(text))
+        }
+
+        // Two-pass: walk the raw text, emit atomic IDs for special-token matches,
+        // BPE-encode the plain-text gaps in between.
+        val out = mutableListOf<Int>()
+        val gap = StringBuilder()
+        var i = 0
+        while (i < text.length) {
+            var match: Pair<String, Int>? = null
+            for (s in specials) {
+                if (text.regionMatches(i, s.first, 0, s.first.length)) {
+                    match = s
+                    break
+                }
+            }
+            if (match != null) {
+                if (gap.isNotEmpty()) {
+                    for (id in encodeBPE(strategy.preprocess(gap.toString()))) out.add(id)
+                    gap.clear()
+                }
+                out.add(match.second)
+                i += match.first.length
+            } else {
+                gap.append(text[i])
+                i++
+            }
+        }
+        if (gap.isNotEmpty()) {
+            for (id in encodeBPE(strategy.preprocess(gap.toString()))) out.add(id)
+        }
+        return out.toIntArray()
     }
 
     /**

--- a/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerEncodingTest.kt
+++ b/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerEncodingTest.kt
@@ -306,6 +306,117 @@ class TokenizerEncodingTest {
         assertEquals(" the", decoded)
     }
 
+    // ==================== Special-token (CONTROL) Encoding ====================
+    //
+    // GGUF marks atomic special tokens (e.g. Llama 3's <|begin_of_text|>, <|eot_id|>;
+    // ChatML's <|im_start|>) with token_type == 3 (CONTROL). These must be emitted
+    // as a single atomic token ID even though their multi-character string would never
+    // be assembled by greedy bottom-up BPE merging from single-char starting tokens.
+
+    @Test
+    fun `BPE encode emits CONTROL tokens atomically not as char fragments`() {
+        // Vocab: byte-level chars + a CONTROL special token.
+        // BPE has no merge chain that could ever assemble "<|begin|>" from chars,
+        // so without special handling encoding it would yield ~9 fragment IDs.
+        val vocab = listOf(
+            "<", "|", "b", "e", "g", "i", "n", ">",  // 0..7  single chars
+            "<|begin|>",                              // 8     CONTROL
+            "h", "l", "o"                             // 9..11 single chars
+        )
+        val scores = FloatArray(vocab.size) { 0f }
+        val tokenTypes = IntArray(vocab.size) { 1 }   // 1 = NORMAL
+        tokenTypes[8] = 3                             // 3 = CONTROL
+
+        val tok = GGUFTokenizer.forTesting(
+            vocab = vocab,
+            scores = scores,
+            bosTokenId = 8,
+            eosTokenId = 8,
+            unkTokenId = 0,
+            strategy = BPEStrategy,
+            tokenTypes = tokenTypes
+        )
+
+        val ids = tok.encode("<|begin|>hello")
+        assertEquals(8, ids[0], "first token must be the atomic <|begin|> id (8), not a fragment of '<'")
+        // Remaining ids should encode "hello" — exact tokenization is irrelevant here;
+        // what matters is that the special token didn't get char-split.
+        assertTrue(ids.size < 9, "expected ~5 ids (1 special + 'hello' chars), got ${ids.size}: ${ids.toList()}")
+    }
+
+    @Test
+    fun `BPE encode finds CONTROL token in middle of plain text`() {
+        val vocab = listOf(
+            "h", "i",                  // 0..1
+            "<|stop|>",                // 2     CONTROL
+            "b", "y", "e"              // 3..5
+        )
+        val scores = FloatArray(vocab.size) { 0f }
+        val tokenTypes = IntArray(vocab.size) { 1 }
+        tokenTypes[2] = 3
+
+        val tok = GGUFTokenizer.forTesting(
+            vocab = vocab,
+            scores = scores,
+            bosTokenId = 2,
+            eosTokenId = 2,
+            unkTokenId = 0,
+            strategy = BPEStrategy,
+            tokenTypes = tokenTypes
+        )
+
+        val ids = tok.encode("hi<|stop|>bye")
+        // Atomic stop token must appear exactly once, and only once.
+        val stopOccurrences = ids.count { it == 2 }
+        assertEquals(1, stopOccurrences, "atomic <|stop|> must appear exactly once, got ids=${ids.toList()}")
+    }
+
+    @Test
+    fun `BPE encode handles two adjacent CONTROL tokens`() {
+        val vocab = listOf(
+            "<|a|>",   // 0  CONTROL
+            "<|b|>",   // 1  CONTROL
+            "x"        // 2
+        )
+        val scores = FloatArray(vocab.size) { 0f }
+        val tokenTypes = intArrayOf(3, 3, 1)
+
+        val tok = GGUFTokenizer.forTesting(
+            vocab = vocab,
+            scores = scores,
+            bosTokenId = 0,
+            eosTokenId = 1,
+            unkTokenId = 2,
+            strategy = BPEStrategy,
+            tokenTypes = tokenTypes
+        )
+
+        val ids = tok.encode("<|a|><|b|>x")
+        // Adjacent specials should yield exactly [0, 1, 2] — no char fragments between them.
+        assertEquals(listOf(0, 1, 2), ids.toList())
+    }
+
+    @Test
+    fun `BPE encode without tokenTypes falls back to plain BPE`() {
+        // No tokenTypes provided → no special handling, plain BPE on chars.
+        // Guards against accidental behavior change for callers that don't pass tokenTypes.
+        val vocab = listOf("h", "i")
+        val scores = floatArrayOf(0f, 0f)
+
+        val tok = GGUFTokenizer.forTesting(
+            vocab = vocab,
+            scores = scores,
+            bosTokenId = 0,
+            eosTokenId = 1,
+            unkTokenId = 0,
+            strategy = BPEStrategy,
+            tokenTypes = null
+        )
+
+        val ids = tok.encode("hi")
+        assertEquals(listOf(0, 1), ids.toList())
+    }
+
     @Test
     fun `BPE round trip`() {
         val vocab = listOf(

--- a/tests/smoke/smoke-models.json
+++ b/tests/smoke/smoke-models.json
@@ -36,13 +36,6 @@
       }
     },
     {
-      "name": "Qwen3.5-9B-Q4_K_M",
-      "runner": "kqwen",
-      "model": "Qwen3.5-9B-Q4_K_M.gguf",
-      "format": "gguf",
-      "steps": 16
-    },
-    {
       "name": "Gemma4-E4B-GGUF",
       "runner": "kgemma",
       "model": "~/.lmstudio/models/lmstudio-community/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf",

--- a/tests/smoke/smoke-models.json
+++ b/tests/smoke/smoke-models.json
@@ -36,6 +36,13 @@
       }
     },
     {
+      "name": "Qwen3.5-9B-Q4_K_M",
+      "runner": "kqwen",
+      "model": "Qwen3.5-9B-Q4_K_M.gguf",
+      "format": "gguf",
+      "steps": 16
+    },
+    {
       "name": "Gemma4-E4B-GGUF",
       "runner": "kgemma",
       "model": "~/.lmstudio/models/lmstudio-community/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf",


### PR DESCRIPTION
## Summary

Fixes #72.

Two-commit stack that takes Llama 3.x tool calling from "produces gibberish" to "round-trips a real tool call against `Llama-3.2-1B-Instruct-Q8_0.gguf` end-to-end on CPU".

- **`8dad771` `fix(tokenizer): emit GGUF CONTROL tokens atomically`**
  Root-cause fix for every chat template. `GGUFTokenizer` now reads `tokenizer.ggml.token_type` and emits CONTROL-flagged tokens (`<|begin_of_text|>`, `<|eot_id|>`, `<|im_start|>`, …) atomically instead of char-fragmenting them through bottom-up BPE. Backwards-compatible: when `token_type` is absent the encoder falls through to the original BPE-only path. New `internal forTesting()` factory + 4 new unit tests exercising the *real* `encode()` (the bug went undetected because pre-existing tests used a `MockBPETokenizer` that copied the same broken algorithm).

- **`268b8e8` `feat(llama3): Meta-documented tool calling`**
  Aligns `Llama3ChatTemplate` with Meta's published prompt format. New `Llama3ToolFormat` enum: `JSON` (default — what Llama 3.2 1B/3B were fine-tuned on for custom tools) and `FUNCTION_TAG` (Llama 3.1 legacy, selectable via `Llama3ToolCallingSupport(FUNCTION_TAG)`). Parser tolerates `parameters` as alias for `arguments`, strips a leading `<|python_tag|>`, and uses brace-counting to extract the first balanced JSON object so trailing prose doesn't break parsing. New `Llama3FunctionTagParserStrategy` for the legacy form. Full prompt shape, when-to-use-which, and the small-model caveat are written up in `docs/llama3-tool-calling.md`.

## Branch base

This PR targets **`feature/gemma4`** (the Gemma 4 epic integration branch), per the GitFlow note in `PLAN-tool-calling.md` ("all sub-feature branches were cut from `feature/gemma4` and PR back into `feature/gemma4` … when `feature/gemma4` eventually merges to `develop`, the whole stack ships together"). `feature/llama-tool` was branched from `feature/gemma4` at `cd48e8e`, so the diff is just the two commits above.

## Before / after on Llama 3.2 1B Q8_0

**Before** (every Llama 3 chat-template invocation):
```
Assistant: system<|end_header_id|>!!list_files /tmp!<|eot_id|><|start_header_id|>!!list_files /tmp!<|eo|>... (looped to step cap)
```

**After**:
```
Assistant: {"name": "list_files", "parameters": {"path": "/tmp"}}
[Tool Call] list_files({"path":"/tmp"})
[Tool Result] list_files -> [dir] android-A9973957
[dir] claude-503 ...
[file] hublogs_2026-04-26_06-28-05.log (33.5 MB) ...
Assistant: The files in /tmp are:
* CalNotificationsAvailable (0 B)
* hublogs_2026-04-22_06-37-17.log (32.0 MB) ...
```

The 1B model emits exactly Meta's documented JSON shape (`"parameters"` key), the parser catches it, `list_files` actually runs against `/tmp`, and round 2 produces a grounded NL summary.

## Out of scope

Qwen3 benefits from the tokenizer fix at the encoder level, but its runtime path has a separate pre-existing bug — raw text generation also produces degenerate repetition. Tracked in #74.

## Test plan

- [x] `./gradlew :llm-core:jvmTest` — all 21 tokenizer tests green (4 new).
- [x] `./gradlew :llm-agent:jvmTest` — all 36 chat-template / parser tests green (11 new).
- [x] `./gradlew :llm-apps:kllama-cli:shadowJar` — builds clean.
- [x] Manual end-to-end: `kllama --demo --template=llama3 -k 0.0 "What files are in /tmp?"` against `Llama-3.2-1B-Instruct-Q8_0.gguf` — clean tool call, real `list_files` execution, grounded round-2 summary.
- [ ] Reviewer to verify `docs/llama3-tool-calling.md` reads cleanly and matches the implementation.
- [ ] (Optional follow-up, not in this PR) add `--llama-tool-format=function-tag` CLI flag to `kllama-cli` for runtime format selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
