### PR TITLE
build(llm-inference): wire native-cpu provider into qwen + llama jvmTest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ skainet-compile-core = { module = "sk.ainet.core:skainet-compile-core", version.
 skainet-compile-dag = { module = "sk.ainet.core:skainet-compile-dag", version.ref = "skainet" }
 skainet-compile-opt = { module = "sk.ainet.core:skainet-compile-opt", version.ref = "skainet" }
 skainet-backend-cpu = { module = "sk.ainet.core:skainet-backend-cpu", version.ref = "skainet" }
+skainet-backend-nativeCpu = { module = "sk.ainet.core:skainet-backend-native-cpu", version.ref = "skainet" }
 skainet-io-core = { module = "sk.ainet.core:skainet-io-core", version.ref = "skainet" }
 skainet-io-gguf = { module = "sk.ainet.core:skainet-io-gguf", version.ref = "skainet" }
 skainet-io-safetensors = { module = "sk.ainet.core:skainet-io-safetensors", version.ref = "skainet" }

--- a/llm-inference/llama/build.gradle.kts
+++ b/llm-inference/llama/build.gradle.kts
@@ -64,6 +64,12 @@ kotlin {
                 implementation(libs.junit)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.skainet.backend.cpu)
+                // Pulls the priority-100 native (FFM) provider onto the
+                // jvmTest classpath so KernelRegistry.bestAvailable()
+                // hands out the native Q4_K / FP32 kernels for the
+                // pipeline test. JVM-only: native-cpu has no Kotlin/
+                // Native, JS, or Wasm targets.
+                implementation(libs.skainet.backend.nativeCpu)
             }
         }
     }

--- a/llm-inference/qwen/build.gradle.kts
+++ b/llm-inference/qwen/build.gradle.kts
@@ -65,6 +65,12 @@ kotlin {
                 implementation(libs.junit)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.skainet.backend.cpu)
+                // Pulls the priority-100 native (FFM) provider onto the
+                // jvmTest classpath so KernelRegistry.bestAvailable()
+                // hands out the native Q4_K / FP32 kernels for the
+                // pipeline test. JVM-only: native-cpu has no Kotlin/
+                // Native, JS, or Wasm targets.
+                implementation(libs.skainet.backend.nativeCpu)
             }
         }
     }


### PR DESCRIPTION
## Summary

Wires the priority-100 native (FFM) kernel provider into the jvmTest classpaths of `llm-inference/qwen` and `llm-inference/llama` so pipeline tests exercise the native Q4_K + FP32 kernels — **4–6× faster than Panama on Q4_K matmul, 1.5–1.8× on FP32 SGEMM** (per upstream microbench numbers from SKaiNET PRs #572 and #575).

**Pairs with upstream PR** [SKaiNET#576](https://github.com/SKaiNET-developers/SKaiNET/pull/576) which adds publishing config for `skainet-backend-native-cpu`. Composite build (`includeBuild("../SKaiNET")` in `settings.gradle.kts:21`) handles the substitution; no SKaiNET release needed for local dev.

**Skips `llm-inference/gemma` deliberately.** Gemma has its own unrelated stability issues today (chat-template / tool-calling gaps per workspace context); validating perf wins on a known-broken inference path would muddy the signal. Same one-line change applies once gemma stabilizes.

## Changes

- **`gradle/libs.versions.toml`** — add `skainet-backend-nativeCpu` alongside the existing `skainet-backend-cpu`. Catalog key uses camelCase (`nativeCpu`) rather than dashes because Gradle's type-safe accessor generator chokes on `native` as a path segment (it's a soft-reserved Kotlin keyword); the underlying Maven coordinate stays kebab-case `sk.ainet.core:skainet-backend-native-cpu`.
- **`llm-inference/qwen/build.gradle.kts`** + **`llm-inference/llama/build.gradle.kts`** — add `implementation(libs.skainet.backend.nativeCpu)` to the `jvmTest` source set, parallel to the existing `skainet.backend.cpu` entry. JVM-only (FFM has no Native / JS / Wasm equivalent).

## Wiring contract

`DefaultCpuOpsJvm` already calls `KernelServiceLoader.installAll()` lazily on first use, so any test that exercises matmul through `ctx.ops` automatically picks up the native provider when it's available. **No runtime code changes anywhere** — pure dependency-graph + auto-discovery via `META-INF/services`.

## Test plan

- [x] `:llm-inference:qwen:jvmTest` — passes; QwenDslPipelineTest 6/6, QwenConfigParserTest 2/2
- [x] `:llm-inference:llama:jvmTest` — passes; LlamaDslPipelineTest 6/6, StateManagementTest 12/14 (2 pre-existing skips), LlamaWeightMapperTest + LlamaQuantDequantTest pass
- [ ] CI confirms green with the local SKaiNET → published 0.22.0-SNAPSHOT swap (this PR depends on upstream publishing landing)
- [ ] On hosts where the native lib doesn't load (sandbox, missing arch), `KernelRegistry` cleanly cascades to Panama priority-50 — the SKaiNET native-cpu module's own `NativeFfmPipelineTest` already exercises this fall-through path

🤖 Generated with [Claude Code](https://claude.com/claude-code)