### PR TITLE
feat(gemma4): text-only ChatModel API for SafeTensors checkpoints

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
@@ -185,10 +185,42 @@ class GGUFTokenizer private constructor(
                 }
             }
 
-            val strategy = BPEStrategy
-            println("Tokenizer: BPE (from tokenizer.json, vocab=${vocab.size}, special=${addedTokenIds.size})")
+            // Pick strategy by sniffing the vocab's space-marker convention:
+            //  - GPT-2 / OpenAI BPE tokenizers prefix word-leading tokens with
+            //    `Ġ` (Ġ) → BPEStrategy
+            //  - SentencePiece-style (LLaMA, Mistral, Gemma) use `▁` (▁)
+            //    → SentencePieceStrategy
+            // Without this, decoding tokens like `▁hello` returns `▁hello`
+            // instead of ` hello`, since BPEStrategy.postprocess only knows
+            // how to strip Ġ.
+            val sentencePieceMarker = "▁"
+            val gpt2Marker = "Ġ"
+            val spVotes = vocab.count { it.startsWith(sentencePieceMarker) }
+            val bpeVotes = vocab.count { it.startsWith(gpt2Marker) }
+            val strategy: TokenizerStrategy = if (spVotes > bpeVotes) SentencePieceStrategy else BPEStrategy
+            val strategyLabel = if (strategy === SentencePieceStrategy) "SentencePiece" else "BPE"
+            // SentencePiece tokenizers shipped via HF `tokenizer.json` (Gemma 4,
+            // LLaMA-3) typically set `add_dummy_prefix=false` — the modern
+            // convention. Without this, encoding `"Hi"` would produce `[▁Hi]`
+            // (id 18428) instead of `[Hi]` (id 10979), shifting every prompt
+            // token by one and breaking parity with HF reference outputs. The
+            // GGUF path reads `tokenizer.ggml.add_space_prefix` directly; this
+            // is the JSON-path equivalent default.
+            val sentencePieceAddSpace = false
+            println(
+                "Tokenizer: $strategyLabel (from tokenizer.json, vocab=${vocab.size}, special=${addedTokenIds.size})"
+            )
 
-            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy, tokenTypes)
+            return GGUFTokenizer(
+                vocab = vocab,
+                scores = scores,
+                _bosTokenId = bosTokenId,
+                _eosTokenId = eosTokenId,
+                unkTokenId = unkTokenId,
+                strategy = strategy,
+                tokenTypes = tokenTypes,
+                addSpacePrefix = if (strategy === SentencePieceStrategy) sentencePieceAddSpace else DEFAULT_ADD_SPACE_PREFIX,
+            )
         }
 
         private fun findMatchingBrace(s: String, start: Int): Int {

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
@@ -99,6 +99,13 @@ class GGUFTokenizer private constructor(
             var eosTokenId = DEFAULT_EOS_TOKEN_ID
             var unkTokenId = DEFAULT_UNK_TOKEN_ID
 
+            // Track added-token IDs so we can mark them as CONTROL in
+            // tokenTypes — that's what flips the atomic-special-token branch
+            // in `encode()` on. Without this, `<bos>`, `<|turn>`, `<turn|>`
+            // etc. get split into per-character BPE pieces and the model
+            // sees a mangled prompt instead of the chat-template control
+            // grammar it was trained on.
+            val addedTokenIds = mutableListOf<Int>()
             val addedTokensStart = json.indexOf("\"added_tokens\"")
             if (addedTokensStart >= 0) {
                 val arrStart = json.indexOf('[', addedTokensStart)
@@ -117,9 +124,12 @@ class GGUFTokenizer private constructor(
                             val id = idMatch.groupValues[1].toInt()
                             val content = unescapeJsonString(contentMatch.groupValues[1])
                             vocabMap[content] = id
+                            addedTokenIds += id
                             when {
                                 content.contains("begin_of_text") || content == "<s>" -> bosTokenId = id
                                 content.contains("end_of_text") || content == "</s>" -> eosTokenId = id
+                                content == "<bos>" -> bosTokenId = id
+                                content == "<eos>" -> eosTokenId = id
                                 content == "<unk>" -> unkTokenId = id
                             }
                         }
@@ -131,6 +141,19 @@ class GGUFTokenizer private constructor(
             val vocab = MutableList(totalVocabSize) { "<unk>" }
             for ((token, id) in vocabMap) {
                 if (id < vocab.size) vocab[id] = token
+            }
+
+            // Mark every added token (BOS/EOS/PAD plus chat-template specials
+            // like `<|turn>`, tool delimiters, etc.) as TOKEN_TYPE_CONTROL so
+            // the encoder treats them atomically. The HF `tokenizer.json`
+            // doesn't carry the GGUF `tokenizer.ggml.token_type` array; this
+            // reconstructs the equivalent from `added_tokens`.
+            val tokenTypes: IntArray? = if (addedTokenIds.isEmpty()) null else {
+                IntArray(totalVocabSize).also { arr ->
+                    for (id in addedTokenIds) {
+                        if (id in arr.indices) arr[id] = TOKEN_TYPE_CONTROL
+                    }
+                }
             }
 
             if (debug) println("DEBUG: Total vocab size = ${vocab.size}, BOS=$bosTokenId, EOS=$eosTokenId")
@@ -163,9 +186,9 @@ class GGUFTokenizer private constructor(
             }
 
             val strategy = BPEStrategy
-            println("Tokenizer: BPE (from tokenizer.json, vocab=${vocab.size})")
+            println("Tokenizer: BPE (from tokenizer.json, vocab=${vocab.size}, special=${addedTokenIds.size})")
 
-            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy)
+            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy, tokenTypes)
         }
 
         private fun findMatchingBrace(s: String, start: Int): Int {

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4SafeTensorsWeightLoader.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4SafeTensorsWeightLoader.kt
@@ -91,13 +91,40 @@ public class Gemma4SafeTensorsWeightLoader(
         // Output weight (weight tying - reuse embed_tokens)
         tensorsByGgufName[Gemma4TensorNames.OUTPUT_WEIGHT] = embedTensor
 
-        // Optional PLE global tensors
-        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
-            HF_PER_LAYER_TOKEN_EMBD, Gemma4TensorNames.PER_LAYER_TOKEN_EMBD, transpose = false)
-        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
-            HF_PER_LAYER_MODEL_PROJ, Gemma4TensorNames.PER_LAYER_MODEL_PROJ, transpose = false)
-        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
-            HF_PER_LAYER_PROJ_NORM, Gemma4TensorNames.PER_LAYER_PROJ_NORM, transpose = false)
+        // Optional PLE global tensors. HF names changed in Gemma 4 vs the
+        // earlier "per_layer_*" convention used by Gemma 3n / GGUF; map both
+        // so synthetic GGUF-style fixtures keep working alongside real HF
+        // checkpoints.
+        //
+        // The token-embeddings-per-layer tensor on real Gemma-4 E2B is
+        // [vocab_size, num_layers, per_layer_dim] in BF16 — 4.7 GB raw, well
+        // over the 2 GB JVM ByteArray limit our reader uses. The GGUF path
+        // sidesteps this by keeping the table Q6_K-packed (~1.8 GB) with a
+        // dedicated row-dequant data type. We don't have an equivalent for
+        // SafeTensors yet, so when the BF16 source is too large we skip the
+        // load — leaving `per_layer_token_embd.weight` absent from the
+        // tensor map, which auto-disables PLE in `GemmaNetworkLoader`. The
+        // model still runs (sandwich norms, layer_output_scale and softcap
+        // are intact) but without the per-layer side-channel signal. PLE
+        // support on the SafeTensors path is tracked separately.
+        loadFirstExistingIfFits(
+            ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            ggufName = Gemma4TensorNames.PER_LAYER_TOKEN_EMBD,
+            hfCandidates = listOf(HF_EMBED_TOKENS_PER_LAYER, HF_PER_LAYER_TOKEN_EMBD),
+            transpose = false,
+        )
+        loadFirstExisting(
+            ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            ggufName = Gemma4TensorNames.PER_LAYER_MODEL_PROJ,
+            hfCandidates = listOf(HF_PER_LAYER_MODEL_PROJECTION, HF_PER_LAYER_MODEL_PROJ),
+            transpose = false,
+        )
+        loadFirstExisting(
+            ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            ggufName = Gemma4TensorNames.PER_LAYER_PROJ_NORM,
+            hfCandidates = listOf(HF_PER_LAYER_PROJECTION_NORM, HF_PER_LAYER_PROJ_NORM),
+            transpose = false,
+        )
     }
 
     private fun <T : DType> loadLayerTensors(
@@ -108,11 +135,11 @@ public class Gemma4SafeTensorsWeightLoader(
         tensorsByGgufName: MutableMap<String, Tensor<T, Float>>,
         layer: Int
     ) {
-        // Input layernorm
+        // Pre-attention input layernorm (HF: input_layernorm; GGUF slot: attn_norm).
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
             hfInputLayernorm(layer), Gemma4TensorNames.inputLayernorm(layer), transpose = false)
 
-        // Attention weights
+        // Attention projections.
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
             hfAttnQ(layer), Gemma4TensorNames.attnQ(layer))
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
@@ -122,11 +149,22 @@ public class Gemma4SafeTensorsWeightLoader(
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
             hfAttnO(layer), Gemma4TensorNames.attnOut(layer))
 
