### PR TITLE
build(release): hotfix 0.21.1 — add missing POM_NAME for apertus/voxtral/llm-performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.transformers
-VERSION_NAME=0.21.0
+VERSION_NAME=0.21.1
 
 POM_DESCRIPTION=SKaiNET-transformers
 

--- a/llm-inference/apertus/gradle.properties
+++ b/llm-inference/apertus/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-transformers-inference-apertus
+POM_NAME=skainet apertus model loader

--- a/llm-inference/voxtral/gradle.properties
+++ b/llm-inference/voxtral/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-transformers-inference-voxtral
+POM_NAME=skainet voxtral model loader

--- a/llm-performance/gradle.properties
+++ b/llm-performance/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-transformers-performance
+POM_NAME=skainet-transformers performance benchmarks


### PR DESCRIPTION
## Summary

- The 0.21.0 release publish failed Sonatype Central Portal validation with `* Project name is missing` on every publication of the `apertus`, `voxtral`, and `llm-performance` modules ([failed run](https://github.com/SKaiNET-developers/SKaiNET-transformers/actions/runs/25099556107)).
- Root cause: those three modules lacked a `gradle.properties` file, so vanniktech's pom-from-gradle-properties auto-config produced POMs without `<name>`. The new Central Portal validator rejects POMs missing `<name>` (OSSRH was lenient about this).
- Adds the three missing files with `POM_ARTIFACT_ID` and `POM_NAME` mirroring the sibling modules' style.
- Bumps `VERSION_NAME` 0.21.0 → 0.21.1 so a fresh tag can re-trigger `publish.yml` (`on: push: tags`).

`llm-runtime/kapertus` does **not** apply the `vanniktech.mavenPublish` plugin and therefore does not publish — no fix needed there.

## Files

| File | Coordinate |
|---|---|
| `llm-inference/apertus/gradle.properties` | `sk.ainet.transformers:skainet-transformers-inference-apertus` |
| `llm-inference/voxtral/gradle.properties` | `sk.ainet.transformers:skainet-transformers-inference-voxtral` |
| `llm-performance/gradle.properties` | `sk.ainet.transformers:skainet-transformers-performance` |
| `gradle.properties` | `VERSION_NAME=0.21.1` |

## Test plan

- [ ] CI green on this PR
- [ ] Merge to `develop`, fast-forward `main`, then push tag `0.21.1`
- [ ] `release` workflow run #N completes green; verify `<release>0.21.1</release>` in `https://repo1.maven.org/maven2/sk/ainet/transformers/skainet-transformers-runtime-kllama-jvm/maven-metadata.xml`
- [ ] `mvn -B -U package` in `SKaiNET-java-demo` resolves all 6 deps from Central without `publishToMavenLocal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)