### PR TITLE
build: post-merge ServiceLoader fix-up for shadow JAR (kllama-cli + skainet-cli)

### DIFF
--- a/llm-apps/kllama-cli/build.gradle.kts
+++ b/llm-apps/kllama-cli/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.zip.ZipFile
+
 plugins {
     kotlin("jvm")
     alias(libs.plugins.shadow)
@@ -25,8 +27,48 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
         )
     }
 
-    // Merge service files for proper SPI support
+    // Merge service files for proper SPI support.
     mergeServiceFiles()
+
+    // Workaround: shadow's mergeServiceFiles silently drops the
+    // skainet-backend-native-cpu KernelProvider entry on this version
+    // (com.gradleup.shadow:9.4.1) — only the cpu module's
+    // Scalar+PanamaVector lines survive. Reconcile by re-reading every
+    // dependency JAR's services file and rewriting the merged file
+    // with the union of all entries (deduplicated, newline-terminated).
+    val runtimeClasspathFiles = project.configurations.named("runtimeClasspath")
+        .map { it.files.filter { f -> f.name.endsWith(".jar") } }
+    doLast {
+        val jar = archiveFile.get().asFile
+        val servicePath = "META-INF/services/sk.ainet.backend.api.kernel.KernelProvider"
+        val entries = linkedSetOf<String>()
+        for (cpJar in runtimeClasspathFiles.get()) {
+            ZipFile(cpJar).use { zf ->
+                val zipEntry = zf.getEntry(servicePath)
+                if (zipEntry != null) {
+                    zf.getInputStream(zipEntry).bufferedReader().useLines { lines ->
+                        lines.map { it.trim() }
+                            .filter { it.isNotEmpty() && !it.startsWith("#") }
+                            .forEach { entries.add(it) }
+                    }
+                }
+            }
+        }
+        if (entries.isEmpty()) return@doLast
+        val tmpFile = temporaryDir.resolve("kernel-provider-services.txt")
+        tmpFile.writeText(entries.joinToString("\n", postfix = "\n"))
+        ant.withGroovyBuilder {
+            "zip"(
+                "destfile" to jar.absolutePath,
+                "update" to true,
+            ) {
+                "zipfileset"(
+                    "file" to tmpFile.absolutePath,
+                    "fullpath" to servicePath,
+                )
+            }
+        }
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/llm-apps/skainet-cli/build.gradle.kts
+++ b/llm-apps/skainet-cli/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.zip.ZipFile
+
 plugins {
     kotlin("jvm")
     alias(libs.plugins.shadow)
@@ -44,6 +46,49 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     }
 
     mergeServiceFiles()
+
+    // Workaround for com.gradleup.shadow:9.4.x — mergeServiceFiles()
+    // silently drops one of two co-located META-INF/services/<X>
+    // entries when both skainet-backend-cpu and skainet-backend-
+    // native-cpu are on the classpath. skainet-cli pulls the kllama
+    // runtime, which (in 0.22.0+) brings native-cpu in transitively;
+    // without this fix the resulting shadow JAR runs Panama priority-
+    // 50 even when the native lib is bundled. See PR #88 for the
+    // kllama-cli copy and the underlying repro. Drop when the
+    // upstream shadow merge is fixed.
+    val skainetCliRuntimeClasspathFiles = project.configurations.named("runtimeClasspath")
+        .map { it.files.filter { f -> f.name.endsWith(".jar") } }
+    doLast {
+        val jar = archiveFile.get().asFile
+        val servicePath = "META-INF/services/sk.ainet.backend.api.kernel.KernelProvider"
+        val entries = linkedSetOf<String>()
+        for (cpJar in skainetCliRuntimeClasspathFiles.get()) {
+            ZipFile(cpJar).use { zf ->
+                val zipEntry = zf.getEntry(servicePath)
+                if (zipEntry != null) {
+                    zf.getInputStream(zipEntry).bufferedReader().useLines { lines ->
+                        lines.map { it.trim() }
+                            .filter { it.isNotEmpty() && !it.startsWith("#") }
+                            .forEach { entries.add(it) }
+                    }
+                }
+            }
+        }
+        if (entries.isEmpty()) return@doLast
+        val tmpFile = temporaryDir.resolve("kernel-provider-services.txt")
+        tmpFile.writeText(entries.joinToString("\n", postfix = "\n"))
+        ant.withGroovyBuilder {
+            "zip"(
+                "destfile" to jar.absolutePath,
+                "update" to true,
+            ) {
+                "zipfileset"(
+                    "file" to tmpFile.absolutePath,
+                    "fullpath" to servicePath,
+                )
+            }
+        }
+    }
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
## Summary

`com.gradleup.shadow:9.4.1` `mergeServiceFiles()` silently drops one of two co-located `META-INF/services/<X>` files when both `skainet-backend-cpu` and `skainet-backend-native-cpu` are on the classpath. The merged file ends up with only `Scalar` + `PanamaVector` entries; `NativeKernelProviderFactory` disappears even though the native lib + classes are bundled in the JAR. Resulting shadow JAR silently runs Panama priority-50 instead of the native priority-100 path.

This PR fixes the two CLIs in transformers that ship as shadow JARs and pull `skainet-backend-cpu` (and will pull `skainet-backend-native-cpu` once SKaiNET 0.22.0 lands):
- **`kllama-cli`** — direct dependency on `kllama` runtime, future-proofed
- **`skainet-cli`** — canonical generic CLI (llama + gemma); transitive dep on `skainet-backend-native-cpu` via kllama runtime

`kbert-cli` is **not** included — bert-cli is a candidate to migrate to a future `skainet-examples` repo (CLIs are demo/tooling, not the primary consumer surface), so fixing it in transformers is short-lived. Will follow if it stays.

## Why this matters (and why it doesn't matter for Spring AI consumers)

The primary consumer surface is the programmatic API in `llm-api` (`ChatModel` / `EmbeddingModel` / `ToolDefinition` — Spring AI-shaped) and the Java surface (`KLlamaJava` / `JavaTools.definition` / `JavaAgentLoop`). Spring Boot apps consuming via Maven preserve each dependency JAR intact under `BOOT-INF/lib/`; ServiceLoader reads each file at runtime, no merge needed — these consumers are immune to this bug.

The bug only bites shadow-jar CLIs (and any other fat-jar packaging that needs explicit service-file merging). Fixing the two CLIs above keeps the demo path consistent with what the API users get for free.

## Workaround

`doLast` after `mergeServiceFiles()` that re-reads every runtime-classpath JAR's services file at the same path, accumulates the union into a `LinkedHashSet` (preserves order, dedups), and rewrites the fat JAR's entry via Ant's `zip update` task. Harmless when only one source file exists — the doLast just rewrites the same entries it found.

## Test plan

- [x] `:llm-apps:kllama-cli:shadowJar` green on develop (skainet 0.21.0) — merged file matches pre-PR content
- [x] `:llm-apps:skainet-cli:shadowJar` green on develop — merged file matches pre-PR content
- [x] On `local-022-test` (skainet 0.22.0 from mavenLocal, native-cpu wired into kllama runtime): kllama-cli's merged services file contains all 3 entries; `KernelRegistry.bestAvailable()` correctly hands out the native provider
- [ ] CI green on this PR

## Out of scope

- **`kbert-cli`** — candidate for migration to `skainet-examples` repo per the CLI consolidation conversation. Will be fixed wherever it ends up living.
- **Proper upstream fix** in com.gradleup.shadow — out of our control; this PR is a workaround until that lands.
- **CLI consolidation** (move kllama-cli + kbert-cli + kllama-java-sample to a separate examples repo) — separate strategic question; orthogonal to this bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)