### PR TITLE
Qwen3 runtime: wire HALF_SPLIT (NEOX) RoPE per architecture

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/RopeUtils.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/RopeUtils.kt
@@ -5,6 +5,46 @@ import kotlin.math.pow
 import kotlin.math.sin
 
 /**
+ * RoPE rotation conventions used by GGUF-based models.
+ *
+ * The two conventions are mathematically equivalent under different weight
+ * permutations and produce identical results IF the weights are stored in the
+ * matching layout. Mismatching them silently corrupts attention.
+ *
+ * | Convention   | llama.cpp name      | Pair indexing                      | Used by                  |
+ * |--------------|---------------------|------------------------------------|--------------------------|
+ * | [INTERLEAVED]| `LLAMA_ROPE_TYPE_NORM` (mode 0) | `(buf[2i], buf[2i+1])` | LLaMA, Mistral, Gemma    |
+ * | [HALF_SPLIT] | `LLAMA_ROPE_TYPE_NEOX` (mode 2) | `(buf[i], buf[i+ropeDim/2])` | Qwen 2/3, Phi, Falcon |
+ *
+ * llama.cpp picks the right convention per architecture via
+ * `llm_arch_rope_type(arch)`. We mirror that mapping in [CpuAttentionBackend]
+ * (and any other backend) so that GGUF tensors load as-is — no weight
+ * permutation at conversion time.
+ */
+public enum class RopeType {
+    /** Interleaved adjacent-pair rotation (llama.cpp NORM, mode 0). */
+    INTERLEAVED,
+    /** Half-split rotation (llama.cpp NEOX, mode 2) — first half rotates with second half. */
+    HALF_SPLIT;
+
+    public companion object {
+        /**
+         * Map a GGUF `general.architecture` string to the RoPE convention the
+         * model was trained / converted with. Mirrors `llm_arch_rope_type()` in
+         * `llama.cpp/src/llama-arch.cpp`.
+         *
+         * Defaults to [INTERLEAVED] for unknown architectures (the LLaMA-family
+         * default), since most new families that need [HALF_SPLIT] derive from
+         * Qwen / Phi / Falcon and should be added here explicitly.
+         */
+        public fun forArchitecture(arch: String): RopeType = when (arch.lowercase()) {
+            "qwen2", "qwen3", "qwen35", "phi2", "phi3", "phi4", "falcon", "mpt", "stablelm", "starcoder2" -> HALF_SPLIT
+            else -> INTERLEAVED
+        }
+    }
+}
+
+/**
  * Compute RoPE (Rotary Position Embedding) frequency for a given pair index and position.
  *
  * Formula: freq = pos / base^(2 * pair / dim)
@@ -63,15 +103,16 @@ public fun applyRopeRotation(
     precomputedCos: FloatArray? = null,
     precomputedSin: FloatArray? = null,
     ropeStride: Int = ropeDim / 2,
-    precomputedMatchBase: Float? = null
+    precomputedMatchBase: Float? = null,
+    ropeType: RopeType = RopeType.INTERLEAVED
 ) {
     val usePrecomputed = precomputedCos != null && precomputedSin != null &&
             (precomputedMatchBase == null || base == precomputedMatchBase)
+    val halfDim = ropeDim / 2
 
     for (h in 0 until nHeads) {
         val headOffset = h * headSize
-        for (pair in 0 until ropeDim / 2) {
-            val i = pair * 2
+        for (pair in 0 until halfDim) {
             val fcr: Float
             val fci: Float
             if (usePrecomputed) {
@@ -81,10 +122,16 @@ public fun applyRopeRotation(
                 fcr = ropeCos(pair, pos, ropeDim, base)
                 fci = ropeSin(pair, pos, ropeDim, base)
             }
-            val v0 = buf[headOffset + i]
-            val v1 = buf[headOffset + i + 1]
-            buf[headOffset + i] = v0 * fcr - v1 * fci
-            buf[headOffset + i + 1] = v0 * fci + v1 * fcr
+            // INTERLEAVED rotates (2i, 2i+1) — adjacent pairs (Llama / Gemma / Mistral).
+            // HALF_SPLIT rotates (i, i + ropeDim/2) — first-half / second-half (Qwen / Phi / Falcon).
+            val (idxA, idxB) = when (ropeType) {
+                RopeType.INTERLEAVED -> headOffset + pair * 2 to headOffset + pair * 2 + 1
+                RopeType.HALF_SPLIT -> headOffset + pair to headOffset + pair + halfDim
+            }
+            val v0 = buf[idxA]
+            val v1 = buf[idxB]
+            buf[idxA] = v0 * fcr - v1 * fci
+            buf[idxB] = v0 * fci + v1 * fcr
         }
     }
 }

--- a/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/RopeUtilsTest.kt
+++ b/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/RopeUtilsTest.kt
@@ -1,0 +1,130 @@
+package sk.ainet.apps.llm
+
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * RoPE rotation tests covering both conventions emitted by GGUF tooling.
+ *
+ * Llama family is INTERLEAVED (`(buf[2i], buf[2i+1])`); Qwen 2/3 / Phi /
+ * Falcon are HALF_SPLIT (`(buf[i], buf[i+ropeDim/2])`). Mismatching the
+ * convention vs. how the model was trained silently corrupts attention —
+ * see ISSUE-74 (Qwen3 runtime degenerate output).
+ */
+class RopeUtilsTest {
+
+    private fun assertCloseTo(expected: Float, actual: Float, tol: Float = 1e-5f) {
+        assertTrue(abs(expected - actual) < tol,
+            "expected $expected, got $actual (delta ${abs(expected - actual)})")
+    }
+
+    @Test
+    fun interleavedRotationMatchesAdjacentPairFormula() {
+        // Single head, headSize = ropeDim = 4 → 2 pairs at indices (0,1) and (2,3).
+        // pos = 1, base = 10000.
+        val buf = floatArrayOf(1f, 2f, 3f, 4f)
+        val pos = 1
+        val ropeDim = 4
+        val base = 10000f
+        applyRopeRotation(buf, nHeads = 1, headSize = ropeDim, ropeDim = ropeDim, pos = pos, base = base)
+
+        // Reference: rotate (b[0], b[1]) by freq(pair=0), (b[2], b[3]) by freq(pair=1).
+        val f0 = pos / base.toDouble().pow(0.0).toFloat()
+        val f1 = pos / base.toDouble().pow(0.5).toFloat()  // 2*1/4 = 0.5
+        val expected = floatArrayOf(
+            1f * cos(f0) - 2f * sin(f0),
+            1f * sin(f0) + 2f * cos(f0),
+            3f * cos(f1) - 4f * sin(f1),
+            3f * sin(f1) + 4f * cos(f1)
+        )
+        for (i in buf.indices) assertCloseTo(expected[i], buf[i])
+    }
+
+    @Test
+    fun halfSplitRotationPairsFirstHalfWithSecondHalf() {
+        // Single head, headSize = ropeDim = 4 → pairs are (b[0], b[2]) and (b[1], b[3]).
+        // Distinct from interleaved which would pair (b[0], b[1]) and (b[2], b[3]).
+        val buf = floatArrayOf(1f, 2f, 3f, 4f)
+        val pos = 1
+        val ropeDim = 4
+        val base = 10000f
+        applyRopeRotation(
+            buf, nHeads = 1, headSize = ropeDim, ropeDim = ropeDim,
+            pos = pos, base = base, ropeType = RopeType.HALF_SPLIT
+        )
+
+        val f0 = pos / base.toDouble().pow(0.0).toFloat()
+        val f1 = pos / base.toDouble().pow(0.5).toFloat()
+        // Pair 0: (b[0]=1, b[2]=3) rotated by f0 → goes back to (b[0], b[2])
+        // Pair 1: (b[1]=2, b[3]=4) rotated by f1 → goes back to (b[1], b[3])
+        val expected = floatArrayOf(
+            1f * cos(f0) - 3f * sin(f0),  // b[0]
+            2f * cos(f1) - 4f * sin(f1),  // b[1]
+            1f * sin(f0) + 3f * cos(f0),  // b[2]
+            2f * sin(f1) + 4f * cos(f1)   // b[3]
+        )
+        for (i in buf.indices) assertCloseTo(expected[i], buf[i])
+    }
+
+    @Test
+    fun halfSplitDoesNotEqualInterleavedForSameInput() {
+        // Regression guard: two conventions must produce *different* outputs on
+        // the same input (so a wiring mistake is observable).
+        val a = floatArrayOf(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f)
+        val b = a.copyOf()
+        val pos = 3
+        applyRopeRotation(a, nHeads = 1, headSize = 8, ropeDim = 8, pos = pos, base = 10000f, ropeType = RopeType.INTERLEAVED)
+        applyRopeRotation(b, nHeads = 1, headSize = 8, ropeDim = 8, pos = pos, base = 10000f, ropeType = RopeType.HALF_SPLIT)
+
+        var anyDiff = false
+        for (i in a.indices) if (abs(a[i] - b[i]) > 1e-4f) anyDiff = true
+        assertTrue(anyDiff, "INTERLEAVED and HALF_SPLIT must produce different rotations: a=${a.toList()} b=${b.toList()}")
+    }
+
+    @Test
+    fun defaultRopeTypeIsInterleavedForBackwardsCompat() {
+        // Callers that don't pass ropeType (existing Llama path) must keep the
+        // pre-fix behavior, i.e. interleaved rotation.
+        val withDefault = floatArrayOf(0.5f, 1.5f, 2.5f, 3.5f)
+        val explicitInterleaved = withDefault.copyOf()
+        applyRopeRotation(withDefault, nHeads = 1, headSize = 4, ropeDim = 4, pos = 2, base = 10000f)
+        applyRopeRotation(
+            explicitInterleaved, nHeads = 1, headSize = 4, ropeDim = 4,
+            pos = 2, base = 10000f, ropeType = RopeType.INTERLEAVED
+        )
+        for (i in withDefault.indices) assertEquals(explicitInterleaved[i], withDefault[i])
+    }
+
+    @Test
+    fun halfSplitMultipleHeadsAreIndependent() {
+        // Each head is rotated independently — the half-split partitioning is
+        // within the head, not across heads.
+        val buf = floatArrayOf(
+            1f, 2f, 3f, 4f,   // head 0
+            5f, 6f, 7f, 8f    // head 1
+        )
+        val pos = 2
+        applyRopeRotation(
+            buf, nHeads = 2, headSize = 4, ropeDim = 4,
+            pos = pos, base = 10000f, ropeType = RopeType.HALF_SPLIT
+        )
+        val f0 = pos / 1f
+        val f1 = pos / 100f
+        // Head 0: (1,3) rotated by f0, (2,4) rotated by f1
+        assertCloseTo(1f * cos(f0) - 3f * sin(f0), buf[0])
+        assertCloseTo(2f * cos(f1) - 4f * sin(f1), buf[1])
+        assertCloseTo(1f * sin(f0) + 3f * cos(f0), buf[2])
+        assertCloseTo(2f * sin(f1) + 4f * cos(f1), buf[3])
+        // Head 1: (5,7) rotated by f0, (6,8) rotated by f1 — same freqs, different inputs
+        assertCloseTo(5f * cos(f0) - 7f * sin(f0), buf[4])
+        assertCloseTo(6f * cos(f1) - 8f * sin(f1), buf[5])
+        assertCloseTo(5f * sin(f0) + 7f * cos(f0), buf[6])
+        assertCloseTo(6f * sin(f1) + 8f * cos(f1), buf[7])
+    }
+}
+
+private fun Double.pow(exp: Double): Double = kotlin.math.exp(exp * kotlin.math.ln(this))