-        // Post-attention layernorm
+        // Sandwich norms — Gemma 4 has FOUR norms per block:
+        //  - attn_norm           ← input_layernorm (already loaded above)
+        //  - post_attention_norm ← post_attention_layernorm    (Gemma-4 only)
+        //  - ffn_norm            ← pre_feedforward_layernorm   (Gemma-4 only)
+        //  - post_ffw_norm       ← post_feedforward_layernorm  (Gemma-4 only)
+        // The GGUF naming on `Gemma4TensorNames.postAttentionLayernorm` is a
+        // legacy alias for the pre-FFN norm slot (`ffn_norm`); the proper
+        // Gemma-4 source for that slot is HF `pre_feedforward_layernorm`.
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
-            hfPostAttnLayernorm(layer), Gemma4TensorNames.postAttentionLayernorm(layer), transpose = false)
+            hfPostAttnLayernorm(layer), Gemma4TensorNames.postAttentionNorm(layer), transpose = false)
+        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            hfPreFfwLayernorm(layer), Gemma4TensorNames.postAttentionLayernorm(layer), transpose = false)
+        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            hfPostFfwLayernorm(layer), Gemma4TensorNames.postFfwNorm(layer), transpose = false)
 
-        // MLP weights
+        // MLP weights.
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
             hfMlpGate(layer), Gemma4TensorNames.ffnGate(layer))
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
@@ -134,11 +172,21 @@ public class Gemma4SafeTensorsWeightLoader(
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
             hfMlpDown(layer), Gemma4TensorNames.ffnDown(layer))
 
-        // Optional PLE per-layer tensors
+        // Per-layer scalar (HF: `layer_scalar`, no `.weight` suffix; scalar shape).
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
-            hfPerLayerProjection(layer), Gemma4TensorNames.perLayerInput(layer))
+            hfLayerScalar(layer), Gemma4TensorNames.layerOutputScale(layer), transpose = false)
 
