### PR TITLE
feat(generate): PrefillStrategy.Batched opt-in for prompt ingestion

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/GenerateExtensions.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/GenerateExtensions.kt
@@ -20,11 +20,19 @@ public fun <T : DType> sampleFromTensor(
 }
 
 /**
- * Auto-regressive generation loop on any [InferenceRuntime].
+ * Generation loop on any [InferenceRuntime].
  *
- * Prepends [bosToken] if not already present, feeds prompt tokens
- * through the model (discarding their logits), then samples
- * [steps] new tokens, calling [onToken] for each.
+ * Prepends [bosToken] if not already present, ingests the prompt via the
+ * configured [prefillStrategy], then samples [steps] new tokens, calling
+ * [onToken] for each.
+ *
+ * The default strategy [PrefillStrategy.Autoregressive] preserves the
+ * historical one-token-per-forward semantics. Opt in to
+ * [PrefillStrategy.Batched] to get the prefill speedup from
+ * [InferenceRuntime.forwardBatched] (typically 3–10× on long prompts).
+ *
+ * Decode is always autoregressive — each generated token depends on the
+ * previous sample, so there is nothing to batch.
  */
 public fun <T : DType> InferenceRuntime<T>.generate(
     prompt: IntArray,
@@ -32,6 +40,7 @@ public fun <T : DType> InferenceRuntime<T>.generate(
     temperature: Float,
     bosToken: Int = 1,
     random: Random = Random.Default,
+    prefillStrategy: PrefillStrategy = PrefillStrategy.Autoregressive,
     onToken: (Int) -> Unit
 ) {
     require(steps > 0) { "steps must be > 0" }
@@ -44,6 +53,23 @@ public fun <T : DType> InferenceRuntime<T>.generate(
         prompt
     }
 
+    when (prefillStrategy) {
+        is PrefillStrategy.Autoregressive -> {
+            generateAutoregressive(fullPrompt, steps, temperature, random, onToken)
+        }
+        is PrefillStrategy.Batched -> {
+            generateBatched(fullPrompt, steps, temperature, random, prefillStrategy.maxBatch, onToken)
+        }
+    }
+}
+
+private fun <T : DType> InferenceRuntime<T>.generateAutoregressive(
+    fullPrompt: IntArray,
+    steps: Int,
+    temperature: Float,
+    random: Random,
+    onToken: (Int) -> Unit
+) {
     var token = fullPrompt[0]
     var pos = 0
     var generatedCount = 0
@@ -60,6 +86,42 @@ public fun <T : DType> InferenceRuntime<T>.generate(
         }
         token = next
         pos++
+    }
+}
+
+private fun <T : DType> InferenceRuntime<T>.generateBatched(
+    fullPrompt: IntArray,
+    steps: Int,
+    temperature: Float,
+    random: Random,
+    maxBatch: Int,
+    onToken: (Int) -> Unit
+) {
+    // Prefill: ingest the prompt in [maxBatch]-sized chunks. forwardBatched
+    // returns the logits at the last position of its input, so the last
+    // chunk's logits are exactly the post-prompt distribution we need to
+    // sample the first generated token from.
+    var lastLogits: sk.ainet.lang.tensor.Tensor<T, Float>? = null
+    var i = 0
+    while (i < fullPrompt.size) {
+        val end = if (i + maxBatch < fullPrompt.size) i + maxBatch else fullPrompt.size
+        val chunk = fullPrompt.copyOfRange(i, end)
+        lastLogits = forwardBatched(chunk)
+        i = end
+    }
+    val postPromptLogits = lastLogits
+        ?: error("generate: prompt is empty after BOS prepend — internal invariant broken")
+
+    // Decode: autoregressive sampling. The first sample comes from
+    // postPromptLogits; each subsequent step does forward(prev_sample).
+    var sample = sampleFromTensor(postPromptLogits, temperature, random)
+    onToken(sample)
+    var generatedCount = 1
+    while (generatedCount < steps) {
+        val logits = forward(sample)
+        sample = sampleFromTensor(logits, temperature, random)
+        onToken(sample)
+        generatedCount++
     }
 }
 

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/PrefillStrategy.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/PrefillStrategy.kt
@@ -1,0 +1,43 @@
+package sk.ainet.apps.llm
+
+/**
+ * Selects how an [InferenceRuntime] processes the prompt before sampling
+ * begins.
+ *
+ * The prompt-processing phase ("prefill") and the sampling phase ("decode")
+ * have very different cost structures. Decode is necessarily one token at a
+ * time — each token depends on the previous sample. Prefill is teacher-
+ * forced, so the entire prompt is known up front and can be ingested in one
+ * batched forward pass; on a long prompt that's typically 3–10× faster than
+ * looping `forward(t)` per token, because graph dispatch and per-layer
+ * setup happen once instead of N times.
+ *
+ * Default is [Autoregressive] — preserves the long-standing one-token-per-
+ * forward behavior so existing callers see no change. Opt in to [Batched]
+ * to use [InferenceRuntime.forwardBatched] for the prompt phase.
+ */
+public sealed interface PrefillStrategy {
+    /**
+     * Process the prompt by calling [InferenceRuntime.forward] once per
+     * token. Equivalent to the original `generate()` semantics.
+     */
+    public object Autoregressive : PrefillStrategy
+
+    /**
+     * Process the prompt in chunks of up to [maxBatch] tokens via
+     * [InferenceRuntime.forwardBatched]. The last chunk's last-position
+     * logits are used to sample the first generated token; subsequent
+     * decode steps remain autoregressive.
+     *
+     * @param maxBatch maximum number of tokens fed to a single
+     *   `forwardBatched` call. The whole prompt goes in one batched
+     *   forward when its length is `<= maxBatch`. Tune lower if memory
+     *   pressure on a long prompt becomes a problem; higher for maximum
+     *   throughput on long prompts.
+     */
+    public data class Batched(val maxBatch: Int = 64) : PrefillStrategy {
+        init {
+            require(maxBatch > 0) { "PrefillStrategy.Batched: maxBatch must be > 0, got $maxBatch" }
+        }
+    }
+}