--- a/llm-runtime/kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/CpuAttentionBackend.kt
+++ b/llm-runtime/kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/CpuAttentionBackend.kt
@@ -3,6 +3,7 @@ package sk.ainet.apps.kllama
 import kotlin.math.sqrt
 import sk.ainet.apps.llm.KvCache
 import sk.ainet.apps.llm.HeapKvCache
+import sk.ainet.apps.llm.RopeType
 import sk.ainet.apps.llm.applyRopeRotation
 import sk.ainet.apps.llm.softmaxInPlace
 import sk.ainet.context.ExecutionContext
@@ -31,7 +32,8 @@ public class CpuAttentionBackend<T : DType>(
     private val dtype: KClass<T>,
     kvCache: KvCache? = null,
     private val ropeFreqBase: Float = 10000f,
-    maxContextLength: Int? = null
+    maxContextLength: Int? = null,
+    private val ropeType: RopeType = RopeType.forArchitecture(weights.metadata.architecture)
 ) : AttentionBackend<T> {
 
     private val dim = weights.metadata.embeddingLength
@@ -113,8 +115,8 @@ public class CpuAttentionBackend<T : DType>(
 
         require(headSize % 2 == 0) { "RoPE requires even head size; got $headSize" }
 
-        applyRopeRotation(qBuf, nHeads, headSize, ropeDim, pos, ropeFreqBase, ropeReal, ropeImag, ropeStride)
-        applyRopeRotation(kBuf, nKvHeads, headSize, ropeDim, pos, ropeFreqBase, ropeReal, ropeImag, ropeStride)
+        applyRopeRotation(qBuf, nHeads, headSize, ropeDim, pos, ropeFreqBase, ropeReal, ropeImag, ropeStride, ropeType = ropeType)
+        applyRopeRotation(kBuf, nKvHeads, headSize, ropeDim, pos, ropeFreqBase, ropeReal, ropeImag, ropeStride, ropeType = ropeType)
     }
 
     private fun attentionGqa(layerIdx: Int, qBuf: FloatArray, pos: Int): FloatArray {


### PR DESCRIPTION
## Summary

Fixes #74.

`applyRopeRotation` only implemented the **interleaved** adjacent-pair convention (`(buf[2i], buf[2i+1])` — llama.cpp `LLAMA_ROPE_TYPE_NORM`), which is correct for Llama / Mistral / Gemma but **wrong** for Qwen 2 / Qwen 3 / Phi / Falcon, which use the **half-split** convention (`(buf[i], buf[i + ropeDim/2])` — llama.cpp `LLAMA_ROPE_TYPE_NEOX`). The two conventions are mathematically equivalent under different weight permutations and produce identical results IF the weights are stored in the matching layout. llama.cpp's GGUF converter does NOT permute Qwen tensors, so applying the interleaved convention silently corrupts attention.

## Before / after on Qwen3-1.7B-Q8_0

```
$ kllama -m Qwen3-1.7B-Q8_0.gguf -k 0.0 "The capital of France is"
```

**Before:**
```
The capital of France is the city of of the the country of of the the country of of the the country of of the the country of of the the country of of
```

**After:**
```
The capital of France is Paris, and the capital of the United States is Washington, D.C. The capital of the United Kingdom is London. The capital of the United States of America
```

Llama 3.2 1B output is unchanged ("Paris. The Eiffel Tower is located in Paris..."), confirming the architecture-keyed default preserves existing behavior.

## Diagnostic ruling-out (these were already correctly wired and not the bug)

- `tokenizer.ggml.token_type` reads (already in #73's `8dad771`).
- `attn_q_norm` / `attn_k_norm` tensors load and `applyPerHeadRMSNorm` runs per-head before RoPE (`hasQKNorm=true` confirmed at runtime for Qwen3 via diagnostic print, then removed).
- `qwen3.rope.freq_base = 1_000_000` reads correctly (vs Llama's 500K).
- `qwen3.attention.layer_norm_rms_epsilon = 1e-6` reads correctly.
- `head_dim = 128` matches `hidden / q_heads = 2048/16 = 128` for Qwen3-1.7B (no shape mismatch).

The single remaining bug was the RoPE convention.

## Implementation

- New `RopeType` enum in `llm-core` with `INTERLEAVED` (default) and `HALF_SPLIT` variants. Companion `forArchitecture(arch)` mirrors llama.cpp's `llm_arch_rope_type()` mapping for all architectures we load through `LlamaWeightLoader`'s accepted set, plus a few common HALF_SPLIT families (Phi, Falcon, MPT, StableLM, Starcoder2) that will route through the same path when added later.
- `applyRopeRotation` takes a `ropeType` parameter (default `INTERLEAVED` for backwards compat — every existing Llama / Gemma / Mistral caller retains its current rotation). The pair indexing is selected by a single `when`; precomputed-table handling, frequency computation, and looping are shared.
- `CpuAttentionBackend` takes an optional `ropeType` constructor parameter that defaults to `RopeType.forArchitecture(weights.metadata.architecture)`. Existing callers in `Main.kt` (both Llama and Qwen paths) get the right convention automatically — no construction-site changes required.

## Tests (`llm-core` `RopeUtilsTest`, 5 cases)

- `interleavedRotationMatchesAdjacentPairFormula` — pins existing behavior against a hand-computed reference.
- `halfSplitRotationPairsFirstHalfWithSecondHalf` — pins NEOX behavior against a hand-computed reference.
- `halfSplitDoesNotEqualInterleavedForSameInput` — regression guard ensuring the two conventions are observably distinct (so a future wiring mistake fails loudly).
- `defaultRopeTypeIsInterleavedForBackwardsCompat` — guards every existing caller from a default-flip.
- `halfSplitMultipleHeadsAreIndependent` — confirms the half-split partitioning is within-head, not cross-head.

All `:llm-core:jvmTest` and `:llm-runtime:kllama:jvmTest` pass.

## Out of scope

- `GpuAttentionBackend` likely needs the same plumbing if anyone runs Qwen3 through the GPU path; not addressed here because the GPU backend isn't on the kllama `--demo` flow this fix targets.
- Qwen3 chat-template / tool-calling validation — runtime now produces coherent text, but chat mode also requires the special-token tokenizer fix from #73 (currently on `feature/gemma4`, not yet on `develop`). Once both land on `develop` the full Qwen3 tool-calling path will work end-to-end.

## Test plan

- [x] `./gradlew :llm-core:jvmTest` — all RoPE tests green (5 new).
- [x] `./gradlew :llm-runtime:kllama:jvmTest` — no regressions on existing Llama runtime tests.
- [x] Manual end-to-end: `kllama -m Qwen3-1.7B-Q8_0.gguf -s 32 -k 0.0 "The capital of France is"` produces coherent text.
- [x] Manual regression: `kllama -m Llama-3.2-1B-Instruct-Q8_0.gguf -s 32 -k 0.0 "The capital of France is"` unchanged.
- [ ] Reviewer to sanity-check the architecture mapping in `RopeType.forArchitecture` against llama.cpp's `llm_arch_rope_type()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
