### PR TITLE
feat(llm-api): provider-neutral ChatModel/EmbeddingModel SPI

### DIFF
--- a/ISSUE-skainet-spring-ai-adapter.md
+++ b/ISSUE-skainet-spring-ai-adapter.md
@@ -1,0 +1,178 @@
+# Spring AI adapter for SKaiNET-transformers (separate companion repo)
+
+**Repository (target):** `SKaiNET-developers/SKaiNET-spring-ai` (new, to be created)
+**Depends on:** `SKaiNET-developers/SKaiNET-transformers` — modules `llm-api`, `llm-providers`
+**Labels:** enhancement, integration, spring
+**Milestone:** —
+
+---
+
+## Summary
+
+Build a thin Spring AI adapter + Spring Boot starter that exposes the existing
+`sk.ainet.llm.api.ChatModel` / `EmbeddingModel` SPI through Spring AI's
+`org.springframework.ai.chat.model.ChatModel` and
+`org.springframework.ai.embedding.EmbeddingModel`. The adapter lives in a
+**separate repository** so the SKaiNET core stays Kotlin Multiplatform and free
+of Spring transitives.
+
+This is the planned follow-up to the neutral SPI work that landed on
+`feature/llm-api-neutral-spi` (modules `llm-api` and `llm-providers`).
+
+## Motivation
+
+- Spring AI's `ChatModel`/`EmbeddingModel` is the most familiar provider-SPI on the
+  JVM today. Many users will reach for `spring-ai-starter-model-*` first.
+- We **do not** want Spring as a dependency in the SKaiNET core. The neutral SPI
+  in `llm-api` already mirrors Spring AI's shape; the adapter is a translation layer
+  of a few hundred lines.
+- A separate repo keeps Spring's release cadence (1.1.x ↔ 2.0.x) decoupled from
+  SKaiNET-transformers' release cadence.
+
+## What's already done (in this repo)
+
+On branch `feature/llm-api-neutral-spi`:
+
+- `llm-api/` — KMP module with `ChatModel`, `StreamingChatModel`, `EmbeddingModel`,
+  `ChatRequest`/`Response`/`Chunk`, `ChatOptions`, `EmbeddingRequest`/`Response`,
+  `Message`/`Role`, `ToolDefinition`/`ToolCall`, `Usage`, `FinishReason`. Kotlin
+  `Flow` for streaming. Deps: `kotlin-stdlib` + `kotlinx-coroutines` only.
+- `llm-providers/` — JVM module with `SkaiNetChatModel<T>` (wraps any
+  `InferenceRuntime<T>` + `Tokenizer` + `ChatTemplate`) and `SkaiNetEmbeddingModel<T>`
+  (wraps `BertRuntime<T>`).
+- BOM updated; binary-compat baseline (`api/`) generated; basic unit tests for
+  mappers and stop-sequence helper.
+
+## Scope (this issue)
+
+A new repository `SKaiNET-spring-ai` with two artifacts.
+
+### 1. `spring-ai-skainet` — adapter library
+
+```
+sk.ainet.llm.spring/
+  SpringSkaiNetChatModel    implements org.springframework.ai.chat.model.ChatModel
+                                       , org.springframework.ai.chat.model.StreamingChatModel
+  SpringSkaiNetEmbeddingModel implements org.springframework.ai.embedding.EmbeddingModel
+  PromptMapper              Spring AI Prompt/Message  ↔ sk.ainet.llm.api.ChatRequest/Message
+  OptionsMapper             Spring AI ChatOptions     ↔ sk.ainet.llm.api.ChatOptions
+  StreamingBridge           kotlinx.coroutines.flow.Flow → reactor.core.publisher.Flux
+                            (via kotlinx-coroutines-reactor `asFlux`)
+```
+
+Translation rules:
+- Spring `Prompt.getInstructions()` → neutral `List<Message>`. Map roles 1:1.
+- Spring `ChatOptions` → neutral `ChatOptions`. `temperature`, `topK`, `topP`,
+  `maxTokens`, `stopSequences`, `seed`, `model` map directly. Spring-only knobs
+  (`frequencyPenalty`, `presencePenalty`) are dropped with a debug log
+  (the underlying SKaiNET runtime does not honor them today).
+- `ChatResponse` ← neutral `ChatResponse`. Wrap each neutral `Generation` in a
+  Spring `org.springframework.ai.chat.model.Generation`. Carry `Usage` into
+  `ChatResponseMetadata`.
+- Streaming: `stream(Prompt)` returns `Flux<ChatResponse>`. Each upstream
+  `ChatResponseChunk` becomes a `ChatResponse` whose single `Generation` carries the
+  delta as content. Final chunk includes finishReason + final usage.
+
+### 2. `spring-ai-starter-model-skainet` — Spring Boot starter
+
+```
+sk.ainet.llm.spring.boot/
+  SkaiNetAutoConfiguration
+    @AutoConfiguration
+    @ConditionalOnClass(SpringSkaiNetChatModel.class)
+    @EnableConfigurationProperties(SkaiNetProperties.class)
+    @ConditionalOnProperty(prefix = "spring.ai.skainet",
+                           name = "enabled", havingValue = "true",
+                           matchIfMissing = true)
+  SkaiNetProperties  prefix = "spring.ai.skainet"
+  resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+```
+
+Properties:
+
+```yaml
+spring.ai.skainet:
+  enabled: true
+  chat:
+    model-path: /models/qwen3-0.6b.gguf       # required if chat enabled
+    model-format: gguf                        # gguf | safetensors
+    chat-template: auto                       # auto | qwen | gemma | llama3 | chatml
+    options:
+      temperature: 0.7
+      max-tokens: 512
+      top-k: 40                               # accepted, ignored at runtime today
+      top-p: 0.95                             # accepted, ignored at runtime today
+      stop-sequences: ["</s>"]
+  embedding:
+    model-path: /models/bge-small-en          # required if embedding enabled
+    options:
+      model: bge-small-en
+```
+
+Conditional bean wiring:
+- `@Bean @ConditionalOnMissingBean ChatModel skaiNetChatModel(...)` —
+  builds an `OptimizedLLMRuntime` from the configured GGUF path, picks the
+  `ChatTemplate` via `ModelRegistry.detect(...)` (or the explicit override),
+  wraps in `SkaiNetChatModel`, then in `SpringSkaiNetChatModel`.
+- `@Bean @ConditionalOnMissingBean EmbeddingModel skaiNetEmbeddingModel(...)` —
+  same pattern with `BertRuntime` (or its eventual `OptimizedLLMRuntime`-based
+  replacement) + `SkaiNetEmbeddingModel`.
+
+## Open dependencies / blockers
+
+The SPI is callable today, but to make the **starter** usable we need a
+"one-call model loader" inside SKaiNET. Two options:
+
+1. Add a `ModelLoader.fromGguf(path): InferenceRuntime<*>` (or similar) inside
+   `llm-providers` and call it from the starter. Cleanest.
+2. Have the starter replicate the wiring from
+   `llm-apps/skainet-cli/Main.kt` (Arena, ExecutionContext, weight loader,
+   tokenizer). Works, but bigger surface to maintain.
+
+Recommend option (1) as a small follow-up PR in this repo before standing up
+the Spring repo. Track separately if needed.
+
+## Acceptance Criteria
+
+- [ ] `SKaiNET-spring-ai` repo exists with `spring-ai-skainet` and
+      `spring-ai-starter-model-skainet` modules and CI green on JDK 17 + 21.
+- [ ] Sample Spring Boot app: 30 lines of YAML + a `@RestController` injecting
+      `org.springframework.ai.chat.client.ChatClient` returns a non-empty
+      response for a Qwen3-0.6B GGUF.
+- [ ] `ChatClient` streaming endpoint (`text/event-stream`) emits tokens
+      progressively, not in one chunk.
+- [ ] `EmbeddingModel.embed("hello").size == dimensions` for a small
+      sentence-transformers model.
+- [ ] Spring AI 1.1.x compatibility documented; build sets `spring-ai-bom` as
+      the dependency-version pin.
+- [ ] No Spring or Reactor classes appear anywhere in SKaiNET-transformers' core
+      modules.
+
+## Reproduction / Test Plan
+
+Once the companion repo is up:
+
+1. Publish SKaiNET-transformers `llm-api` + `llm-providers` artifacts (snapshot
+   to mavenLocal is fine for first iteration).
+2. In the new repo, depend on those + `org.springframework.ai:spring-ai-bom:1.1.x`.
+3. Run the sample Boot app against `Qwen3-0.6B-Q8_0.gguf`:
+   - `POST /chat` with body `"Hello, who are you?"` → 200, non-empty body
+   - `GET /chat/stream?q=hello` → `text/event-stream`, multiple chunks
+4. Run the embedding sample against a `bge-small-en` checkpoint and check that
+   two semantically similar sentences yield cosine similarity > 0.7.
+
+## Reference
+
+- Spring AI Ollama starter
+  (`org.springframework.ai:spring-ai-starter-model-ollama`) is the closest
+  structural analog for the autoconfig + properties layout.
+- Streaming bridge: `kotlinx.coroutines.reactor.asFlux` (artifact
+  `org.jetbrains.kotlinx:kotlinx-coroutines-reactor`).
+- Memory note in this repo:
+  `feedback_neutral_spi_over_framework_coupling.md` — keep Spring out of core.
+
+## Related
+
+- Plan file (this repo, this branch): `.claude/plans/spring-ai-s-own-docs-partitioned-toucan.md`
+- Modules: `llm-api/`, `llm-providers/`
+- BOM: `llm-bom/build.gradle.kts` already exposes both new modules.