--- a/llm-runtime/kllama/src/jvmTest/kotlin/sk/ainet/apps/kllama/PrefillStrategyEquivalenceTest.kt
+++ b/llm-runtime/kllama/src/jvmTest/kotlin/sk/ainet/apps/kllama/PrefillStrategyEquivalenceTest.kt
@@ -1,0 +1,161 @@
+package sk.ainet.apps.kllama
+
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.apps.llm.PrefillStrategy
+import sk.ainet.apps.llm.generate
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.llama.LlamaNetworkLoader
+
+/**
+ * Verifies that `generate(prefillStrategy = Batched)` produces the same
+ * generated tokens as `generate(prefillStrategy = Autoregressive)` at
+ * temperature=0 (greedy) on a fixed prompt. This is the user-facing
+ * counterpart to [BatchedPrefillEquivalenceTest], which exercises the
+ * lower-level `forwardBatched` directly.
+ *
+ * Without this gate, `generate()` could ship a default that silently
+ * picks the wrong path, or a future change could re-introduce a `seqLen
+ * > 1`-only bug akin to the one fixed in PR #81.
+ *
+ * Skipped if the model is not present.
+ */
+class PrefillStrategyEquivalenceTest {
+
+    companion object {
+        private val MODEL_PATH = Path.of(
+            System.getProperty("user.home"),
+            ".lmstudio/models/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+            "tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+        )
+    }
+
+    @Test
+    fun `Batched prefill yields identical greedy generation`() {
+        if (!MODEL_PATH.exists()) {
+            println("[skip] Model not at $MODEL_PATH")
+            return
+        }
+        runBlocking {
+            val ctx = DirectCpuExecutionContext()
+            val tokenizer = JvmRandomAccessSource.open(MODEL_PATH.toString()).use { source ->
+                GGUFTokenizer.fromRandomAccessSource(source)
+            }
+            val prompt = "The capital of France is"
+            val promptTokens = tokenizer.encode(prompt)
+            val steps = 16
+
+            val auto = mutableListOf<Int>()
+            run {
+                val model = LlamaNetworkLoader.fromGguf(
+                    randomAccessProvider = { JvmRandomAccessSource.open(MODEL_PATH.toString()) },
+                    quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32
+                ).load<FP32, Float>(ctx)
+                val runtime = OptimizedLLMRuntime(
+                    model = model, ctx = ctx,
+                    mode = OptimizedLLMMode.DIRECT, dtype = FP32::class
+                )
+                runtime.generate(
+                    prompt = promptTokens,
+                    steps = steps,
+                    temperature = 0f,
+                    random = Random(0),
+                    prefillStrategy = PrefillStrategy.Autoregressive
+                ) { auto.add(it) }
+            }
+
+            val batched = mutableListOf<Int>()
+            run {
+                val model = LlamaNetworkLoader.fromGguf(
+                    randomAccessProvider = { JvmRandomAccessSource.open(MODEL_PATH.toString()) },
+                    quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32
+                ).load<FP32, Float>(ctx)
+                val runtime = OptimizedLLMRuntime(
+                    model = model, ctx = ctx,
+                    mode = OptimizedLLMMode.DIRECT, dtype = FP32::class
+                )
+                runtime.generate(
+                    prompt = promptTokens,
+                    steps = steps,
+                    temperature = 0f,
+                    random = Random(0),
+                    prefillStrategy = PrefillStrategy.Batched(maxBatch = 64)
+                ) { batched.add(it) }
+            }
+
+            println("[diag] auto    : $auto")
+            println("[diag] batched : $batched")
+            assertEquals(auto, batched, "Batched generation diverges from autoregressive at temperature=0")
+        }
+    }
+
+    @Test
+    fun `Batched prefill with chunking yields identical greedy generation`() {
+        // Force chunked prefill (maxBatch < prompt length) to exercise the
+        // multi-chunk path through forwardBatched.
+        if (!MODEL_PATH.exists()) {
+            println("[skip] Model not at $MODEL_PATH")
+            return
+        }
+        runBlocking {
+            val ctx = DirectCpuExecutionContext()
+            val tokenizer = JvmRandomAccessSource.open(MODEL_PATH.toString()).use { source ->
+                GGUFTokenizer.fromRandomAccessSource(source)
+            }
+            val prompt = "The capital of France is Paris and"
+            val promptTokens = tokenizer.encode(prompt)
+            val steps = 8
+
+            val auto = mutableListOf<Int>()
+            run {
+                val model = LlamaNetworkLoader.fromGguf(
+                    randomAccessProvider = { JvmRandomAccessSource.open(MODEL_PATH.toString()) },
+                    quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32
+                ).load<FP32, Float>(ctx)
+                val runtime = OptimizedLLMRuntime(
+                    model = model, ctx = ctx,
+                    mode = OptimizedLLMMode.DIRECT, dtype = FP32::class
+                )
+                runtime.generate(
+                    prompt = promptTokens,
+                    steps = steps,
+                    temperature = 0f,
+                    random = Random(0),
+                    prefillStrategy = PrefillStrategy.Autoregressive
+                ) { auto.add(it) }
+            }
+
+            val batched = mutableListOf<Int>()
+            run {
+                val model = LlamaNetworkLoader.fromGguf(
+                    randomAccessProvider = { JvmRandomAccessSource.open(MODEL_PATH.toString()) },
+                    quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32
+                ).load<FP32, Float>(ctx)
+                val runtime = OptimizedLLMRuntime(
+                    model = model, ctx = ctx,
+                    mode = OptimizedLLMMode.DIRECT, dtype = FP32::class
+                )
+                runtime.generate(
+                    prompt = promptTokens,
+                    steps = steps,
+                    temperature = 0f,
+                    random = Random(0),
+                    prefillStrategy = PrefillStrategy.Batched(maxBatch = 3)  // forces 2-3 chunks
+                ) { batched.add(it) }
+            }
+
+            println("[diag] auto (chunked):    $auto")
+            println("[diag] batched (chunked): $batched")
+            assertEquals(auto, batched, "Chunked batched generation diverges from autoregressive")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PrefillStrategy` sealed interface (`Autoregressive` default, `Batched(maxBatch=64)` opt-in) and a `prefillStrategy` parameter on the `InferenceRuntime.generate()` extension.
- `Autoregressive` preserves historical one-token-per-forward semantics — existing callers see no behavior change.
- `Batched` ingests the prompt via `forwardBatched` in chunks of up to `maxBatch` tokens, then continues sampling autoregressively. Wires PR #81's correctness fix into the user-facing generation path.

## Why

After PR #81 fixed the `forwardBatched` correctness bug, the throughput win was reachable only by callers manually invoking `runtime.forwardBatched()` and managing the post-prompt logits themselves. The standard `runtime.generate(prompt, steps, ...)` path still did per-token autoregressive prefill. This PR closes that gap — opt in with `prefillStrategy = PrefillStrategy.Batched(maxBatch = 64)` and the generation API does the right thing.

Decode stays autoregressive — each generated token depends on the previous sample, so there's nothing to batch there.

## Test plan

`PrefillStrategyEquivalenceTest` (TinyLlama 1.1B Q8_0, DEQUANTIZE_TO_FP32, temperature=0):

- [x] **Whole-prompt batched** — 16 tokens of greedy decode, autoregressive == batched, exact match
- [x] **Chunked batched** (`maxBatch=3` against a 7-token prompt) — 8 tokens of greedy decode exercising multi-chunk `forwardBatched`, autoregressive == batched

Both cases produce coherent output (token 3681 = \" Paris\" after \"The capital of France is\"), so this also catches the case where the batched path silently produces nonsense.

## Follow-ups (separate work)

- M2.5: prefill tok/s benchmark (TinyLlama / Qwen3 at 256 / 1024 / 4096 prompt tokens) — release-note material.
- Upstream `permute(axes)` op — replaces the manual copy in `swapSeqHeadDims` from PR #81.
- M1 unpark — scratch-pool call-site migrations now that upstream PR #550 has shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)