-        // Optional QK normalization
+        // Optional Per-Layer Embedding (PLE) per-layer tensors.
+        // The HF projection sends [B,S,perLayerDim] back into the residual at
+        // hidden_size, so it goes into the `proj` slot, NOT `per_layer_input`.
+        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            hfPerLayerInputGate(layer), Gemma4TensorNames.pleInpGate(layer))
+        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            hfPerLayerProjection(layer), Gemma4TensorNames.pleProj(layer))
+        loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
+            hfPostPerLayerInputNorm(layer), Gemma4TensorNames.plePostNorm(layer), transpose = false)
+
+        // Optional QK normalization (per-head Q/K RMSNorm).
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
             hfAttnQNorm(layer), Gemma4TensorNames.attnQNorm(layer), transpose = false)
         loadTensorIfExists(ctx, dtype, reader, tensorsByHfName, tensorsByGgufName,
@@ -159,6 +207,51 @@ public class Gemma4SafeTensorsWeightLoader(
         if (info != null) {
             val tensor = loadAndConvertTensor<T>(ctx, dtype, reader, info, transpose)
             tensorsByGgufName[ggufName] = tensor
+        }
+    }
+
+    private fun <T : DType> loadFirstExisting(
+        ctx: ExecutionContext,
+        dtype: KClass<T>,
+        reader: StreamingShardedSafeTensorsReader,
+        tensorsByHfName: Map<String, ShardedTensorInfo>,
+        tensorsByGgufName: MutableMap<String, Tensor<T, Float>>,
+        ggufName: String,
+        hfCandidates: List<String>,
+        transpose: Boolean = false
+    ) {
+        for (hfName in hfCandidates) {
+            val info = tensorsByHfName[hfName] ?: continue
+            tensorsByGgufName[ggufName] = loadAndConvertTensor<T>(ctx, dtype, reader, info, transpose)
+            return
+        }
+    }
+
+    /**
+     * Variant of [loadFirstExisting] that silently skips the load if the
+     * raw on-disk tensor exceeds [MAX_BYTES_PER_TENSOR] (the JVM ByteArray
+     * limit our streaming reader is bound by). Used for PLE globals on
+     * real Gemma-4 SafeTensors checkpoints, where the BF16 source is too
+     * large for the eager reader path.
+     */
+    private fun <T : DType> loadFirstExistingIfFits(
+        ctx: ExecutionContext,
+        dtype: KClass<T>,
+        reader: StreamingShardedSafeTensorsReader,
+        tensorsByHfName: Map<String, ShardedTensorInfo>,
+        tensorsByGgufName: MutableMap<String, Tensor<T, Float>>,
+        ggufName: String,
+        hfCandidates: List<String>,
+        transpose: Boolean = false
+    ) {
+        for (hfName in hfCandidates) {
+            val info = tensorsByHfName[hfName] ?: continue
+            if (info.sizeInBytes > MAX_BYTES_PER_TENSOR) {
+                // Leave the slot empty so PLE auto-detection turns off cleanly.
+                return
+            }
+            tensorsByGgufName[ggufName] = loadAndConvertTensor<T>(ctx, dtype, reader, info, transpose)
+            return
         }
     }
 
@@ -202,9 +295,21 @@ public class Gemma4SafeTensorsWeightLoader(
     }
 
     private companion object {
+        // The streaming sharded reader returns each tensor as a single
+        // ByteArray, which the JVM caps at Int.MAX_VALUE bytes. Keep a
+        // little headroom for safety.
+        const val MAX_BYTES_PER_TENSOR: Long = Int.MAX_VALUE.toLong() - 1024L
+
         const val HF_EMBED_TOKENS = "model.language_model.embed_tokens.weight"
         const val HF_OUTPUT_NORM = "model.language_model.norm.weight"
 
+        // Gemma 4 (HF transformers ≥ 5.5) PLE global tensor names.
+        const val HF_EMBED_TOKENS_PER_LAYER = "model.language_model.embed_tokens_per_layer.weight"
+        const val HF_PER_LAYER_MODEL_PROJECTION = "model.language_model.per_layer_model_projection.weight"
+        const val HF_PER_LAYER_PROJECTION_NORM = "model.language_model.per_layer_projection_norm.weight"
+
+        // Legacy aliases (Gemma 3n / GGUF-converted checkpoints). Tried as a
+        // fallback if the new HF names are absent.
         const val HF_PER_LAYER_TOKEN_EMBD = "model.language_model.per_layer_token_embd.weight"
         const val HF_PER_LAYER_MODEL_PROJ = "model.language_model.per_layer_model_proj.weight"
         const val HF_PER_LAYER_PROJ_NORM = "model.language_model.per_layer_proj_norm.weight"
@@ -215,10 +320,15 @@ public class Gemma4SafeTensorsWeightLoader(
         fun hfAttnV(layer: Int) = "model.language_model.layers.$layer.self_attn.v_proj.weight"
         fun hfAttnO(layer: Int) = "model.language_model.layers.$layer.self_attn.o_proj.weight"
         fun hfPostAttnLayernorm(layer: Int) = "model.language_model.layers.$layer.post_attention_layernorm.weight"
+        fun hfPreFfwLayernorm(layer: Int) = "model.language_model.layers.$layer.pre_feedforward_layernorm.weight"
+        fun hfPostFfwLayernorm(layer: Int) = "model.language_model.layers.$layer.post_feedforward_layernorm.weight"
+        fun hfLayerScalar(layer: Int) = "model.language_model.layers.$layer.layer_scalar"
         fun hfMlpGate(layer: Int) = "model.language_model.layers.$layer.mlp.gate_proj.weight"
         fun hfMlpUp(layer: Int) = "model.language_model.layers.$layer.mlp.up_proj.weight"
         fun hfMlpDown(layer: Int) = "model.language_model.layers.$layer.mlp.down_proj.weight"
         fun hfPerLayerProjection(layer: Int) = "model.language_model.layers.$layer.per_layer_projection.weight"
+        fun hfPerLayerInputGate(layer: Int) = "model.language_model.layers.$layer.per_layer_input_gate.weight"
+        fun hfPostPerLayerInputNorm(layer: Int) = "model.language_model.layers.$layer.post_per_layer_input_norm.weight"
         fun hfAttnQNorm(layer: Int) = "model.language_model.layers.$layer.self_attn.q_norm.weight"
         fun hfAttnKNorm(layer: Int) = "model.language_model.layers.$layer.self_attn.k_norm.weight"
     }

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaPerLayerTokenEmbedTensorData.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaPerLayerTokenEmbedTensorData.kt
@@ -37,7 +37,7 @@ public class GemmaPerLayerTokenEmbedTensorData(
     logicalShape: Shape,
     public val quantType: GGMLQuantizationType,
     public val packedBytes: ByteArray
-) : TensorData<FP32, Float> {
+) : TensorData<FP32, Float>, RowDequantSource {
 
     override val shape: Shape = logicalShape
 
@@ -71,7 +71,7 @@ public class GemmaPerLayerTokenEmbedTensorData(
      * Dequant one row (vocabulary entry) to FP32. Returns a fresh
      * `FloatArray` of length `shape[1]`.
      */
-    public fun dequantRow(rowIdx: Int): FloatArray {
+    public override fun dequantRow(rowIdx: Int): FloatArray {
         require(rowIdx in 0 until shape[0]) {
             "rowIdx $rowIdx out of range [0, ${shape[0]})"
         }

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/PerLayerEmbedding.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/PerLayerEmbedding.kt
@@ -145,10 +145,11 @@ public class PerLayerEmbedding<T : DType, V>(
         })
         val rawBuf = FloatArray(batch * seq * perLayerTotal)
         val weightData = embedTokensWeight.data
-        if (weightData is GemmaPerLayerTokenEmbedTensorData) {
-            // Quant bytes kept intact on load (Gemma 4 E2B path). Dequant only
-            // the rows we need — cheap for decode (batch*seq=1) even on the
-            // 9 GB logical embedding.
+        if (weightData is RowDequantSource) {
+            // Source kept in its packed/encoded form on load — Q-bytes for
+            // the GGUF path, BF16 mmap for the SafeTensors path. We dequant
+            // only the rows we need (one per token per decode step), even
+            // though the full logical tensor is much larger than 2 GB.
             for (i in 0 until batch * seq) {
                 val tokenId = idsFlat[i]
                 require(tokenId in 0 until vocabSize) {

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/RowDequantSource.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/RowDequantSource.kt
@@ -1,0 +1,27 @@
+package sk.ainet.models.gemma
+
+/**
+ * Marker for [sk.ainet.lang.tensor.data.TensorData] implementations that
+ * cannot be materialised as a single dense `FloatArray` (the logical
+ * tensor exceeds `Int.MAX_VALUE` elements / 2 GB) and instead expose a
+ * cheap per-row dequantisation API.
+ *
+ * `PerLayerEmbedding.compute` calls [dequantRow] for the small number of
+ * rows actually touched per decode step (one per token). Callers that
+ * see a tensor implementing this interface MUST use [dequantRow] instead
+ * of `copyToFloatArray()`.
+ *
+ * Implementors:
+ *  - [GemmaPerLayerTokenEmbedTensorData] — Q-quantised GGUF source, dequants
+ *    Q6_K bytes via the GGUF `DequantOps` table.
+ *  - `SafeTensorsPerLayerTokenEmbedTensorData` (JVM-only) — BF16/F16 source,
+ *    dequants by reading the half-float for each column out of an mmap'd
+ *    file region.
+ */
+public interface RowDequantSource {
+    /**
+     * Dequantise one logical row of the embedding table to a fresh
+     * `FloatArray` of length equal to the row width (`shape[1]`).
+     */
+    public fun dequantRow(rowIdx: Int): FloatArray
+}

--- a/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/Gemma4SafeTensorsMappedPle.kt
+++ b/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/Gemma4SafeTensorsMappedPle.kt
@@ -1,0 +1,112 @@
+package sk.ainet.models.gemma
+
+import java.lang.foreign.Arena
+import java.nio.channels.FileChannel
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.safetensors.StreamingShardedSafeTensorsReader
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+
+/**
+ * JVM-only post-processor for [Gemma4Weights] that injects the
+ * `embed_tokens_per_layer` table via a memory-mapped read when the source
+ * tensor is too large for the eager `ByteArray`-based loader path.
+ *
+ * `Gemma4SafeTensorsWeightLoader` skips this tensor when its raw size
+ * exceeds the JVM `ByteArray` limit (~2 GB; the BF16 table on Gemma 4 E2B
+ * is 4.7 GB). Calling this after the load mmap's the tensor's byte
+ * region, wraps it in a [SafeTensorsPerLayerTokenEmbedTensorData] for
+ * lazy per-row dequantisation, and inserts it under the GGUF-style key
+ * the rest of the runtime expects, which flips PLE auto-detection on in
+ * `GemmaNetworkLoader`.
+ *
+ * Lifetime: the returned tensor's storage is owned by [arena]; close the
+ * arena (typically when the chat model is closed) to release the mmap'd
+ * region. Don't close it earlier — `PerLayerEmbedding.compute` reads
+ * rows on every decode step.
+ */
+public object Gemma4SafeTensorsMappedPle {
+
+    private const val HF_EMBED_TOKENS_PER_LAYER = "model.language_model.embed_tokens_per_layer.weight"
+
+    /**
+     * If the embed-tokens-per-layer tensor is absent from [weights]
+     * (typically because the eager loader skipped it for size), mmap it
+     * from the SafeTensors checkpoint at [indexPath] and return an
+     * updated [Gemma4Weights] with the tensor injected.
+     *
+     * Returns [weights] unchanged when:
+     *  - the tensor is already loaded (small fixture, F32 source, etc.), or
+     *  - the checkpoint doesn't contain the tensor at all (unimodal Gemma 4
+     *    variants without PLE).
+     *
+     * @param indexPath path to `model.safetensors.index.json` (or a
+     *   directory / single shard the original loader was given).
+     * @param ctx execution context used to wrap the new [TensorData].
+     * @param arena arena that owns the mmap'd region's lifetime.
+     */
+    public fun injectIfMissing(
+        weights: Gemma4Weights<FP32, Float>,
+        indexPath: String,
+        ctx: ExecutionContext,
+        arena: Arena,
+    ): Gemma4Weights<FP32, Float> {
+        if (weights.tensors.containsKey(Gemma4TensorNames.PER_LAYER_TOKEN_EMBD)) return weights
+
+        val reader = runCatching {
+            kotlinx.coroutines.runBlocking {
+                StreamingShardedSafeTensorsReader.openFromIndex(indexPath)
+            }
+        }.getOrNull() ?: return weights
+
+        return reader.use { r ->
+            val info = r.tensors.firstOrNull { it.name == HF_EMBED_TOKENS_PER_LAYER }
+                ?: return@use weights
+
+            val indexDir: Path = Paths.get(indexPath).let { p ->
+                if (p.toFile().isDirectory) p else (p.parent ?: Paths.get("."))
+            }
+            val shardPath = indexDir.resolve(info.shardFilename)
+
+            val segment = FileChannel.open(shardPath, StandardOpenOption.READ).use { fc ->
+                fc.map(
+                    FileChannel.MapMode.READ_ONLY,
+                    info.absoluteDataOffset,
+                    info.sizeInBytes,
+                    arena,
+                )
+            }
+
+            val logicalShape = Shape(*info.shape.map { it.toInt() }.toIntArray()).let {
+                if (it.rank == 2) it else flattenTrailingDims(it)
+            }
+            val data = SafeTensorsPerLayerTokenEmbedTensorData(
+                logicalShape = logicalShape,
+                segment = segment,
+                sourceDtype = info.dtype,
+            )
+            val tensor = ctx.fromData(data, FP32::class)
+            weights.copy(
+                tensors = weights.tensors + (Gemma4TensorNames.PER_LAYER_TOKEN_EMBD to tensor),
+            )
+        }
+    }
+
+    /**
+     * Collapse a rank-3+ shape into a 2-D `[rows, cols]` shape by
+     * multiplying out every dimension after the first. Used in case a
+     * future Gemma-4 checkpoint stores the table as
+     * `[vocab, num_layers, per_layer_dim]` instead of the flat
+     * `[vocab, per_layer_total]` we observe today on E2B.
+     */
+    private fun flattenTrailingDims(shape: Shape): Shape {
+        require(shape.rank >= 2) { "Cannot flatten rank-${shape.rank} shape: $shape" }
+        val rows = shape[0]
+        var cols = 1
+        for (i in 1 until shape.rank) cols *= shape[i]
+        return Shape(rows, cols)
+    }
+}

--- a/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/SafeTensorsPerLayerTokenEmbedTensorData.kt
+++ b/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/SafeTensorsPerLayerTokenEmbedTensorData.kt
@@ -1,0 +1,143 @@
+package sk.ainet.models.gemma
+
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.types.FP32
+
+/**
+ * [TensorData] wrapper for the Gemma 4 `embed_tokens_per_layer` table when
+ * loaded from a SafeTensors checkpoint. Wraps a memory-mapped region of
+ * raw BF16 bytes and provides cheap per-row dequantisation via
+ * [dequantRow]; the full logical tensor (`[vocab × num_layers × per_layer_dim]`,
+ * ~9.4 GB FP32 on Gemma 4 E2B) is never materialised.
+ *
+ * The complementary GGUF path is [GemmaPerLayerTokenEmbedTensorData], which
+ * wraps Q6_K-packed bytes; both implement [RowDequantSource] so
+ * [PerLayerEmbedding.compute] can dispatch uniformly.
+ *
+ * `get` / `set` are unsupported by design — this class is consumed
+ * exclusively via [dequantRow]. If anything else in the pipeline tries
+ * to treat it as a normal float tensor it will throw loudly rather than
+ * silently producing wrong results.
+ *
+ * Currently supports BF16 source only (the dtype of the real
+ * `google/gemma-4-e2b-it` checkpoint). F16 / F32 sources are easy to add
+ * by branching in [dequantRow] on [sourceDtype].
+ *
+ * @param logicalShape 2-D logical shape `[vocab_size, per_layer_total]`.
+ * @param segment memory-mapped, read-only region containing the tensor's
+ *   raw bytes laid out row-major along `[vocab_size, per_layer_total]`.
+ *   Lifetime is owned by the caller — typically an [java.lang.foreign.Arena]
+ *   tied to the chat model's lifecycle.
+ * @param sourceDtype on-disk element dtype. The accepted set today is
+ *   `"BF16"`; `"F16"` and `"F32"` will be added when a checkpoint surfaces
+ *   that needs them.
+ */
+public class SafeTensorsPerLayerTokenEmbedTensorData(
+    logicalShape: Shape,
+    private val segment: MemorySegment,
+    private val sourceDtype: String,
+) : TensorData<FP32, Float>, RowDequantSource {
+
+    override val shape: Shape = logicalShape
+
+    private val rowWidth: Int
+    private val bytesPerElement: Long
+    private val bytesPerRow: Long
+
+    init {
+        require(logicalShape.rank == 2) {
+            "SafeTensorsPerLayerTokenEmbedTensorData requires 2-D logical shape, got $logicalShape"
+        }
+        rowWidth = logicalShape[1]
+        bytesPerElement = when (sourceDtype.uppercase()) {
+            "BF16", "F16" -> 2L
+            "F32" -> 4L
+            else -> error("Unsupported SafeTensors PLE dtype: $sourceDtype (expected BF16 / F16 / F32)")
+        }
+        bytesPerRow = rowWidth.toLong() * bytesPerElement
+        val expected = logicalShape[0].toLong() * bytesPerRow
+        require(segment.byteSize() >= expected) {
+            "Mapped segment is ${segment.byteSize()} bytes but tensor needs $expected " +
+                "(shape=$logicalShape dtype=$sourceDtype)"
+        }
+    }
+
+    override fun dequantRow(rowIdx: Int): FloatArray {
+        require(rowIdx in 0 until shape[0]) {
+            "rowIdx $rowIdx out of range [0, ${shape[0]})"
+        }
+        val out = FloatArray(rowWidth)
+        val rowBase = rowIdx.toLong() * bytesPerRow
+        when (sourceDtype.uppercase()) {
+            "BF16" -> {
+                // BF16 stores the upper 16 bits of an FP32 value. Reconstruct
+                // by zero-extending into the high half of an Int and reading
+                // as a float. SafeTensors is little-endian; JVM_SHORT_LE
+                // matches that on every platform.
+                for (i in 0 until rowWidth) {
+                    val bits = segment.get(
+                        ValueLayout.JAVA_SHORT.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN),
+                        rowBase + i.toLong() * 2L
+                    ).toInt() and 0xFFFF
+                    out[i] = Float.fromBits(bits shl 16)
+                }
+            }
+            "F16" -> {
+                for (i in 0 until rowWidth) {
+                    val bits = segment.get(
+                        ValueLayout.JAVA_SHORT.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN),
+                        rowBase + i.toLong() * 2L
+                    ).toInt() and 0xFFFF
+                    out[i] = halfBitsToFloat(bits)
+                }
+            }
+            "F32" -> {
+                for (i in 0 until rowWidth) {
+                    out[i] = segment.get(
+                        ValueLayout.JAVA_FLOAT.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN),
+                        rowBase + i.toLong() * 4L
+                    )
+                }
+            }
+        }
+        return out
+    }
+
+    override fun get(vararg indices: Int): Float =
+        error(
+            "SafeTensorsPerLayerTokenEmbedTensorData.get is unsupported — use dequantRow() " +
+                "instead. The full logical table is too large to materialise as a JVM " +
+                "FloatArray (> Int.MAX_VALUE elements on Gemma 4 E2B)."
+        )
+
+    override fun set(vararg indices: Int, value: Float) {
+        error("SafeTensorsPerLayerTokenEmbedTensorData is read-only.")
+    }
+
+    private companion object {
+        // IEEE 754 half-precision → single-precision. Adapted from the
+        // standard reference impl. Branchless on subnormal/inf/nan.
+        fun halfBitsToFloat(h: Int): Float {
+            val sign = (h ushr 15) and 0x1
+            val exp = (h ushr 10) and 0x1F
+            val mant = h and 0x3FF
+            val fbits = when (exp) {
+                0 -> if (mant == 0) sign shl 31 else {
+                    // Subnormal: normalise.
+                    var m = mant
+                    var e = -1
+                    while ((m and 0x400) == 0) { m = m shl 1; e-- }
+                    val mantissa = (m and 0x3FF) shl 13
+                    val biased = (e + 127 + 1) and 0xFF
+                    (sign shl 31) or (biased shl 23) or mantissa
+                }
+                31 -> (sign shl 31) or (0xFF shl 23) or (mant shl 13)
+                else -> (sign shl 31) or ((exp + 112) shl 23) or (mant shl 13)
+            }
+            return Float.fromBits(fbits)
+        }
+    }
+}

--- a/llm-providers/src/main/kotlin/sk/ainet/llm/providers/SkaiNetChatModel.kt
+++ b/llm-providers/src/main/kotlin/sk/ainet/llm/providers/SkaiNetChatModel.kt
@@ -43,7 +43,15 @@ public class SkaiNetChatModel<T : DType>(
     private val chatTemplate: ChatTemplate,
     public override val defaultOptions: ChatOptions = ChatOptions.DEFAULTS,
     private val bosTokenId: Int = tokenizer.bosTokenId,
-    private val eosTokenId: Int = tokenizer.eosTokenId,
+    /**
+     * Stop-sequence token ids. Modern instruction-tuned models often expose
+     * multiple terminators in their `generation_config.json` — e.g. Gemma 4
+     * has `[1, 106, 50]` (`<eos>`, `<turn|>`, plus a chat-end variant). Pass
+     * the full set so a single `<turn|>` cleanly closes the response instead
+     * of running until `maxTokens`. Defaults to the tokenizer's primary EOS
+     * for backward compatibility with single-EOS callers.
+     */
+    private val eosTokenIds: Set<Int> = setOf(tokenizer.eosTokenId),
     private val random: Random = Random.Default,
     private val modelId: String? = null,
 ) : StreamingChatModel {
@@ -59,7 +67,7 @@ public class SkaiNetChatModel<T : DType>(
             maxTokens = opts.maxTokens ?: 512,
             temperature = opts.temperature ?: 0f,
         ) { tokenId ->
-            if (tokenId == eosTokenId) {
+            if (tokenId in eosTokenIds) {
                 finish = FinishReason.STOP
                 false
             } else {
@@ -103,7 +111,7 @@ public class SkaiNetChatModel<T : DType>(
                 temperature = opts.temperature ?: 0f,
             ) { tokenId ->
                 if (!isActive) return@runGenerationLoop false
-                if (tokenId == eosTokenId) {
+                if (tokenId in eosTokenIds) {
                     finish = FinishReason.STOP
                     return@runGenerationLoop false
                 }

--- a/llm-runtime/kgemma/build.gradle.kts
+++ b/llm-runtime/kgemma/build.gradle.kts
@@ -95,6 +95,11 @@ kotlin {
                 // kllama's `implementation(project(":llm-agent"))` isn't
                 // transitively visible by default.
                 implementation(project(":llm-agent"))
+                // Spring-AI-style ChatModel surface used by Gemma4ChatModel.
+                // llm-providers / llm-api are JVM-only today, so they live
+                // here rather than in commonMain.
+                implementation(project(":llm-providers"))
+                implementation(project(":llm-api"))
             }
         }
         val jvmTest by getting {

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
@@ -1,5 +1,6 @@
 package sk.ainet.apps.kgemma
 
+import java.lang.foreign.Arena
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -15,6 +16,9 @@ import sk.ainet.lang.tensor.data.MemorySegmentTensorDataFactory
 import sk.ainet.lang.types.FP32
 import sk.ainet.llm.api.ChatOptions
 import sk.ainet.llm.providers.SkaiNetChatModel
+import sk.ainet.models.gemma.Gemma4SafeTensorsMappedPle
+import sk.ainet.models.gemma.Gemma4SafeTensorsWeightLoader
+import sk.ainet.models.gemma.Gemma4Weights
 
 /**
  * One-call factory that wires a Gemma 4 SafeTensors checkpoint into the
@@ -91,9 +95,27 @@ public object Gemma4ChatModel {
                 allowQuantized = false,
             ),
         )
-        val runtime = runBlocking {
-            ingestion.loadDslRuntimeFromSafeTensors(resolvedIndex.toString())
-        }
+
+        // Two-step load so we can inject the mmap'd PLE token-embedding
+        // table between weight loading and DSL build. The eager loader
+        // skips that tensor when it exceeds the 2 GB ByteArray limit
+        // (4.7 GB BF16 on Gemma 4 E2B), and `injectIfMissing` re-attaches
+        // it via FileChannel.map. The shared arena owns the mmap'd region's
+        // lifetime — it intentionally outlives the model on a process basis;
+        // a follow-up will plumb explicit close via a wrapping ChatModel.
+        @Suppress("UNCHECKED_CAST")
+        val rawWeights = runBlocking {
+            Gemma4SafeTensorsWeightLoader(resolvedIndex.toString())
+                .loadToMap(ctx, FP32::class)
+        } as Gemma4Weights<FP32, Float>
+        val pleArena = Arena.ofShared()
+        val weights = Gemma4SafeTensorsMappedPle.injectIfMissing(
+            weights = rawWeights,
+            indexPath = resolvedIndex.toString(),
+            ctx = ctx,
+            arena = pleArena,
+        )
+        val runtime = ingestion.buildDslRuntime(weights)
 
         val tokenizerFile = modelDir.resolve("tokenizer.json")
         require(tokenizerFile.exists()) {

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import sk.ainet.apps.kllama.chat.Gemma4ChatTemplate
 import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
@@ -15,6 +16,10 @@ import sk.ainet.io.model.QuantPolicy
 import sk.ainet.lang.tensor.data.MemorySegmentTensorDataFactory
 import sk.ainet.lang.types.FP32
 import sk.ainet.llm.api.ChatOptions
+import sk.ainet.llm.api.ChatRequest
+import sk.ainet.llm.api.ChatResponse
+import sk.ainet.llm.api.ChatResponseChunk
+import sk.ainet.llm.api.StreamingChatModel
 import sk.ainet.llm.providers.SkaiNetChatModel
 import sk.ainet.models.gemma.Gemma4SafeTensorsMappedPle
 import sk.ainet.models.gemma.Gemma4SafeTensorsWeightLoader
@@ -81,7 +86,7 @@ public object Gemma4ChatModel {
         options: ChatOptions = ChatOptions.DEFAULTS,
         modelId: String? = "gemma4",
         enableThinking: Boolean = false,
-    ): SkaiNetChatModel<FP32> {
+    ): StreamingChatModel {
         val (resolvedIndex, modelDir) = resolveIndexAndDir(indexPath)
         require(resolvedIndex.exists()) {
             "SafeTensors index not found: $resolvedIndex"
@@ -136,7 +141,7 @@ public object Gemma4ChatModel {
         // the rendered prompt, and the tokenizer maps that string to the BOS
         // token id. SkaiNetChatModel.runGenerationLoop only prepends BOS if it
         // is not already first, so the natural construction does not double up.
-        return SkaiNetChatModel(
+        val delegate = SkaiNetChatModel(
             runtime = runtime,
             tokenizer = tokenizer,
             chatTemplate = chatTemplate,
@@ -144,6 +149,34 @@ public object Gemma4ChatModel {
             eosTokenIds = eosTokenIds,
             modelId = modelId,
         )
+        return ArenaScopedStreamingChatModel(delegate, pleArena)
+    }
+
+    /**
+     * Wraps a [SkaiNetChatModel] together with a JVM [Arena] that owns the
+     * memory-mapped PLE token-embedding region. Closing this propagates to
+     * both — `delegate.close()` resets the runtime, then `arena.close()`
+     * unmaps the file region, releasing the underlying file handle.
+     *
+     * Without this wrapper, the only way the mmap'd region got cleaned up
+     * was at JVM exit (the arena was unreachable but bound to a long-lived
+     * native segment). Fine for tests; not fine for any process that
+     * builds and discards multiple chat models.
+     */
+    private class ArenaScopedStreamingChatModel(
+        private val delegate: StreamingChatModel,
+        private val arena: Arena,
+    ) : StreamingChatModel {
+        override val defaultOptions: ChatOptions get() = delegate.defaultOptions
+        override fun call(request: ChatRequest): ChatResponse = delegate.call(request)
+        override fun stream(request: ChatRequest): Flow<ChatResponseChunk> = delegate.stream(request)
+        override fun close() {
+            try {
+                delegate.close()
+            } finally {
+                runCatching { arena.close() }
+            }
+        }
     }
 
     /**

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
@@ -1,0 +1,140 @@
+package sk.ainet.apps.kgemma
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlinx.coroutines.runBlocking
+import sk.ainet.apps.kllama.chat.Gemma4ChatTemplate
+import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.tensor.data.MemorySegmentTensorDataFactory
+import sk.ainet.lang.types.FP32
+import sk.ainet.llm.api.ChatOptions
+import sk.ainet.llm.providers.SkaiNetChatModel
+
+/**
+ * One-call factory that wires a Gemma 4 SafeTensors checkpoint into the
+ * Spring-AI-style [SkaiNetChatModel] surface for text-only chat.
+ *
+ * Composes the four already-existing pieces:
+ *  1. [Gemma4Ingestion.loadDslRuntimeFromSafeTensors] — produces an
+ *     `InferenceRuntime<FP32>` from the DSL `gemmaNetwork()` definition.
+ *  2. [GGUFTokenizer.fromTokenizerJson] — loads HF `tokenizer.json` next to
+ *     the index file (same loader the kgemma CLI uses).
+ *  3. [Gemma4ChatTemplate] — emits the official `<bos><|turn>…<turn|>` format.
+ *  4. [SkaiNetChatModel] — the neutral `ChatModel` / `StreamingChatModel` adapter.
+ *
+ * Caller experience:
+ *
+ * ```
+ * val model = Gemma4ChatModel.fromSafeTensors("/path/to/model.safetensors.index.json")
+ * println(model.call(ChatRequest("Hello!")).result.text)
+ * ```
+ *
+ * **Scope (v1):**
+ *  - FP32 SafeTensors only. Q4_K_M GGUF parity vs llama.cpp is a known open
+ *    issue and is intentionally not exercised by this factory.
+ *  - Text-only — no vision / audio.
+ *  - Tool calling parses correctly on the template side, but real-checkpoint
+ *    end-to-end tool calling is gated on the same parity bug.
+ *
+ * **Memory:** A full FP32 E2B checkpoint is ~20 GB resident — run with a heap
+ * sized for it (`-Xmx24g` or larger). The supplied [ExecutionContext] backs
+ * tensor data with a [MemorySegmentTensorDataFactory] by default; callers that
+ * already own a context can pass it in.
+ *
+ * **Threading:** [SkaiNetChatModel] is documented as not thread-safe — KV-cache
+ * state is mutated across forward passes. Use one instance per concurrent
+ * request.
+ */
+public object Gemma4ChatModel {
+
+    /**
+     * Build a [SkaiNetChatModel] for a Gemma 4 SafeTensors checkpoint.
+     *
+     * @param indexPath Either the `model.safetensors.index.json` (sharded
+     *   layout, recommended) OR the directory containing it / a single
+     *   `model.safetensors`. The factory resolves the model directory and
+     *   the actual index file from this argument.
+     * @param ctx Execution context for tensor allocation. A
+     *   [DirectCpuExecutionContext] backed by [MemorySegmentTensorDataFactory]
+     *   is the default — same construction the kgemma CLI uses.
+     * @param options Default [ChatOptions] applied when a [sk.ainet.llm.api.ChatRequest]
+     *   does not override them.
+     * @param modelId Optional identifier surfaced on every [sk.ainet.llm.api.ChatResponse].
+     * @param enableThinking Forwarded to [Gemma4ChatTemplate] — opt-in `<|think|>`
+     *   priming on the system turn. Off by default.
+     */
+    public fun fromSafeTensors(
+        indexPath: String,
+        ctx: ExecutionContext = DirectCpuExecutionContext(
+            tensorDataFactory = MemorySegmentTensorDataFactory()
+        ),
+        options: ChatOptions = ChatOptions.DEFAULTS,
+        modelId: String? = "gemma4",
+        enableThinking: Boolean = false,
+    ): SkaiNetChatModel<FP32> {
+        val (resolvedIndex, modelDir) = resolveIndexAndDir(indexPath)
+        require(resolvedIndex.exists()) {
+            "SafeTensors index not found: $resolvedIndex"
+        }
+
+        val ingestion = Gemma4Ingestion<FP32>(
+            ctx = ctx,
+            dtype = FP32::class,
+            config = Gemma4LoadConfig(
+                quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+                allowQuantized = false,
+            ),
+        )
+        val runtime = runBlocking {
+            ingestion.loadDslRuntimeFromSafeTensors(resolvedIndex.toString())
+        }
+
+        val tokenizerFile = modelDir.resolve("tokenizer.json")
+        require(tokenizerFile.exists()) {
+            "tokenizer.json not found alongside checkpoint at $modelDir"
+        }
+        val tokenizer = GGUFTokenizer.fromTokenizerJson(Files.readString(tokenizerFile))
+
+        val chatTemplate = Gemma4ChatTemplate(enableThinking = enableThinking)
+
+        // Gemma4ChatTemplate emits `<bos>` itself as the very first character of
+        // the rendered prompt, and the tokenizer maps that string to the BOS
+        // token id. SkaiNetChatModel.runGenerationLoop only prepends BOS if it
+        // is not already first, so the natural construction does not double up.
+        return SkaiNetChatModel(
+            runtime = runtime,
+            tokenizer = tokenizer,
+            chatTemplate = chatTemplate,
+            defaultOptions = options,
+            modelId = modelId,
+        )
+    }
+
+    private fun resolveIndexAndDir(input: String): Pair<Path, Path> {
+        val p = Paths.get(input)
+        return when {
+            p.isDirectory() -> {
+                val idx = p.resolve("model.safetensors.index.json")
+                val single = p.resolve("model.safetensors")
+                val chosen = if (idx.exists()) idx else single
+                chosen to p
+            }
+            p.fileName?.toString() == "model.safetensors.index.json" -> {
+                p to (p.parent ?: Paths.get("."))
+            }
+            p.fileName?.toString() == "model.safetensors" -> {
+                p to (p.parent ?: Paths.get("."))
+            }
+            else -> {
+                // Caller passed a custom path; treat its parent as the model dir.
+                p to (p.parent ?: Paths.get("."))
+            }
+        }
+    }
+}

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModel.kt
@@ -125,6 +125,13 @@ public object Gemma4ChatModel {
 
         val chatTemplate = Gemma4ChatTemplate(enableThinking = enableThinking)
 
+        // Gemma 4 ships multiple stop ids (`<eos>=1`, `<turn|>=106`, and the
+        // chat-end variant `50` per the released `generation_config.json`).
+        // Without all of them, greedy decoding will keep emitting `<turn|>`
+        // tokens past the natural turn boundary until `maxTokens` runs out.
+        val eosTokenIds = readEosTokenIds(modelDir)
+            ?: setOf(tokenizer.eosTokenId)
+
         // Gemma4ChatTemplate emits `<bos>` itself as the very first character of
         // the rendered prompt, and the tokenizer maps that string to the BOS
         // token id. SkaiNetChatModel.runGenerationLoop only prepends BOS if it
@@ -134,8 +141,36 @@ public object Gemma4ChatModel {
             tokenizer = tokenizer,
             chatTemplate = chatTemplate,
             defaultOptions = options,
+            eosTokenIds = eosTokenIds,
             modelId = modelId,
         )
+    }
+
+    /**
+     * Read `eos_token_id` from `generation_config.json` next to the
+     * checkpoint. Accepts either a scalar (`"eos_token_id": 1`) or a list
+     * (`"eos_token_id": [1, 106, 50]`); returns `null` if the file is
+     * missing or unparseable so the caller can fall back to the
+     * tokenizer's default.
+     */
+    private fun readEosTokenIds(modelDir: Path): Set<Int>? {
+        val genConfig = modelDir.resolve("generation_config.json")
+        if (!genConfig.exists()) return null
+        return runCatching {
+            val text = Files.readString(genConfig)
+            val arrayMatch = Regex("""\"eos_token_id\"\s*:\s*\[\s*([^\]]*)\]""").find(text)
+            if (arrayMatch != null) {
+                arrayMatch.groupValues[1]
+                    .split(',')
+                    .mapNotNull { it.trim().toIntOrNull() }
+                    .toSet()
+                    .takeIf { it.isNotEmpty() }
+            } else {
+                Regex("""\"eos_token_id\"\s*:\s*(\d+)""").find(text)
+                    ?.groupValues?.get(1)?.toIntOrNull()
+                    ?.let { setOf(it) }
+            }
+        }.getOrNull()
     }
 
     private fun resolveIndexAndDir(input: String): Pair<Path, Path> {

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModelSmokeTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModelSmokeTest.kt
@@ -1,0 +1,132 @@
+package sk.ainet.apps.kgemma
+
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import sk.ainet.llm.api.ChatOptions
+import sk.ainet.llm.api.ChatRequest
+import sk.ainet.llm.api.FinishReason
+
+/**
+ * End-to-end smoke test for [Gemma4ChatModel.fromSafeTensors] against a real
+ * Gemma 4 SafeTensors checkpoint. Proves the v1 wiring goal: SafeTensors →
+ * `InferenceRuntime` → `Tokenizer` → `Gemma4ChatTemplate` → `SkaiNetChatModel`
+ * produces non-empty text.
+ *
+ * Self-skips when `GEMMA4_E2B_SAFETENSORS_PATH` is not set so default CI stays
+ * green (full E2B FP32 is ~20 GB resident — opt-in only).
+ *
+ * Does NOT assert a fixed output prefix. Gemma 4 numerical parity on real
+ * weights is still being validated; the assertion bar is "coherent enough"
+ * (non-blank, decodable, reasonable finish reason).
+ */
+class Gemma4ChatModelSmokeTest {
+
+    @Test
+    fun `chat model call returns non-empty text on FP32 SafeTensors`() {
+        val indexPath = locateCheckpoint() ?: return
+        val maxTokens = probeMaxTokens(default = 32)
+
+        val model = Gemma4ChatModel.fromSafeTensors(
+            indexPath = indexPath.toString(),
+            options = ChatOptions(
+                temperature = 0f,
+                maxTokens = maxTokens,
+            ),
+        )
+
+        try {
+            val response = model.call(ChatRequest("Say hello in one short sentence."))
+
+            println("[smoke] modelId=${response.modelId}")
+            println("[smoke] finish=${response.generations.firstOrNull()?.finishReason}")
+            println("[smoke] usage=${response.usage}")
+            println("[smoke] text='${response.text.replace("\n", "\\n")}'")
+
+            assertTrue(response.text.isNotBlank(), "ChatModel produced blank text")
+            val finish = response.generations.firstOrNull()?.finishReason
+            assertNotNull(finish, "Missing finish reason")
+            assertTrue(
+                finish == FinishReason.STOP || finish == FinishReason.LENGTH ||
+                    finish == FinishReason.TOOL_CALL,
+                "Unexpected finish reason: $finish",
+            )
+            val usage = response.usage
+            assertNotNull(usage, "Usage should be reported")
+            assertTrue(usage.completionTokens > 0, "Expected at least one completion token")
+        } finally {
+            model.close()
+        }
+    }
+
+    @Test
+    fun `chat model stream yields chunks then a terminal chunk with finish reason`() {
+        val indexPath = locateCheckpoint() ?: return
+
+        val model = Gemma4ChatModel.fromSafeTensors(
+            indexPath = indexPath.toString(),
+            options = ChatOptions(
+                temperature = 0f,
+                maxTokens = probeMaxTokens(default = 16),
+            ),
+        )
+
+        try {
+            val chunks = runBlocking {
+                model.stream(ChatRequest("Hi.")).toList()
+            }
+            println("[smoke] stream produced ${chunks.size} chunks")
+
+            assertTrue(chunks.isNotEmpty(), "Stream produced no chunks")
+            val terminal = chunks.last()
+            assertNotNull(terminal.finishReason, "Terminal chunk missing finish reason")
+            val anyTextChunk = chunks.any { it.delta.isNotEmpty() }
+            assertTrue(anyTextChunk, "Stream had no non-empty delta chunk")
+        } finally {
+            model.close()
+        }
+    }
+
+    /**
+     * Optional override for the per-call generation budget. Lets a developer
+     * run a fast probe (e.g. `GEMMA4_SMOKE_MAX_TOKENS=4`) without recompiling.
+     */
+    private fun probeMaxTokens(default: Int): Int =
+        System.getenv("GEMMA4_SMOKE_MAX_TOKENS")?.trim()?.toIntOrNull()?.coerceAtLeast(1) ?: default
+
+    private fun locateCheckpoint(): Path? {
+        val raw = System.getenv("GEMMA4_E2B_SAFETENSORS_PATH")?.trim().orEmpty()
+        if (raw.isEmpty()) {
+            println("[skip] GEMMA4_E2B_SAFETENSORS_PATH not set.")
+            return null
+        }
+        val p = Path.of(raw)
+        if (!p.exists()) {
+            println("[skip] Path does not exist: $p")
+            return null
+        }
+        // Accept either the index file directly, the directory containing it,
+        // or a single-file model.safetensors layout.
+        val resolved = when {
+            p.isDirectory() -> {
+                val idx = p.resolve("model.safetensors.index.json")
+                val single = p.resolve("model.safetensors")
+                when {
+                    idx.exists() -> idx
+                    single.exists() -> single
+                    else -> {
+                        println("[skip] No SafeTensors checkpoint found in $p")
+                        return null
+                    }
+                }
+            }
+            else -> p
+        }
+        return resolved
+    }
+}

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModelToolCallTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModelToolCallTest.kt
@@ -1,0 +1,143 @@
+package sk.ainet.apps.kgemma
+
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import sk.ainet.llm.api.ChatOptions
+import sk.ainet.llm.api.ChatRequest
+import sk.ainet.llm.api.FinishReason
+import sk.ainet.llm.api.Message
+import sk.ainet.llm.api.ToolDefinition
+
+/**
+ * Regression smoke for tool calling against a real Gemma 4 E2B SafeTensors
+ * checkpoint via [Gemma4ChatModel.fromSafeTensors].
+ *
+ * Counterpart of the GGUF-flavoured `Gemma4E2BToolCallSmokeTest`, which is
+ * `@Ignore`d on a separate Q4_K_M parity question. The SafeTensors path no
+ * longer suffers the prompt-corruption issue (`GGUFTokenizer.fromTokenizerJson`
+ * was patched to recognise `added_tokens` as atomic CONTROL tokens), so the
+ * model receives the chat-template grammar the trainer used and is expected
+ * to emit `<|tool_call>call:NAME{...}<tool_call|>` on a calculator-style
+ * prompt.
+ *
+ * Self-skips when `GEMMA4_E2B_SAFETENSORS_PATH` is not set.
+ *
+ * Asserts shape, not exact wording: any `<|tool_call>` marker in the
+ * generated text — or any parsed tool call in the response — counts as a
+ * pass. Don't byte-equality-check the arguments JSON; the goal here is the
+ * grammar, not the arithmetic.
+ */
+class Gemma4ChatModelToolCallTest {
+
+    @Test
+    fun `chat model emits a tool_call against a calculator tool`() {
+        val indexPath = locateCheckpoint() ?: return
+
+        val calculator = ToolDefinition(
+            name = "calculator",
+            description = "Evaluate a mathematical expression. Supports +, -, *, / and parentheses.",
+            parametersJsonSchema = """
+                {
+                    "type": "object",
+                    "properties": {
+                        "expression": {
+                            "type": "string",
+                            "description": "The mathematical expression to evaluate, e.g. '17 * 23'"
+                        }
+                    }
+                }
+            """.trimIndent(),
+        )
+
+        val model = Gemma4ChatModel.fromSafeTensors(
+            indexPath = indexPath.toString(),
+            options = ChatOptions(
+                temperature = 0f,
+                maxTokens = 64,
+            ),
+        )
+
+        try {
+            val response = model.call(
+                ChatRequest(
+                    messages = listOf(
+                        Message.user("What is 17 * 23? Use the calculator tool."),
+                    ),
+                    tools = listOf(calculator),
+                ),
+            )
+
+            val generation = response.generations.firstOrNull()
+            val text = generation?.message?.content.orEmpty()
+            val toolCalls = generation?.message?.toolCalls.orEmpty()
+            val finish = generation?.finishReason
+
+            println("[toolcall-smoke] finish=$finish")
+            println("[toolcall-smoke] toolCalls.size=${toolCalls.size}")
+            println("[toolcall-smoke] text='${text.replace("\n", "\\n")}'")
+            toolCalls.forEachIndexed { i, c ->
+                println("[toolcall-smoke]   [$i] name=${c.name} args=${c.argumentsJson}")
+            }
+
+            // Pass criterion: any of the following indicates the model emitted
+            // (or attempted) a tool-call grammar, which is what we're verifying:
+            //   - the chat template parser found a parseable tool_call,
+            //   - the runtime saw `<|tool_call>` literally in the stream, or
+            //   - the finish reason was tagged TOOL_CALL.
+            val markerInText = "<|tool_call>" in text
+            val sawToolCall = toolCalls.isNotEmpty() ||
+                markerInText ||
+                finish == FinishReason.TOOL_CALL
+
+            assertTrue(
+                sawToolCall,
+                "Expected a tool_call marker or parsed tool call. Got finish=$finish, " +
+                    "toolCalls=${toolCalls.size}, marker_in_text=$markerInText, text='$text'",
+            )
+
+            // If the model produced a structured tool call, sanity-check it
+            // resolved to the registered tool. Don't assert on argument
+            // contents — that's a separate concern from grammar.
+            if (toolCalls.isNotEmpty()) {
+                assertTrue(
+                    toolCalls.any { it.name == "calculator" },
+                    "Tool call name didn't resolve to 'calculator': ${toolCalls.map { it.name }}",
+                )
+            }
+        } finally {
+            model.close()
+        }
+    }
+
+    private fun locateCheckpoint(): Path? {
+        val raw = System.getenv("GEMMA4_E2B_SAFETENSORS_PATH")?.trim().orEmpty()
+        if (raw.isEmpty()) {
+            println("[skip] GEMMA4_E2B_SAFETENSORS_PATH not set.")
+            return null
+        }
+        val p = Path.of(raw)
+        if (!p.exists()) {
+            println("[skip] Path does not exist: $p")
+            return null
+        }
+        val resolved = when {
+            p.isDirectory() -> {
+                val idx = p.resolve("model.safetensors.index.json")
+                val single = p.resolve("model.safetensors")
+                when {
+                    idx.exists() -> idx
+                    single.exists() -> single
+                    else -> {
+                        println("[skip] No SafeTensors checkpoint found in $p")
+                        return null
+                    }
+                }
+            }
+            else -> p
+        }
+        return resolved
+    }
+}

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModelToolCallTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4ChatModelToolCallTest.kt
@@ -52,11 +52,19 @@ class Gemma4ChatModelToolCallTest {
             """.trimIndent(),
         )
 
+        // Real models on a calculator prompt emit the `<|tool_call>` opener
+        // well within the first ~15 tokens. 24 keeps the run cheap (FP32
+        // single-core decode is slow) while leaving headroom for the rest
+        // of the tool-call grammar. `GEMMA4_TOOLCALL_MAX_TOKENS` overrides
+        // for diagnostic runs that need to see more of the response.
+        val maxTokens = System.getenv("GEMMA4_TOOLCALL_MAX_TOKENS")
+            ?.trim()?.toIntOrNull()?.coerceAtLeast(1)
+            ?: 24
         val model = Gemma4ChatModel.fromSafeTensors(
             indexPath = indexPath.toString(),
             options = ChatOptions(
                 temperature = 0f,
-                maxTokens = 64,
+                maxTokens = maxTokens,
             ),
         )
 

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4TokenizerParityTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/Gemma4TokenizerParityTest.kt
@@ -1,0 +1,151 @@
+package sk.ainet.apps.kgemma
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
+
+/**
+ * Fast (no-model-load) regression guard for the tokenizer fixes that
+ * landed alongside the SafeTensors path:
+ *
+ *  - `fromTokenizerJson` populates `tokenTypes` from `added_tokens` so
+ *    chat-template control tokens (`<bos>`, `<|turn>`, `<turn|>`, etc.)
+ *    encode atomically rather than splitting into per-character BPE
+ *    pieces. The 1f20c27 / 444fd17 commits.
+ *  - SentencePiece marker (`▁`) auto-detection picks
+ *    `SentencePieceStrategy` for Gemma-style vocabs and disables
+ *    `add_dummy_prefix` so encoding "Hi" returns id 10979 (not the
+ *    `▁Hi` variant 18428). 1f20c27.
+ *
+ * Asserts byte-equality with the HuggingFace `tokenizers` Python lib
+ * reference for a chat-template-rendered single-user-turn prompt.
+ *
+ * Self-skips if `GEMMA4_E2B_SAFETENSORS_PATH` is unset — we only need
+ * the model dir to read `tokenizer.json`, not the SafeTensors weights.
+ */
+class Gemma4TokenizerParityTest {
+
+    @Test
+    fun `chat template rendered prompt tokenizes to HF reference ids`() {
+        val tokenizerJson = locateTokenizerJson() ?: return
+        val tokenizer = GGUFTokenizer.fromTokenizerJson(Files.readString(tokenizerJson))
+
+        // Exact rendered output of `Gemma4ChatTemplate.apply()` for a single
+        // user turn with the canonical prompt. Hand-built here so the test
+        // doesn't depend on the chat-template module — that way we're
+        // verifying the tokenizer in isolation.
+        val prompt = "<bos><|turn>user\nSay hello in one short sentence.<turn|>\n<|turn>model\n"
+
+        // Reference IDs produced by HuggingFace `tokenizers` Python lib
+        // against the same tokenizer.json (see commit message on 444fd17
+        // for the diagnostic trace). Locked to byte-equality.
+        val expected = intArrayOf(
+            2,        // <bos>
+            105,      // <|turn>
+            2364,     // user
+            107,      // \n
+            37889,    // Say
+            29104,    //  hello
+            528,      //  in
+            886,      //  one
+            2822,     //  short
+            13315,    //  sentence
+            236761,   // .
+            106,      // <turn|>
+            107,      // \n
+            105,      // <|turn>
+            4368,     // model
+            107,      // \n
+        )
+
+        val actual = tokenizer.encode(prompt)
+        assertEquals(
+            expected.toList(), actual.toList(),
+            "Tokenized prompt diverged from HF reference. Got ${actual.size} tokens, " +
+                "expected ${expected.size}.",
+        )
+    }
+
+    @Test
+    fun `single-token specials encode atomically with the right ids`() {
+        val tokenizerJson = locateTokenizerJson() ?: return
+        val tokenizer = GGUFTokenizer.fromTokenizerJson(Files.readString(tokenizerJson))
+
+        val cases = listOf(
+            "<bos>" to 2,
+            "<eos>" to 1,
+            "<pad>" to 0,
+            "<|turn>" to 105,
+            "<turn|>" to 106,
+        )
+        for ((literal, expectedId) in cases) {
+            val encoded = tokenizer.encode(literal)
+            assertEquals(
+                listOf(expectedId), encoded.toList(),
+                "Special token $literal did not encode atomically — got ${encoded.toList()}",
+            )
+        }
+    }
+
+    @Test
+    fun `bos and eos token ids resolve from added_tokens`() {
+        val tokenizerJson = locateTokenizerJson() ?: return
+        val tokenizer = GGUFTokenizer.fromTokenizerJson(Files.readString(tokenizerJson))
+
+        assertEquals(2, tokenizer.bosTokenId, "BOS id should be 2 (Gemma 4)")
+        assertEquals(1, tokenizer.eosTokenId, "EOS id should be 1 (Gemma 4)")
+    }
+
+    @Test
+    fun `decoded text has no SentencePiece marker leakage`() {
+        val tokenizerJson = locateTokenizerJson() ?: return
+        val tokenizer = GGUFTokenizer.fromTokenizerJson(Files.readString(tokenizerJson))
+
+        // Round-trip encode → decode for a phrase with multiple internal
+        // spaces. With BPE strategy + the `▁` SentencePiece marker, the
+        // marker would leak into the decoded output literally. With the
+        // SP-strategy auto-detect fix, decode replaces `▁` with " ".
+        val original = "Hello world from Gemma."
+        val ids = tokenizer.encode(original)
+        val decoded = tokenizer.decode(ids)
+
+        assertTrue(
+            "▁" !in decoded,
+            "Decoded text leaks the SentencePiece word-boundary marker: '$decoded'",
+        )
+        // Spaces should round-trip; we don't assert byte-equality because
+        // tokenizers often canonicalise leading/trailing whitespace, but
+        // every word should still be present.
+        for (word in original.split(' ')) {
+            assertTrue(
+                word in decoded,
+                "Word '$word' missing from decoded round-trip output: '$decoded'",
+            )
+        }
+    }
+
+    private fun locateTokenizerJson(): Path? {
+        val raw = System.getenv("GEMMA4_E2B_SAFETENSORS_PATH")?.trim().orEmpty()
+        if (raw.isEmpty()) {
+            println("[skip] GEMMA4_E2B_SAFETENSORS_PATH not set.")
+            return null
+        }
+        val p = Path.of(raw)
+        if (!p.exists()) {
+            println("[skip] Path does not exist: $p")
+            return null
+        }
+        val modelDir: Path = if (p.isDirectory()) p else (p.parent ?: return null)
+        val tokenizerJson = modelDir.resolve("tokenizer.json")
+        if (!tokenizerJson.exists()) {
+            println("[skip] tokenizer.json not found in $modelDir")
+            return null
+        }
+        return tokenizerJson
+    }
+}


### PR DESCRIPTION
## Summary

Wires a real Gemma 4 SafeTensors checkpoint (`google/gemma-4-e2b-it`) into the existing Spring-AI-style `ChatModel` / `StreamingChatModel` SPI behind a one-call factory:

```kotlin
val model = Gemma4ChatModel.fromSafeTensors("/path/to/model.safetensors.index.json")
println(model.call(ChatRequest("Hello!")).text)
```

End-to-end: load → render via `Gemma4ChatTemplate` → tokenize → forward → decode → `ChatResponse`. Verified against the real E2B checkpoint to produce coherent English (`'Hello! How can I help you with your question?<turn|>'`) on a canonical greeting prompt; tokenization is byte-equal to the HuggingFace `tokenizers` Python reference (16 prompt tokens for the chat-template-rendered "Say hello in one short sentence." input).

## Output trajectory across the chain of fixes

Each commit moved the smoke output one structural level closer to correct:

| Stage | Output |
| --- | --- |
| Original | `']^{Defer▁sahajalerdir'` (random fragments) |
| + sandwich norms / layer scale / `post_attention_norm` mapping | `'▁проти▁meet▁బ్యా▁\`/'` (valid wordpieces, wrong content) |
| + mmap'd PLE side-channel | `'<\|turn>\n<\|>'` (correct grammar, wrong place) |
| + atomic special-token encoding + SP marker auto-detect | `'Hello! How can I help you with your question?<turn\|>'` ✓ |

## Commits

1. **`ec67718` feat(kgemma): Gemma4ChatModel factory for text-only chat** — new `Gemma4ChatModel.fromSafeTensors(indexPath, …)` JVM-side factory + env-gated `Gemma4ChatModelSmokeTest`. Adds `:llm-providers` and `:llm-api` to `:llm-runtime:kgemma` jvmMain deps.

2. **`444fd17` fix(gemma4): produce coherent text on real SafeTensors checkpoint** — the big one. `Gemma4SafeTensorsWeightLoader` had Gemma-3-style mappings on a Gemma-4 checkpoint: HF `post_attention_layernorm` was being routed into the GGUF `ffn_norm` slot; sandwich norms (`post_attention_norm`, `post_ffw_norm`), `layer_output_scale`, and the renamed PLE globals (`embed_tokens_per_layer`, `per_layer_model_projection`, `per_layer_projection_norm`) were never loaded — the auto-detect at `GemmaNetworkLoader.kt:153–164` keys on the GGUF tensor suffixes those produce, so the entire Gemma-4 architecture was running with `sandwichNorms=false`, `layerOutputScale=false`, `ple=false` silently. Also: the 4.7 GB BF16 PLE token-embedding table exceeds the JVM `ByteArray` limit, so this commit adds a `RowDequantSource` interface (commonMain), a JVM-only `SafeTensorsPerLayerTokenEmbedTensorData`, and a `Gemma4SafeTensorsMappedPle.injectIfMissing` post-loader that `FileChannel.map`s the byte range straight from the shard. Also fixes atomic special-token encoding in `GGUFTokenizer.fromTokenizerJson` — `tokenTypes` was never populated from `added_tokens`, so `<bos>`, `<\|turn>`, etc. got per-character BPE'd and the model received a corrupted prompt.

3. **`1f20c27` fix(tokenizer): auto-detect SentencePiece marker in fromTokenizerJson** — `fromTokenizerJson` was hard-coding `BPEStrategy` (Ġ marker) even when the vocab uses SentencePiece-style `▁`. Encoding "Hi" produced `[▁Hi]` instead of `[Hi]`, and decoding leaked `▁` into user-visible text. Fix: count vocab entries by leading marker and pick `SentencePieceStrategy` if `▁` dominates; default `addSpacePrefix=false` for the SP path. Also adds `Gemma4ChatModelToolCallTest` (env-gated).

4. **`119844f` feat(chat): multi-id EOS / stop-token support** — `SkaiNetChatModel` was checking a single `eosTokenId`. Gemma 4 ships `[1, 106, 50]` in `generation_config.json`. Replace single-id field with `eosTokenIds: Set<Int>`, default `{tokenizer.eosTokenId}`. Factory parses `eos_token_id` from `generation_config.json` and passes the set through.

5. **`d2cb892` feat(kgemma): propagate close() to mmap arena** — the `pleArena` owned the mmap'd PLE region but had no lifecycle wiring; released only at JVM exit. Wraps `SkaiNetChatModel` in `ArenaScopedStreamingChatModel` whose `close()` cascades to delegate then arena. Return type widened from `SkaiNetChatModel<FP32>` to `StreamingChatModel`.

6. **`6f8ec42` test(kgemma): fast tokenizer parity guard against HF reference** — no-model-load test running in ~12 s. Asserts byte-equality of the chat-template-rendered prompt's token IDs against the HF Python reference. Locks in the three tokenizer fixes so future regressions fail in seconds instead of needing a 10-min smoke run.

7. **`d58514f` test(kgemma): tighten tool-call probe budget + add env override** — `Gemma4ChatModelToolCallTest` defaulted to `maxTokens = 64`, pushing the run past 20 min on FP32 single-core decode. Lower default to 24 (real models emit `<\|tool_call>` within ~5–15 tokens); add `GEMMA4_TOOLCALL_MAX_TOKENS` for diagnostic runs.

## Test plan

- [x] `./gradlew :llm-core:jvmTest :llm-inference:gemma:jvmTest` — pass in 7 s.
- [x] `./gradlew :llm-inference:llama:jvmTest :llm-inference:bert:jvmTest :llm-runtime:kllama:jvmTest :llm-agent:jvmTest` — pass in 8 m 43 s. Shared `GGUFTokenizer` changes don't regress LLaMA / BERT / Voxtral paths.
- [x] `./gradlew :llm-runtime:kgemma:jvmTest --tests Gemma4TokenizerParityTest` (env-gated) — pass in 12 s. Locks in HF-byte-parity for the chat-template-rendered prompt.
- [x] `./gradlew :llm-runtime:kgemma:jvmTest --tests Gemma4ChatModelSmokeTest` (env-gated, FP32 SafeTensors) — pass in 9 m 58 s. Produces coherent English on the canonical prompt with `finish=STOP`.
- [ ] `./gradlew :llm-runtime:kgemma:jvmTest --tests Gemma4ChatModelToolCallTest` (env-gated) — **not yet run end-to-end**; test compiles. Worth one async run before merging.

## Out of scope, follow-ups

- **Q4_K_M GGUF parity** — separate code path. `Gemma4ReferenceParityDiagnostic` still produces divergent output the existing `@Ignore`d GGUF tool-call test was originally written against; this PR doesn't touch the GGUF loader.
- **Refactor `Gemma4SafeTensorsMappedPle` to consume upstream `loadTensorStorageMapped`** — drops the manual `FileChannel.map` glue. SKaiNET 0.22.1 ships the API. **Already prepared** as a stacked PR on top of this one.
- **Multiplatform `Gemma4ChatModel`** — currently JVM-only because `:llm-providers` / `:llm-api` are JVM-only. Lifts when those modules go multiplatform.

## Compatibility

- `SkaiNetChatModel.eosTokenId: Int` parameter replaced with `eosTokenIds: Set<Int>`. Default is `setOf(tokenizer.eosTokenId)` so positional construction keeps working; named-arg callers using `eosTokenId = …` need to switch to `eosTokenIds = setOf(…)`. No callers in this monorepo use the named arg.
- `Gemma4ChatModel.fromSafeTensors` return type widened from `SkaiNetChatModel<FP32>` to `StreamingChatModel`. All existing callsites use the interface methods (`call`, `stream`, `close`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)