--- a/llm-api/api/jvm/llm-api.api
+++ b/llm-api/api/jvm/llm-api.api
@@ -1,0 +1,280 @@
+public abstract interface class sk/ainet/llm/api/ChatModel : java/lang/AutoCloseable {
+	public abstract fun call (Lsk/ainet/llm/api/ChatRequest;)Lsk/ainet/llm/api/ChatResponse;
+	public fun close ()V
+	public abstract fun getDefaultOptions ()Lsk/ainet/llm/api/ChatOptions;
+}
+
+public final class sk/ainet/llm/api/ChatModel$DefaultImpls {
+	public static fun close (Lsk/ainet/llm/api/ChatModel;)V
+}
+
+public final class sk/ainet/llm/api/ChatOptions {
+	public static final field Companion Lsk/ainet/llm/api/ChatOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Long;)Lsk/ainet/llm/api/ChatOptions;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/ChatOptions;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Long;ILjava/lang/Object;)Lsk/ainet/llm/api/ChatOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxTokens ()Ljava/lang/Integer;
+	public final fun getModel ()Ljava/lang/String;
+	public final fun getSeed ()Ljava/lang/Long;
+	public final fun getStopSequences ()Ljava/util/List;
+	public final fun getTemperature ()Ljava/lang/Float;
+	public final fun getTopK ()Ljava/lang/Integer;
+	public final fun getTopP ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/ChatOptions$Companion {
+	public final fun getDEFAULTS ()Lsk/ainet/llm/api/ChatOptions;
+}
+
+public final class sk/ainet/llm/api/ChatRequest {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lsk/ainet/llm/api/ChatOptions;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;Ljava/util/List;)Lsk/ainet/llm/api/ChatRequest;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/ChatRequest;Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;Ljava/util/List;ILjava/lang/Object;)Lsk/ainet/llm/api/ChatRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessages ()Ljava/util/List;
+	public final fun getOptions ()Lsk/ainet/llm/api/ChatOptions;
+	public final fun getTools ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/ChatResponse {
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lsk/ainet/llm/api/Usage;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;)Lsk/ainet/llm/api/ChatResponse;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/ChatResponse;Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/ChatResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGenerations ()Ljava/util/List;
+	public final fun getModelId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUsage ()Lsk/ainet/llm/api/Usage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/ChatResponseChunk {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;Lsk/ainet/llm/api/Usage;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;Lsk/ainet/llm/api/Usage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lsk/ainet/llm/api/FinishReason;
+	public final fun component4 ()Lsk/ainet/llm/api/Usage;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;Lsk/ainet/llm/api/Usage;)Lsk/ainet/llm/api/ChatResponseChunk;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/ChatResponseChunk;Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;Lsk/ainet/llm/api/Usage;ILjava/lang/Object;)Lsk/ainet/llm/api/ChatResponseChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDelta ()Ljava/lang/String;
+	public final fun getFinishReason ()Lsk/ainet/llm/api/FinishReason;
+	public final fun getToolCallDelta ()Ljava/util/List;
+	public final fun getUsage ()Lsk/ainet/llm/api/Usage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/Embedding {
+	public fun <init> (I[F)V
+	public final fun component1 ()I
+	public final fun component2 ()[F
+	public final fun copy (I[F)Lsk/ainet/llm/api/Embedding;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/Embedding;I[FILjava/lang/Object;)Lsk/ainet/llm/api/Embedding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getVector ()[F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class sk/ainet/llm/api/EmbeddingModel : java/lang/AutoCloseable {
+	public abstract fun call (Lsk/ainet/llm/api/EmbeddingRequest;)Lsk/ainet/llm/api/EmbeddingResponse;
+	public fun close ()V
+	public fun embed (Ljava/lang/String;)[F
+	public fun embed (Ljava/util/List;)Ljava/util/List;
+	public abstract fun getDimensions ()I
+}
+
+public final class sk/ainet/llm/api/EmbeddingModel$DefaultImpls {
+	public static fun close (Lsk/ainet/llm/api/EmbeddingModel;)V
+	public static fun embed (Lsk/ainet/llm/api/EmbeddingModel;Ljava/lang/String;)[F
+	public static fun embed (Lsk/ainet/llm/api/EmbeddingModel;Ljava/util/List;)Ljava/util/List;
+}
+
+public final class sk/ainet/llm/api/EmbeddingOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Lsk/ainet/llm/api/EmbeddingOptions;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/EmbeddingOptions;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/llm/api/EmbeddingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDimensions ()Ljava/lang/Integer;
+	public final fun getModel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/EmbeddingRequest {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/EmbeddingOptions;)V
+	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/EmbeddingOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lsk/ainet/llm/api/EmbeddingOptions;
+	public final fun copy (Ljava/util/List;Lsk/ainet/llm/api/EmbeddingOptions;)Lsk/ainet/llm/api/EmbeddingRequest;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/EmbeddingRequest;Ljava/util/List;Lsk/ainet/llm/api/EmbeddingOptions;ILjava/lang/Object;)Lsk/ainet/llm/api/EmbeddingRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInputs ()Ljava/util/List;
+	public final fun getOptions ()Lsk/ainet/llm/api/EmbeddingOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/EmbeddingResponse {
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lsk/ainet/llm/api/Usage;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;)Lsk/ainet/llm/api/EmbeddingResponse;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/EmbeddingResponse;Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/EmbeddingResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmbeddings ()Ljava/util/List;
+	public final fun getModelId ()Ljava/lang/String;
+	public final fun getUsage ()Lsk/ainet/llm/api/Usage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/FinishReason : java/lang/Enum {
+	public static final field ERROR Lsk/ainet/llm/api/FinishReason;
+	public static final field LENGTH Lsk/ainet/llm/api/FinishReason;
+	public static final field STOP Lsk/ainet/llm/api/FinishReason;
+	public static final field TOOL_CALL Lsk/ainet/llm/api/FinishReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lsk/ainet/llm/api/FinishReason;
+	public static fun values ()[Lsk/ainet/llm/api/FinishReason;
+}
+
+public final class sk/ainet/llm/api/Generation {
+	public fun <init> (Lsk/ainet/llm/api/Message;Lsk/ainet/llm/api/FinishReason;)V
+	public final fun component1 ()Lsk/ainet/llm/api/Message;
+	public final fun component2 ()Lsk/ainet/llm/api/FinishReason;
+	public final fun copy (Lsk/ainet/llm/api/Message;Lsk/ainet/llm/api/FinishReason;)Lsk/ainet/llm/api/Generation;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/Generation;Lsk/ainet/llm/api/Message;Lsk/ainet/llm/api/FinishReason;ILjava/lang/Object;)Lsk/ainet/llm/api/Generation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFinishReason ()Lsk/ainet/llm/api/FinishReason;
+	public final fun getMessage ()Lsk/ainet/llm/api/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/Message {
+	public static final field Companion Lsk/ainet/llm/api/Message$Companion;
+	public fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lsk/ainet/llm/api/Role;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/Message;Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/Message;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRole ()Lsk/ainet/llm/api/Role;
+	public final fun getToolCallId ()Ljava/lang/String;
+	public final fun getToolCalls ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/Message$Companion {
+	public final fun assistant (Ljava/lang/String;Ljava/util/List;)Lsk/ainet/llm/api/Message;
+	public static synthetic fun assistant$default (Lsk/ainet/llm/api/Message$Companion;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lsk/ainet/llm/api/Message;
+	public final fun system (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public final fun tool (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public static synthetic fun tool$default (Lsk/ainet/llm/api/Message$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/Message;
+	public final fun user (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+}
+
+public final class sk/ainet/llm/api/Role : java/lang/Enum {
+	public static final field ASSISTANT Lsk/ainet/llm/api/Role;
+	public static final field SYSTEM Lsk/ainet/llm/api/Role;
+	public static final field TOOL Lsk/ainet/llm/api/Role;
+	public static final field USER Lsk/ainet/llm/api/Role;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lsk/ainet/llm/api/Role;
+	public static fun values ()[Lsk/ainet/llm/api/Role;
+}
+
+public abstract interface class sk/ainet/llm/api/StreamingChatModel : sk/ainet/llm/api/ChatModel {
+	public abstract fun stream (Lsk/ainet/llm/api/ChatRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class sk/ainet/llm/api/StreamingChatModel$DefaultImpls {
+	public static fun close (Lsk/ainet/llm/api/StreamingChatModel;)V
+}
+
+public final class sk/ainet/llm/api/ToolCall {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/ToolCall;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/ToolCall;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/ToolCall;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgumentsJson ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/ToolDefinition {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/ToolDefinition;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/ToolDefinition;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/ToolDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParametersJsonSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/llm/api/Usage {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lsk/ainet/llm/api/Usage;
+	public static synthetic fun copy$default (Lsk/ainet/llm/api/Usage;IIILjava/lang/Object;)Lsk/ainet/llm/api/Usage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompletionTokens ()I
+	public final fun getPromptTokens ()I
+	public final fun getTotalTokens ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/llm-api/api/jvm/llm-api.api
+++ b/llm-api/api/jvm/llm-api.api
@@ -4,13 +4,16 @@ public abstract interface class sk/ainet/llm/api/ChatModel : java/lang/AutoClose
 	public abstract fun getDefaultOptions ()Lsk/ainet/llm/api/ChatOptions;
 }
 
-public final class sk/ainet/llm/api/ChatModel$DefaultImpls {
-	public static fun close (Lsk/ainet/llm/api/ChatModel;)V
-}
-
 public final class sk/ainet/llm/api/ChatOptions {
 	public static final field Companion Lsk/ainet/llm/api/ChatOptions$Companion;
+	public static final field DEFAULTS Lsk/ainet/llm/api/ChatOptions;
 	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Long;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -35,11 +38,12 @@ public final class sk/ainet/llm/api/ChatOptions {
 }
 
 public final class sk/ainet/llm/api/ChatOptions$Companion {
-	public final fun getDEFAULTS ()Lsk/ainet/llm/api/ChatOptions;
 }
 
 public final class sk/ainet/llm/api/ChatRequest {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;)V
 	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/ChatOptions;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
@@ -56,6 +60,8 @@ public final class sk/ainet/llm/api/ChatRequest {
 }
 
 public final class sk/ainet/llm/api/ChatResponse {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;)V
 	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
@@ -73,6 +79,9 @@ public final class sk/ainet/llm/api/ChatResponse {
 }
 
 public final class sk/ainet/llm/api/ChatResponseChunk {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;Lsk/ainet/llm/api/Usage;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lsk/ainet/llm/api/FinishReason;Lsk/ainet/llm/api/Usage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -111,14 +120,9 @@ public abstract interface class sk/ainet/llm/api/EmbeddingModel : java/lang/Auto
 	public abstract fun getDimensions ()I
 }
 
-public final class sk/ainet/llm/api/EmbeddingModel$DefaultImpls {
-	public static fun close (Lsk/ainet/llm/api/EmbeddingModel;)V
-	public static fun embed (Lsk/ainet/llm/api/EmbeddingModel;Ljava/lang/String;)[F
-	public static fun embed (Lsk/ainet/llm/api/EmbeddingModel;Ljava/util/List;)Ljava/util/List;
-}
-
 public final class sk/ainet/llm/api/EmbeddingOptions {
 	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -134,6 +138,7 @@ public final class sk/ainet/llm/api/EmbeddingOptions {
 
 public final class sk/ainet/llm/api/EmbeddingRequest {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/EmbeddingOptions;)V
 	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/EmbeddingOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
@@ -148,6 +153,8 @@ public final class sk/ainet/llm/api/EmbeddingRequest {
 }
 
 public final class sk/ainet/llm/api/EmbeddingResponse {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;)V
 	public fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/util/List;Lsk/ainet/llm/api/Usage;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
@@ -188,8 +195,13 @@ public final class sk/ainet/llm/api/Generation {
 
 public final class sk/ainet/llm/api/Message {
 	public static final field Companion Lsk/ainet/llm/api/Message$Companion;
+	public fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;)V
+	public fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
 	public fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lsk/ainet/llm/api/Role;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun assistant (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public static final fun assistant (Ljava/lang/String;Ljava/util/List;)Lsk/ainet/llm/api/Message;
 	public final fun component1 ()Lsk/ainet/llm/api/Role;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
@@ -204,13 +216,19 @@ public final class sk/ainet/llm/api/Message {
 	public final fun getToolCallId ()Ljava/lang/String;
 	public final fun getToolCalls ()Ljava/util/List;
 	public fun hashCode ()I
+	public static final fun system (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
 	public fun toString ()Ljava/lang/String;
+	public static final fun tool (Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public static final fun tool (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public static final fun user (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
 }
 
 public final class sk/ainet/llm/api/Message$Companion {
+	public final fun assistant (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
 	public final fun assistant (Ljava/lang/String;Ljava/util/List;)Lsk/ainet/llm/api/Message;
 	public static synthetic fun assistant$default (Lsk/ainet/llm/api/Message$Companion;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lsk/ainet/llm/api/Message;
 	public final fun system (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
+	public final fun tool (Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/Message;
 	public final fun tool (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/llm/api/Message;
 	public static synthetic fun tool$default (Lsk/ainet/llm/api/Message$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/llm/api/Message;
 	public final fun user (Ljava/lang/String;)Lsk/ainet/llm/api/Message;
@@ -228,10 +246,6 @@ public final class sk/ainet/llm/api/Role : java/lang/Enum {
 
 public abstract interface class sk/ainet/llm/api/StreamingChatModel : sk/ainet/llm/api/ChatModel {
 	public abstract fun stream (Lsk/ainet/llm/api/ChatRequest;)Lkotlinx/coroutines/flow/Flow;
-}
-
-public final class sk/ainet/llm/api/StreamingChatModel$DefaultImpls {
-	public static fun close (Lsk/ainet/llm/api/StreamingChatModel;)V
 }
 
 public final class sk/ainet/llm/api/ToolCall {

--- a/llm-api/build.gradle.kts
+++ b/llm-api/build.gradle.kts
@@ -25,7 +25,14 @@ kotlin {
     linuxArm64()
     macosArm64()
 
-    jvm()
+    jvm {
+        compilerOptions {
+            // Generate real Java default methods for interface defaults instead of $DefaultImpls
+            // so Java consumers can implement ChatModel / EmbeddingModel without overriding
+            // close() or the embed() overloads.
+            freeCompilerArgs.add("-Xjvm-default=all")
+        }
+    }
 
     js {
         browser()

--- a/llm-api/build.gradle.kts
+++ b/llm-api/build.gradle.kts
@@ -1,0 +1,55 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidMultiplatformLibrary)
+    alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.kover)
+    alias(libs.plugins.binary.compatibility.validator)
+}
+
+kotlin {
+    android {
+        namespace = "sk.ainet.llm.api"
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+
+    iosArm64()
+    iosSimulatorArm64()
+    linuxX64()
+    linuxArm64()
+    macosArm64()
+
+    jvm()
+
+    js {
+        browser()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(kotlin("stdlib-common"))
+            api(libs.kotlinx.coroutines)
+        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}

--- a/llm-api/gradle.properties
+++ b/llm-api/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=skainet-transformers-api
+POM_NAME=Provider-neutral ChatModel and EmbeddingModel SPI
+
+kotlin.mpp.applyDefaultHierarchyTemplate=false

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatModel.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatModel.kt
@@ -1,0 +1,38 @@
+package sk.ainet.llm.api
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Provider-neutral chat completion SPI.
+ *
+ * Mirrors the shape of Spring AI's `ChatModel` so the design is familiar to JVM
+ * developers, but has zero Spring or Reactor dependencies — only `kotlin-stdlib`
+ * and `kotlinx-coroutines`. Framework adapters (Spring AI, LangChain4j, ...) live
+ * in companion repositories and translate to this interface at the seam.
+ *
+ * Implementations are typically **not** thread-safe — they hold mutable
+ * KV-cache state across forward passes. Callers requiring concurrent invocation
+ * should use a pool decorator.
+ */
+public interface ChatModel : AutoCloseable {
+
+    /** Synchronous chat completion. */
+    public fun call(request: ChatRequest): ChatResponse
+
+    /** Default options used when [ChatRequest.options] is `null`. */
+    public val defaultOptions: ChatOptions
+
+    /** Free any native or runtime resources. Default no-op. */
+    override fun close(): Unit = Unit
+}
+
+/**
+ * Token-by-token streaming variant.
+ *
+ * Implementations emit a [ChatResponseChunk] per generated token (or per fixed
+ * batch of tokens). The terminal chunk carries [ChatResponseChunk.finishReason]
+ * and final [ChatResponseChunk.usage]. Cancellation of the [Flow] aborts generation.
+ */
+public interface StreamingChatModel : ChatModel {
+    public fun stream(request: ChatRequest): Flow<ChatResponseChunk>
+}

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatOptions.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatOptions.kt
@@ -1,0 +1,32 @@
+package sk.ainet.llm.api
+
+/**
+ * Per-request knobs for chat generation.
+ *
+ * Mirrors the knob set used by Spring AI / OpenAI / Ollama so the design is familiar.
+ * `null` means "use the model's default". Concrete adapters MAY ignore knobs they
+ * don't support (and should log a one-time warning when they do).
+ */
+public data class ChatOptions(
+    public val model: String? = null,
+    public val temperature: Float? = null,
+    public val topK: Int? = null,
+    public val topP: Float? = null,
+    public val maxTokens: Int? = null,
+    public val stopSequences: List<String> = emptyList(),
+    public val seed: Long? = null,
+) {
+    public companion object {
+        public val DEFAULTS: ChatOptions = ChatOptions(
+            temperature = 0.7f,
+            maxTokens = 512,
+        )
+    }
+}
+
+/** Per-request knobs for embedding generation. */
+public data class EmbeddingOptions(
+    public val model: String? = null,
+    /** Request a specific output dimensionality (only honored if the model supports projection). */
+    public val dimensions: Int? = null,
+)

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatOptions.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatOptions.kt
@@ -1,5 +1,8 @@
 package sk.ainet.llm.api
 
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
+
 /**
  * Per-request knobs for chat generation.
  *
@@ -7,7 +10,7 @@ package sk.ainet.llm.api
  * `null` means "use the model's default". Concrete adapters MAY ignore knobs they
  * don't support (and should log a one-time warning when they do).
  */
-public data class ChatOptions(
+public data class ChatOptions @JvmOverloads constructor(
     public val model: String? = null,
     public val temperature: Float? = null,
     public val topK: Int? = null,
@@ -17,6 +20,7 @@ public data class ChatOptions(
     public val seed: Long? = null,
 ) {
     public companion object {
+        @JvmField
         public val DEFAULTS: ChatOptions = ChatOptions(
             temperature = 0.7f,
             maxTokens = 512,
@@ -25,7 +29,7 @@ public data class ChatOptions(
 }
 
 /** Per-request knobs for embedding generation. */
-public data class EmbeddingOptions(
+public data class EmbeddingOptions @JvmOverloads constructor(
     public val model: String? = null,
     /** Request a specific output dimensionality (only honored if the model supports projection). */
     public val dimensions: Int? = null,

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatRequest.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatRequest.kt
@@ -1,5 +1,7 @@
 package sk.ainet.llm.api
 
+import kotlin.jvm.JvmOverloads
+
 /**
  * A chat completion request.
  *
@@ -7,7 +9,7 @@ package sk.ainet.llm.api
  * @param options Per-request overrides; `null` means fall back to the model's [ChatModel.defaultOptions].
  * @param tools Tools the model may call (empty if tool calling is not in use).
  */
-public data class ChatRequest(
+public data class ChatRequest @JvmOverloads constructor(
     public val messages: List<Message>,
     public val options: ChatOptions? = null,
     public val tools: List<ToolDefinition> = emptyList(),

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatRequest.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatRequest.kt
@@ -1,0 +1,16 @@
+package sk.ainet.llm.api
+
+/**
+ * A chat completion request.
+ *
+ * @param messages Conversation history; the model continues from the last message.
+ * @param options Per-request overrides; `null` means fall back to the model's [ChatModel.defaultOptions].
+ * @param tools Tools the model may call (empty if tool calling is not in use).
+ */
+public data class ChatRequest(
+    public val messages: List<Message>,
+    public val options: ChatOptions? = null,
+    public val tools: List<ToolDefinition> = emptyList(),
+) {
+    public constructor(prompt: String) : this(listOf(Message.user(prompt)))
+}

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatResponse.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatResponse.kt
@@ -1,5 +1,7 @@
 package sk.ainet.llm.api
 
+import kotlin.jvm.JvmOverloads
+
 /** A single completion candidate. */
 public data class Generation(
     public val message: Message,
@@ -7,7 +9,7 @@ public data class Generation(
 )
 
 /** Synchronous chat response. */
-public data class ChatResponse(
+public data class ChatResponse @JvmOverloads constructor(
     public val generations: List<Generation>,
     public val usage: Usage? = null,
     public val modelId: String? = null,
@@ -23,7 +25,7 @@ public data class ChatResponse(
  * @param toolCallDelta New tool call(s) detected in this chunk (typically only on the final chunk).
  * @param finishReason Set on the terminal chunk only.
  */
-public data class ChatResponseChunk(
+public data class ChatResponseChunk @JvmOverloads constructor(
     public val delta: String,
     public val toolCallDelta: List<ToolCall> = emptyList(),
     public val finishReason: FinishReason? = null,

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatResponse.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ChatResponse.kt
@@ -1,0 +1,31 @@
+package sk.ainet.llm.api
+
+/** A single completion candidate. */
+public data class Generation(
+    public val message: Message,
+    public val finishReason: FinishReason,
+)
+
+/** Synchronous chat response. */
+public data class ChatResponse(
+    public val generations: List<Generation>,
+    public val usage: Usage? = null,
+    public val modelId: String? = null,
+) {
+    /** Convenience: text content of the first generation, or empty string if there is none. */
+    public val text: String get() = generations.firstOrNull()?.message?.content.orEmpty()
+}
+
+/**
+ * One streaming increment.
+ *
+ * @param delta Newly generated text since the last chunk (may be empty for non-text chunks).
+ * @param toolCallDelta New tool call(s) detected in this chunk (typically only on the final chunk).
+ * @param finishReason Set on the terminal chunk only.
+ */
+public data class ChatResponseChunk(
+    public val delta: String,
+    public val toolCallDelta: List<ToolCall> = emptyList(),
+    public val finishReason: FinishReason? = null,
+    public val usage: Usage? = null,
+)

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/EmbeddingModel.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/EmbeddingModel.kt
@@ -1,0 +1,25 @@
+package sk.ainet.llm.api
+
+/**
+ * Provider-neutral text-embedding SPI.
+ *
+ * Mirrors Spring AI's `EmbeddingModel` shape; no Spring deps.
+ */
+public interface EmbeddingModel : AutoCloseable {
+
+    /** Batch embedding. The result list is the same length and order as [EmbeddingRequest.inputs]. */
+    public fun call(request: EmbeddingRequest): EmbeddingResponse
+
+    /** Convenience: embed a single string and return its raw vector. */
+    public fun embed(text: String): FloatArray =
+        call(EmbeddingRequest(text)).embeddings.first().vector
+
+    /** Convenience: embed many strings, return raw vectors in input order. */
+    public fun embed(texts: List<String>): List<FloatArray> =
+        call(EmbeddingRequest(texts)).embeddings.sortedBy { it.index }.map { it.vector }
+
+    /** Output vector dimensionality. */
+    public val dimensions: Int
+
+    override fun close(): Unit = Unit
+}

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/EmbeddingRequest.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/EmbeddingRequest.kt
@@ -1,0 +1,30 @@
+package sk.ainet.llm.api
+
+/** Embedding generation request — one or more input strings. */
+public data class EmbeddingRequest(
+    public val inputs: List<String>,
+    public val options: EmbeddingOptions? = null,
+) {
+    public constructor(input: String) : this(listOf(input))
+}
+
+/** A single embedding result. */
+public data class Embedding(
+    public val index: Int,
+    public val vector: FloatArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Embedding) return false
+        return index == other.index && vector.contentEquals(other.vector)
+    }
+
+    override fun hashCode(): Int = 31 * index + vector.contentHashCode()
+}
+
+/** Embedding generation response. */
+public data class EmbeddingResponse(
+    public val embeddings: List<Embedding>,
+    public val usage: Usage? = null,
+    public val modelId: String? = null,
+)

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/EmbeddingRequest.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/EmbeddingRequest.kt
@@ -1,7 +1,9 @@
 package sk.ainet.llm.api
 
+import kotlin.jvm.JvmOverloads
+
 /** Embedding generation request — one or more input strings. */
-public data class EmbeddingRequest(
+public data class EmbeddingRequest @JvmOverloads constructor(
     public val inputs: List<String>,
     public val options: EmbeddingOptions? = null,
 ) {
@@ -23,7 +25,7 @@ public data class Embedding(
 }
 
 /** Embedding generation response. */
-public data class EmbeddingResponse(
+public data class EmbeddingResponse @JvmOverloads constructor(
     public val embeddings: List<Embedding>,
     public val usage: Usage? = null,
     public val modelId: String? = null,

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/FinishReason.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/FinishReason.kt
@@ -1,0 +1,13 @@
+package sk.ainet.llm.api
+
+/** Why generation stopped. */
+public enum class FinishReason {
+    /** EOS token reached or stop sequence matched. */
+    STOP,
+    /** Hit `maxTokens` cap. */
+    LENGTH,
+    /** Assistant emitted a tool call and is awaiting a tool result. */
+    TOOL_CALL,
+    /** Generation aborted due to error. */
+    ERROR,
+}

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/Message.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/Message.kt
@@ -1,5 +1,8 @@
 package sk.ainet.llm.api
 
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+
 /** Role of a message in a chat conversation. */
 public enum class Role { SYSTEM, USER, ASSISTANT, TOOL }
 
@@ -12,7 +15,7 @@ public enum class Role { SYSTEM, USER, ASSISTANT, TOOL }
  * @param toolCallId If [role] is [Role.TOOL], the id of the originating tool call this message responds to.
  * @param name Optional speaker name (some templates use it for tool messages).
  */
-public data class Message(
+public data class Message @JvmOverloads constructor(
     public val role: Role,
     public val content: String,
     public val toolCalls: List<ToolCall> = emptyList(),
@@ -20,10 +23,19 @@ public data class Message(
     public val name: String? = null,
 ) {
     public companion object {
+        @JvmStatic
         public fun system(content: String): Message = Message(Role.SYSTEM, content)
+
+        @JvmStatic
         public fun user(content: String): Message = Message(Role.USER, content)
+
+        @JvmStatic
+        @JvmOverloads
         public fun assistant(content: String, toolCalls: List<ToolCall> = emptyList()): Message =
             Message(Role.ASSISTANT, content, toolCalls)
+
+        @JvmStatic
+        @JvmOverloads
         public fun tool(content: String, toolCallId: String, name: String? = null): Message =
             Message(Role.TOOL, content, toolCallId = toolCallId, name = name)
     }

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/Message.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/Message.kt
@@ -1,0 +1,30 @@
+package sk.ainet.llm.api
+
+/** Role of a message in a chat conversation. */
+public enum class Role { SYSTEM, USER, ASSISTANT, TOOL }
+
+/**
+ * A single message in a chat conversation.
+ *
+ * @param role Speaker role.
+ * @param content Text content. Empty string is allowed (e.g., assistant message that only contains tool calls).
+ * @param toolCalls Tool calls emitted by an assistant message (empty otherwise).
+ * @param toolCallId If [role] is [Role.TOOL], the id of the originating tool call this message responds to.
+ * @param name Optional speaker name (some templates use it for tool messages).
+ */
+public data class Message(
+    public val role: Role,
+    public val content: String,
+    public val toolCalls: List<ToolCall> = emptyList(),
+    public val toolCallId: String? = null,
+    public val name: String? = null,
+) {
+    public companion object {
+        public fun system(content: String): Message = Message(Role.SYSTEM, content)
+        public fun user(content: String): Message = Message(Role.USER, content)
+        public fun assistant(content: String, toolCalls: List<ToolCall> = emptyList()): Message =
+            Message(Role.ASSISTANT, content, toolCalls)
+        public fun tool(content: String, toolCallId: String, name: String? = null): Message =
+            Message(Role.TOOL, content, toolCallId = toolCallId, name = name)
+    }
+}

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ToolDefinition.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/ToolDefinition.kt
@@ -1,0 +1,23 @@
+package sk.ainet.llm.api
+
+/**
+ * Description of a tool the model may call.
+ *
+ * The [parametersJsonSchema] is a JSON Schema document (as a raw string) describing
+ * the tool's argument shape — kept as a plain string here so the neutral SPI does not
+ * pull in any JSON library. Adapters are free to construct it from `kotlinx.serialization`,
+ * Jackson, or any other source.
+ */
+public data class ToolDefinition(
+    public val name: String,
+    public val description: String,
+    public val parametersJsonSchema: String,
+)
+
+/** A tool call emitted by the model. */
+public data class ToolCall(
+    public val id: String,
+    public val name: String,
+    /** Raw JSON-encoded argument object as produced by the model. */
+    public val argumentsJson: String,
+)

--- a/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/Usage.kt
+++ b/llm-api/src/commonMain/kotlin/sk/ainet/llm/api/Usage.kt
@@ -1,0 +1,9 @@
+package sk.ainet.llm.api
+
+/** Token accounting for a single request. */
+public data class Usage(
+    public val promptTokens: Int,
+    public val completionTokens: Int,
+) {
+    public val totalTokens: Int get() = promptTokens + completionTokens
+}

--- a/llm-bom/build.gradle.kts
+++ b/llm-bom/build.gradle.kts
@@ -15,11 +15,17 @@ dependencies {
     api(platform("sk.ainet:skainet-bom:${libs.versions.skainet.get()}"))
 
     constraints {
+        // Public SPI (provider-neutral)
+        api(project(":llm-api"))
+
         // LLM core
         api(project(":llm-core"))
 
         // Agent
         api(project(":llm-agent"))
+
+        // Providers — concrete adapters from runtimes to llm-api
+        api(project(":llm-providers"))
 
         // Inference — model loaders
         api(project(":llm-inference:llama"))

--- a/llm-providers/api/llm-providers.api
+++ b/llm-providers/api/llm-providers.api
@@ -11,9 +11,6 @@ public final class sk/ainet/llm/providers/SkaiNetEmbeddingModel : sk/ainet/llm/a
 	public fun <init> (Lsk/ainet/models/bert/BertRuntime;Lsk/ainet/apps/llm/Tokenizer;ILjava/lang/String;)V
 	public synthetic fun <init> (Lsk/ainet/models/bert/BertRuntime;Lsk/ainet/apps/llm/Tokenizer;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun call (Lsk/ainet/llm/api/EmbeddingRequest;)Lsk/ainet/llm/api/EmbeddingResponse;
-	public fun close ()V
-	public fun embed (Ljava/lang/String;)[F
-	public fun embed (Ljava/util/List;)Ljava/util/List;
 	public fun getDimensions ()I
 }
 

--- a/llm-providers/api/llm-providers.api
+++ b/llm-providers/api/llm-providers.api
@@ -1,0 +1,19 @@
+public final class sk/ainet/llm/providers/SkaiNetChatModel : sk/ainet/llm/api/StreamingChatModel {
+	public fun <init> (Lsk/ainet/apps/llm/InferenceRuntime;Lsk/ainet/apps/llm/Tokenizer;Lsk/ainet/apps/kllama/chat/ChatTemplate;Lsk/ainet/llm/api/ChatOptions;IILkotlin/random/Random;Ljava/lang/String;)V
+	public synthetic fun <init> (Lsk/ainet/apps/llm/InferenceRuntime;Lsk/ainet/apps/llm/Tokenizer;Lsk/ainet/apps/kllama/chat/ChatTemplate;Lsk/ainet/llm/api/ChatOptions;IILkotlin/random/Random;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun call (Lsk/ainet/llm/api/ChatRequest;)Lsk/ainet/llm/api/ChatResponse;
+	public fun close ()V
+	public fun getDefaultOptions ()Lsk/ainet/llm/api/ChatOptions;
+	public fun stream (Lsk/ainet/llm/api/ChatRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class sk/ainet/llm/providers/SkaiNetEmbeddingModel : sk/ainet/llm/api/EmbeddingModel {
+	public fun <init> (Lsk/ainet/models/bert/BertRuntime;Lsk/ainet/apps/llm/Tokenizer;ILjava/lang/String;)V
+	public synthetic fun <init> (Lsk/ainet/models/bert/BertRuntime;Lsk/ainet/apps/llm/Tokenizer;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun call (Lsk/ainet/llm/api/EmbeddingRequest;)Lsk/ainet/llm/api/EmbeddingResponse;
+	public fun close ()V
+	public fun embed (Ljava/lang/String;)[F
+	public fun embed (Ljava/util/List;)Ljava/util/List;
+	public fun getDimensions ()I
+}
+

--- a/llm-providers/build.gradle.kts
+++ b/llm-providers/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     jvmToolchain(21)
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
+        freeCompilerArgs.add("-Xjvm-default=all")
     }
     explicitApi()
 }
@@ -31,6 +32,9 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
 }
+
+// Pick up Java sources alongside Kotlin in src/test
+sourceSets["test"].java.srcDir("src/test/java")
 
 tasks.test {
     useJUnitPlatform()

--- a/llm-providers/build.gradle.kts
+++ b/llm-providers/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.jetbrainsKotlinJvm)
+    alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.kover)
+    alias(libs.plugins.binary.compatibility.validator)
+    alias(libs.plugins.kotlinSerialization)
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
+    }
+    explicitApi()
+}
+
+dependencies {
+    api(project(":llm-api"))
+    api(project(":llm-core"))
+    api(project(":llm-agent"))
+    api(project(":llm-inference:bert"))
+
+    implementation(libs.skainet.lang.core)
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/llm-providers/gradle.properties
+++ b/llm-providers/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-transformers-providers
+POM_NAME=Concrete ChatModel and EmbeddingModel adapters wrapping SKaiNET runtimes

--- a/llm-providers/src/main/kotlin/sk/ainet/llm/providers/Mappers.kt
+++ b/llm-providers/src/main/kotlin/sk/ainet/llm/providers/Mappers.kt
@@ -1,0 +1,46 @@
+package sk.ainet.llm.providers
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import sk.ainet.llm.api.Message
+import sk.ainet.llm.api.Role
+import sk.ainet.llm.api.ToolCall as ApiToolCall
+import sk.ainet.llm.api.ToolDefinition as ApiToolDefinition
+import sk.ainet.apps.kllama.chat.ChatMessage
+import sk.ainet.apps.kllama.chat.ChatRole
+import sk.ainet.apps.kllama.chat.ToolCall as AgentToolCall
+import sk.ainet.apps.kllama.chat.ToolDefinition as AgentToolDefinition
+
+private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+internal fun Message.toAgent(): ChatMessage = ChatMessage(
+    role = role.toAgent(),
+    content = content,
+    toolCalls = toolCalls.takeIf { it.isNotEmpty() }?.map { it.toAgent() },
+    toolCallId = toolCallId,
+)
+
+internal fun Role.toAgent(): ChatRole = when (this) {
+    Role.SYSTEM -> ChatRole.SYSTEM
+    Role.USER -> ChatRole.USER
+    Role.ASSISTANT -> ChatRole.ASSISTANT
+    Role.TOOL -> ChatRole.TOOL
+}
+
+internal fun ApiToolDefinition.toAgent(): AgentToolDefinition = AgentToolDefinition(
+    name = name,
+    description = description,
+    parameters = json.parseToJsonElement(parametersJsonSchema) as JsonObject,
+)
+
+internal fun ApiToolCall.toAgent(): AgentToolCall = AgentToolCall(
+    id = id,
+    name = name,
+    arguments = json.parseToJsonElement(argumentsJson) as JsonObject,
+)
+
+internal fun AgentToolCall.toApi(): ApiToolCall = ApiToolCall(
+    id = id,
+    name = name,
+    argumentsJson = arguments.toString(),
+)

--- a/llm-providers/src/main/kotlin/sk/ainet/llm/providers/SkaiNetChatModel.kt
+++ b/llm-providers/src/main/kotlin/sk/ainet/llm/providers/SkaiNetChatModel.kt
@@ -1,0 +1,209 @@
+package sk.ainet.llm.providers
+
+import kotlin.random.Random
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import sk.ainet.apps.kllama.chat.ChatTemplate
+import sk.ainet.apps.llm.InferenceRuntime
+import sk.ainet.apps.llm.Tokenizer
+import sk.ainet.apps.llm.sampleFromTensor
+import sk.ainet.lang.types.DType
+import sk.ainet.llm.api.ChatOptions
+import sk.ainet.llm.api.ChatRequest
+import sk.ainet.llm.api.ChatResponse
+import sk.ainet.llm.api.ChatResponseChunk
+import sk.ainet.llm.api.FinishReason
+import sk.ainet.llm.api.Generation
+import sk.ainet.llm.api.Message
+import sk.ainet.llm.api.StreamingChatModel
+import sk.ainet.llm.api.Usage
+
+/**
+ * Adapts an `InferenceRuntime` + `Tokenizer` + `ChatTemplate` to the neutral
+ * [StreamingChatModel] SPI.
+ *
+ * **Threading:** A single instance is **not** thread-safe — KV-cache state is
+ * mutated across forward passes. Use one instance per concurrent request, or
+ * wrap many instances in a pool decorator.
+ *
+ * **Sampling knobs:** Only [ChatOptions.temperature], [ChatOptions.maxTokens],
+ * and [ChatOptions.stopSequences] are honored today. `topK` / `topP` /
+ * `frequencyPenalty` are accepted in the request shape (for API parity with
+ * Spring AI / OpenAI) but ignored — the underlying runtime currently does
+ * temperature-only categorical sampling.
+ */
+public class SkaiNetChatModel<T : DType>(
+    private val runtime: InferenceRuntime<T>,
+    private val tokenizer: Tokenizer,
+    private val chatTemplate: ChatTemplate,
+    public override val defaultOptions: ChatOptions = ChatOptions.DEFAULTS,
+    private val bosTokenId: Int = tokenizer.bosTokenId,
+    private val eosTokenId: Int = tokenizer.eosTokenId,
+    private val random: Random = Random.Default,
+    private val modelId: String? = null,
+) : StreamingChatModel {
+
+    override fun call(request: ChatRequest): ChatResponse {
+        val opts = merged(request.options)
+        val promptTokens = renderAndTokenize(request)
+        val sb = StringBuilder()
+        var produced = 0
+        var finish = FinishReason.LENGTH
+        runGenerationLoop(
+            promptTokens = promptTokens,
+            maxTokens = opts.maxTokens ?: 512,
+            temperature = opts.temperature ?: 0f,
+        ) { tokenId ->
+            if (tokenId == eosTokenId) {
+                finish = FinishReason.STOP
+                false
+            } else {
+                sb.append(tokenizer.decode(tokenId))
+                produced++
+                val stopAt = findStopSequenceStart(sb, opts.stopSequences)
+                if (stopAt != null) {
+                    sb.setLength(stopAt)
+                    finish = FinishReason.STOP
+                    false
+                } else {
+                    true
+                }
+            }
+        }
+        val text = sb.toString()
+        val toolCalls = if (chatTemplate.containsToolCall(text))
+            chatTemplate.parseToolCalls(text).map { it.toApi() }
+        else emptyList()
+        if (toolCalls.isNotEmpty()) finish = FinishReason.TOOL_CALL
+
+        val message = Message.assistant(text, toolCalls)
+        return ChatResponse(
+            generations = listOf(Generation(message, finish)),
+            usage = Usage(promptTokens = promptTokens.size, completionTokens = produced),
+            modelId = modelId,
+        )
+    }
+
+    override fun stream(request: ChatRequest): Flow<ChatResponseChunk> = channelFlow {
+        withContext(Dispatchers.Default) {
+            val opts = merged(request.options)
+            val promptTokens = renderAndTokenize(request)
+            val sb = StringBuilder()
+            var produced = 0
+            var finish = FinishReason.LENGTH
+
+            runGenerationLoop(
+                promptTokens = promptTokens,
+                maxTokens = opts.maxTokens ?: 512,
+                temperature = opts.temperature ?: 0f,
+            ) { tokenId ->
+                if (!isActive) return@runGenerationLoop false
+                if (tokenId == eosTokenId) {
+                    finish = FinishReason.STOP
+                    return@runGenerationLoop false
+                }
+                val piece = tokenizer.decode(tokenId)
+                val before = sb.length
+                sb.append(piece)
+                produced++
+
+                val stopAt = findStopSequenceStart(sb, opts.stopSequences)
+                if (stopAt != null) {
+                    finish = FinishReason.STOP
+                    val keep = (stopAt - before).coerceAtLeast(0)
+                    if (keep > 0) {
+                        trySend(ChatResponseChunk(delta = piece.substring(0, keep)))
+                    }
+                    sb.setLength(stopAt)
+                    return@runGenerationLoop false
+                }
+                val sendResult = trySend(ChatResponseChunk(delta = piece))
+                !sendResult.isClosed
+            }
+
+            val text = sb.toString()
+            val toolCalls = if (chatTemplate.containsToolCall(text))
+                chatTemplate.parseToolCalls(text).map { it.toApi() }
+            else emptyList()
+            if (toolCalls.isNotEmpty()) finish = FinishReason.TOOL_CALL
+
+            send(
+                ChatResponseChunk(
+                    delta = "",
+                    toolCallDelta = toolCalls,
+                    finishReason = finish,
+                    usage = Usage(promptTokens = promptTokens.size, completionTokens = produced),
+                )
+            )
+        }
+    }.buffer(Channel.UNLIMITED)
+
+    override fun close() {
+        runtime.reset()
+    }
+
+    private fun merged(opts: ChatOptions?): ChatOptions =
+        opts?.let {
+            ChatOptions(
+                model = it.model ?: defaultOptions.model,
+                temperature = it.temperature ?: defaultOptions.temperature,
+                topK = it.topK ?: defaultOptions.topK,
+                topP = it.topP ?: defaultOptions.topP,
+                maxTokens = it.maxTokens ?: defaultOptions.maxTokens,
+                stopSequences = if (it.stopSequences.isNotEmpty()) it.stopSequences else defaultOptions.stopSequences,
+                seed = it.seed ?: defaultOptions.seed,
+            )
+        } ?: defaultOptions
+
+    private fun renderAndTokenize(request: ChatRequest): IntArray {
+        val agentMessages = request.messages.map { it.toAgent() }
+        val agentTools = request.tools.map { it.toAgent() }
+        val rendered = chatTemplate.apply(agentMessages, agentTools, addGenerationPrompt = true)
+        return tokenizer.encode(rendered)
+    }
+
+    /**
+     * Runs the autoregressive loop synchronously on the calling thread.
+     *
+     * Mirrors the prefill/sample structure of [sk.ainet.apps.llm.generate] but exposes
+     * a per-token `Boolean` callback so callers can stop early on EOS or stop sequences.
+     */
+    private fun runGenerationLoop(
+        promptTokens: IntArray,
+        maxTokens: Int,
+        temperature: Float,
+        onSampled: (Int) -> Boolean,
+    ) {
+        require(maxTokens > 0) { "maxTokens must be > 0" }
+        runtime.reset()
+
+        val full = if (promptTokens.isEmpty() || promptTokens[0] != bosTokenId) {
+            intArrayOf(bosTokenId) + promptTokens
+        } else {
+            promptTokens
+        }
+
+        var token = full[0]
+        var pos = 0
+        var produced = 0
+        while (produced < maxTokens) {
+            val logits = runtime.forward(token)
+            val next = if (pos + 1 < full.size) {
+                full[pos + 1]
+            } else {
+                sampleFromTensor(logits, temperature, random)
+            }
+            if (pos + 1 >= full.size) {
+                if (!onSampled(next)) return
+                produced++
+            }
+            token = next
+            pos++
+        }
+    }
+}

--- a/llm-providers/src/main/kotlin/sk/ainet/llm/providers/SkaiNetEmbeddingModel.kt
+++ b/llm-providers/src/main/kotlin/sk/ainet/llm/providers/SkaiNetEmbeddingModel.kt
@@ -1,0 +1,45 @@
+@file:Suppress("DEPRECATION")
+
+package sk.ainet.llm.providers
+
+import sk.ainet.apps.llm.Tokenizer
+import sk.ainet.lang.types.DType
+import sk.ainet.llm.api.Embedding
+import sk.ainet.llm.api.EmbeddingModel
+import sk.ainet.llm.api.EmbeddingRequest
+import sk.ainet.llm.api.EmbeddingResponse
+import sk.ainet.llm.api.Usage
+import sk.ainet.models.bert.BertRuntime
+
+/**
+ * Adapts a BERT-style encoder runtime (`BertRuntime`) + `Tokenizer` to the neutral
+ * [EmbeddingModel] SPI.
+ *
+ * The runtime already does mean pooling + L2 normalization internally, so the
+ * adapter is little more than a tensor-to-FloatArray copy.
+ *
+ * **Threading:** Like [SkaiNetChatModel], a single instance is **not** thread-safe.
+ */
+public class SkaiNetEmbeddingModel<T : DType>(
+    private val runtime: BertRuntime<T>,
+    private val tokenizer: Tokenizer,
+    public override val dimensions: Int,
+    private val modelId: String? = null,
+) : EmbeddingModel {
+
+    override fun call(request: EmbeddingRequest): EmbeddingResponse {
+        var totalPromptTokens = 0
+        val embeddings = request.inputs.mapIndexed { idx, text ->
+            val tokens = tokenizer.encode(text)
+            totalPromptTokens += tokens.size
+            val tensor = runtime.encode(tokens)
+            val vector = tensor.data.copyToFloatArray()
+            Embedding(index = idx, vector = vector)
+        }
+        return EmbeddingResponse(
+            embeddings = embeddings,
+            usage = Usage(promptTokens = totalPromptTokens, completionTokens = 0),
+            modelId = modelId,
+        )
+    }
+}

--- a/llm-providers/src/main/kotlin/sk/ainet/llm/providers/StopSequences.kt
+++ b/llm-providers/src/main/kotlin/sk/ainet/llm/providers/StopSequences.kt
@@ -1,0 +1,19 @@
+package sk.ainet.llm.providers
+
+/**
+ * Returns the index in [buffer] at which the earliest match of any [stopSequences]
+ * begins, or `null` if none of the sequences appears.
+ *
+ * The buffer is checked in its current entirety on every call — fine for token-level
+ * streaming where each tick decodes only a few bytes.
+ */
+internal fun findStopSequenceStart(buffer: CharSequence, stopSequences: List<String>): Int? {
+    if (stopSequences.isEmpty()) return null
+    var earliest = -1
+    for (s in stopSequences) {
+        if (s.isEmpty()) continue
+        val idx = buffer.indexOf(s)
+        if (idx >= 0 && (earliest < 0 || idx < earliest)) earliest = idx
+    }
+    return if (earliest < 0) null else earliest
+}

--- a/llm-providers/src/test/java/sk/ainet/llm/providers/JavaInteropTest.java
+++ b/llm-providers/src/test/java/sk/ainet/llm/providers/JavaInteropTest.java
@@ -1,0 +1,110 @@
+package sk.ainet.llm.providers;
+
+import org.junit.jupiter.api.Test;
+import sk.ainet.llm.api.ChatOptions;
+import sk.ainet.llm.api.ChatRequest;
+import sk.ainet.llm.api.ChatResponse;
+import sk.ainet.llm.api.Embedding;
+import sk.ainet.llm.api.EmbeddingRequest;
+import sk.ainet.llm.api.EmbeddingResponse;
+import sk.ainet.llm.api.FinishReason;
+import sk.ainet.llm.api.Generation;
+import sk.ainet.llm.api.Message;
+import sk.ainet.llm.api.Role;
+import sk.ainet.llm.api.ToolCall;
+import sk.ainet.llm.api.ToolDefinition;
+import sk.ainet.llm.api.Usage;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Compile-and-run check that the public llm-api SPI is reachable from plain Java
+ * with the ergonomics we care about: static factory methods on Message, JvmField on
+ * ChatOptions.DEFAULTS, and JvmOverloads-generated short constructors.
+ */
+class JavaInteropTest {
+
+    @Test
+    void messageStaticFactories() {
+        Message sys = Message.system("you are helpful");
+        Message usr = Message.user("hi");
+        Message asst = Message.assistant("hello back");
+        Message tool = Message.tool("42", "call-1");
+
+        assertEquals(Role.SYSTEM, sys.getRole());
+        assertEquals(Role.USER, usr.getRole());
+        assertEquals(Role.ASSISTANT, asst.getRole());
+        assertEquals(Role.TOOL, tool.getRole());
+        assertEquals("call-1", tool.getToolCallId());
+    }
+
+    @Test
+    void chatOptionsDefaultsIsStaticField() {
+        ChatOptions defaults = ChatOptions.DEFAULTS;
+        assertNotNull(defaults);
+        assertEquals(0.7f, defaults.getTemperature(), 1e-6);
+        assertEquals(512, defaults.getMaxTokens());
+    }
+
+    @Test
+    void chatOptionsBuiltViaJvmOverloads() {
+        // No-args constructor should exist via @JvmOverloads on the primary constructor.
+        ChatOptions empty = new ChatOptions();
+        assertNull(empty.getTemperature());
+        assertEquals(Collections.emptyList(), empty.getStopSequences());
+    }
+
+    @Test
+    void chatRequestSinglePromptConstructor() {
+        ChatRequest r = new ChatRequest("hello");
+        assertEquals(1, r.getMessages().size());
+        assertEquals("hello", r.getMessages().get(0).getContent());
+        assertNull(r.getOptions());
+    }
+
+    @Test
+    void embeddingResponseShape() {
+        Embedding e = new Embedding(0, new float[] { 0.1f, 0.2f, 0.3f });
+        EmbeddingResponse resp = new EmbeddingResponse(
+            Collections.singletonList(e),
+            new Usage(2, 0),
+            "test-model"
+        );
+        assertEquals(1, resp.getEmbeddings().size());
+        assertEquals(3, resp.getEmbeddings().get(0).getVector().length);
+    }
+
+    @Test
+    void chatResponseAndGenerationConstructible() {
+        Message asst = Message.assistant("done");
+        Generation gen = new Generation(asst, FinishReason.STOP);
+        ChatResponse resp = new ChatResponse(Collections.singletonList(gen));
+        assertEquals("done", resp.getText());
+        assertSame(FinishReason.STOP, resp.getGenerations().get(0).getFinishReason());
+    }
+
+    @Test
+    void toolDefinitionAndToolCallConstructible() {
+        ToolDefinition def = new ToolDefinition(
+            "search",
+            "Web search",
+            "{\"type\":\"object\"}"
+        );
+        ToolCall call = new ToolCall("tc-1", "search", "{\"q\":\"hello\"}");
+        assertEquals("search", def.getName());
+        assertEquals("tc-1", call.getId());
+    }
+
+    @Test
+    void embeddingRequestSingleStringConstructor() {
+        EmbeddingRequest r = new EmbeddingRequest("hello");
+        assertEquals(1, r.getInputs().size());
+        assertEquals("hello", r.getInputs().get(0));
+    }
+}

--- a/llm-providers/src/test/kotlin/sk/ainet/llm/providers/MappersTest.kt
+++ b/llm-providers/src/test/kotlin/sk/ainet/llm/providers/MappersTest.kt
@@ -1,0 +1,68 @@
+package sk.ainet.llm.providers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import sk.ainet.apps.kllama.chat.ChatRole
+import sk.ainet.apps.kllama.chat.ToolCall as AgentToolCall
+import sk.ainet.llm.api.Message
+import sk.ainet.llm.api.Role
+import sk.ainet.llm.api.ToolCall as ApiToolCall
+import sk.ainet.llm.api.ToolDefinition as ApiToolDefinition
+
+class MappersTest {
+
+    @Test fun `Role enum maps to ChatRole 1to1`() {
+        assertEquals(ChatRole.SYSTEM, Role.SYSTEM.toAgent())
+        assertEquals(ChatRole.USER, Role.USER.toAgent())
+        assertEquals(ChatRole.ASSISTANT, Role.ASSISTANT.toAgent())
+        assertEquals(ChatRole.TOOL, Role.TOOL.toAgent())
+    }
+
+    @Test fun `Message preserves content, role, toolCallId`() {
+        val msg = Message.tool(content = "42", toolCallId = "call-7", name = "calc")
+        val agent = msg.toAgent()
+        assertEquals(ChatRole.TOOL, agent.role)
+        assertEquals("42", agent.content)
+        assertEquals("call-7", agent.toolCallId)
+    }
+
+    @Test fun `ToolDefinition parametersJsonSchema parses to JsonObject`() {
+        val td = ApiToolDefinition(
+            name = "search",
+            description = "Web search",
+            parametersJsonSchema = """{"type":"object","properties":{"q":{"type":"string"}}}""",
+        )
+        val agent = td.toAgent()
+        assertEquals("search", agent.name)
+        assertEquals("Web search", agent.description)
+        assertEquals("object", (agent.parameters["type"] as JsonPrimitive).content)
+    }
+
+    @Test fun `agent ToolCall round-trips through API ToolCall`() {
+        val original = AgentToolCall(
+            id = "tc-1",
+            name = "lookup",
+            arguments = buildJsonObject { /* empty */ },
+        )
+        val viaApi = original.toApi().toAgent()
+        assertEquals(original.id, viaApi.id)
+        assertEquals(original.name, viaApi.name)
+        assertEquals(original.arguments, viaApi.arguments)
+    }
+
+    @Test fun `API ToolCall back-and-forth preserves arguments JSON`() {
+        val api = ApiToolCall(
+            id = "tc-2",
+            name = "lookup",
+            argumentsJson = """{"key":"value","n":7}""",
+        )
+        val agent = api.toAgent()
+        // Serialized form may reorder keys; check semantic equality via re-parse.
+        assertEquals(api.id, agent.id)
+        assertEquals(api.name, agent.name)
+        assertEquals("value", (agent.arguments["key"] as JsonPrimitive).content)
+        assertEquals(7, (agent.arguments["n"] as JsonPrimitive).content.toInt())
+    }
+}

--- a/llm-providers/src/test/kotlin/sk/ainet/llm/providers/StopSequencesTest.kt
+++ b/llm-providers/src/test/kotlin/sk/ainet/llm/providers/StopSequencesTest.kt
@@ -1,0 +1,29 @@
+package sk.ainet.llm.providers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class StopSequencesTest {
+
+    @Test fun `returns null when no stop sequences configured`() {
+        assertNull(findStopSequenceStart("anything goes here", emptyList()))
+    }
+
+    @Test fun `returns null when stop sequence is absent`() {
+        assertNull(findStopSequenceStart("hello world", listOf("###")))
+    }
+
+    @Test fun `returns index of single stop`() {
+        assertEquals(5, findStopSequenceStart("hello###world", listOf("###")))
+    }
+
+    @Test fun `returns earliest of multiple stops`() {
+        // "STOP" at index 6, "###" at index 11
+        assertEquals(6, findStopSequenceStart("hello STOP and ###", listOf("###", "STOP")))
+    }
+
+    @Test fun `ignores empty stop sequences`() {
+        assertEquals(5, findStopSequenceStart("hello###", listOf("", "###")))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,8 +23,10 @@ if (localSkaiNet.isDirectory) {
 
 rootProject.name = "SKaiNET-transformers"
 
+include("llm-api")
 include("llm-core")
 include("llm-agent")
+include("llm-providers")
 include("llm-inference:llama")
 include("llm-inference:qwen")
 include("llm-inference:gemma")


### PR DESCRIPTION
## Summary

- Adds `llm-api` (KMP, deps: `kotlin-stdlib` + `kotlinx-coroutines` only) — the provider-neutral `ChatModel` / `StreamingChatModel` / `EmbeddingModel` SPI, shaped after Spring AI but with **zero** Spring or Reactor types in core.
- Adds `llm-providers` (JVM) — `SkaiNetChatModel<T>` wraps any `InferenceRuntime + Tokenizer + ChatTemplate` (synchronous `call` and Kotlin-`Flow` `stream` with EOS / stop-sequence early-stop and tool-call detection); `SkaiNetEmbeddingModel<T>` wraps `BertRuntime`.
- Updates `llm-bom` so a single BOM pin covers both new artifacts.
- Java-friendliness pass: `@JvmOverloads` on data-class constructors, `@JvmStatic` on `Message` factories, `@JvmField` on `ChatOptions.DEFAULTS`, `-Xjvm-default=all` so interface defaults compile to real Java default methods. Verified by `JavaInteropTest.java`.

Closes #76. Follow-up tracked in #77 (Spring AI adapter as a separate companion repo `SKaiNET-spring-ai`).

## Why

Spring AI's `ChatModel` / `EmbeddingModel` design is good and developers know it, but coupling SKaiNET-transformers' core to Spring would (1) shrink KMP reach (Spring is JVM-only), (2) drag every consumer into Spring's transitives, (3) make non-Spring consumers second-class. This PR keeps the core framework-neutral so Spring AI / LangChain4j / Quarkus / plain Ktor each becomes a thin external adapter against a stable SPI.

## What changed

### `llm-api/` (new module)
- `ChatModel`, `StreamingChatModel` (Kotlin `Flow<ChatResponseChunk>`), `EmbeddingModel`
- `ChatRequest` / `ChatResponse` / `ChatResponseChunk` / `Generation` / `Usage` / `FinishReason`
- `EmbeddingRequest` / `EmbeddingResponse` / `Embedding`
- `ChatOptions` / `EmbeddingOptions` (Spring AI–shaped knobs)
- `Message` / `Role` / `ToolDefinition` / `ToolCall` (JSON kept as raw strings — zero JSON-lib dep)

### `llm-providers/` (new module)
- `SkaiNetChatModel<T>` — honors `temperature`, `maxTokens`, `stopSequences`; detects EOS and tool calls via `ChatTemplate.containsToolCall` / `parseToolCalls`. `topK`/`topP` accepted in the API for parity but ignored (the underlying `OptimizedLLMRuntime` is temperature-only today; documented).
- `SkaiNetEmbeddingModel<T>` — wraps `BertRuntime` (suppressed deprecation pending the unified-runtime migration).
- `Mappers.kt` — neutral `Message`/`ToolCall`/`ToolDefinition` ↔ `llm-agent` types.
- `StopSequences.kt` — pure helper, unit-tested.

### Tests
- `StopSequencesTest`, `MappersTest` (Kotlin)
- `JavaInteropTest.java` — proves the SPI is comfortable from plain Java.

### Build wiring
- `settings.gradle.kts` includes `:llm-api` and `:llm-providers`
- `llm-bom/build.gradle.kts` adds constraints for both
- Binary-compat baselines checked in (`llm-api/api/`, `llm-providers/api/`)

## Branch base

Targeting `feature/gemma4` because it's the immediate parent — diff is just the two SPI commits + the Java-friendliness commit. Retarget to `develop` once `feature/gemma4` lands or by rebasing.

## Out of scope (deliberately deferred)

- Spring AI adapter + Boot starter — separate repo, see #77.
- One-call GGUF builder (`SkaiNetChatModel.fromGguf(path)`) — needs a unified loader inside SKaiNET first; current SPI takes a pre-built runtime.
- `topK` / `topP` sampling — needs a runtime-side change in `OptimizedLLMRuntime`.
- Multimodal — text-only this iteration.

## Test plan

- [x] `./gradlew :llm-api:build :llm-providers:build :llm-bom:build` green
- [x] `llm-providers` Kotlin + Java tests pass (`StopSequencesTest`, `MappersTest`, `JavaInteropTest`)
- [x] `apiCheck` passes against checked-in baselines
- [ ] Smoke check: a Spring-free 30-line app constructs `SkaiNetChatModel` against a Qwen3 GGUF and gets a non-empty response (proves the SPI is genuinely framework-neutral; deferred until the one-call loader lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)