### PR TITLE
refactor(gemma4): consume upstream loadTensorStorageMapped for PLE mmap

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-skainet = "0.21.0"
+skainet = "0.22.1"
 agp = "9.2.0"
 jacksonDatabind = "2.21.3"
 jsonSchemaValidator = "3.0.2"

--- a/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/Gemma4SafeTensorsMappedPle.kt
+++ b/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/Gemma4SafeTensorsMappedPle.kt
@@ -2,12 +2,12 @@ package sk.ainet.models.gemma
 
 import java.lang.foreign.Arena
 import java.nio.channels.FileChannel
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import sk.ainet.context.ExecutionContext
 import sk.ainet.io.safetensors.StreamingShardedSafeTensorsReader
 import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.storage.BufferHandle
 import sk.ainet.lang.types.FP32
 
 /**
@@ -63,26 +63,33 @@ public object Gemma4SafeTensorsMappedPle {
         }.getOrNull() ?: return weights
 
         return reader.use { r ->
+            // Resolve the tensor's metadata + file location via the upstream
+            // sharded `loadTensorStorageMapped` (added in skainet-io-safetensors
+            // 0.22.1). The returned `TensorStorage`'s `BufferHandle.FileBacked`
+            // tells us the path / offset / size — we then run the JVM-specific
+            // `FileChannel.map(..., Arena)` to materialise a `MemorySegment` of
+            // the right byte range. (`BufferAccessor` upstream returns
+            // ByteArrays, which are 2 GB-capped; we need a long-indexed
+            // segment for the 4.7 GB PLE table on Gemma 4 E2B.)
             val info = r.tensors.firstOrNull { it.name == HF_EMBED_TOKENS_PER_LAYER }
                 ?: return@use weights
-
-            val indexDir: Path = Paths.get(indexPath).let { p ->
-                if (p.toFile().isDirectory) p else (p.parent ?: Paths.get("."))
+            val storage = r.loadTensorStorageMapped(info)
+            val handle = storage.buffer
+            require(handle is BufferHandle.FileBacked) {
+                "Expected file-backed handle from loadTensorStorageMapped, got ${handle::class}"
             }
-            val shardPath = indexDir.resolve(info.shardFilename)
 
-            val segment = FileChannel.open(shardPath, StandardOpenOption.READ).use { fc ->
+            val segment = FileChannel.open(Paths.get(handle.path), StandardOpenOption.READ).use { fc ->
                 fc.map(
                     FileChannel.MapMode.READ_ONLY,
-                    info.absoluteDataOffset,
-                    info.sizeInBytes,
+                    handle.fileOffset,
+                    handle.sizeInBytes,
                     arena,
                 )
             }
 
-            val logicalShape = Shape(*info.shape.map { it.toInt() }.toIntArray()).let {
-                if (it.rank == 2) it else flattenTrailingDims(it)
-            }
+            val logicalShape = if (storage.shape.rank == 2) storage.shape
+                else flattenTrailingDims(storage.shape)
             val data = SafeTensorsPerLayerTokenEmbedTensorData(
                 logicalShape = logicalShape,
                 segment = segment,


### PR DESCRIPTION
**Stacked on top of #89.** Will rebase to `develop` automatically after #89 merges.

## Summary

Drops `Gemma4SafeTensorsMappedPle`'s manual path-resolution + `FileChannel.map` glue in favour of `StreamingShardedSafeTensorsReader.loadTensorStorageMapped` shipped in skainet-io-safetensors 0.22.1 ([SKaiNET PR #582](https://github.com/SKaiNET-developers/SKaiNET/pull/582)).

Before:

```kotlin
val info = r.tensors.firstOrNull { it.name == HF_EMBED_TOKENS_PER_LAYER } ?: return@use weights
val indexDir = Paths.get(indexPath).let { p -> if (p.toFile().isDirectory) p else (p.parent ?: Paths.get(".")) }
val shardPath = indexDir.resolve(info.shardFilename)
val segment = FileChannel.open(shardPath, StandardOpenOption.READ).use { fc ->
    fc.map(MapMode.READ_ONLY, info.absoluteDataOffset, info.sizeInBytes, arena)
}
```

After:

```kotlin
val info = r.tensors.firstOrNull { it.name == HF_EMBED_TOKENS_PER_LAYER } ?: return@use weights
val storage = r.loadTensorStorageMapped(info)
val handle = storage.buffer as BufferHandle.FileBacked
val segment = FileChannel.open(Paths.get(handle.path), StandardOpenOption.READ).use { fc ->
    fc.map(MapMode.READ_ONLY, handle.fileOffset, handle.sizeInBytes, arena)
}
```

`FileChannel.map` is still JVM-specific because the upstream `BufferAccessor` returns 2 GB-capped `ByteArray`s and we need a long-indexed `MemorySegment` for the 4.7 GB PLE table on Gemma 4 E2B — but path resolution + offset/size derivation is now upstream's job, and the consumer is one of the first downstream uses of the new API (validates the upstream design end-to-end).

Bumps `gradle/libs.versions.toml` `skainet` from 0.21.0 → 0.22.1.

## Test plan

- [x] `./gradlew :llm-inference:gemma:compileKotlinJvm :llm-runtime:kgemma:compileTestKotlinJvm` — clean against published 0.22.1 (CI run **25184460014** on the push: `Build & Test → completed success`).
- [x] `Gemma4TokenizerParityTest` — 6 s, green (sanity that the version bump didn't perturb anything tokenizer-side).
- [ ] `Gemma4ChatModelSmokeTest` (env-gated, ~10 min) — refactor only changes path-resolution glue (same mmap byte range, same dequant), so runtime behaviour should be identical to the parent branch's verified state. Worth one async run before final merge.

## Compatibility

Internal-only refactor — no public API changes; no behavioural changes intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)