### PR TITLE
fix(apertus): route through OptimizedLLMRuntime + apertusNetwork()

### DIFF
--- a/APERTUS_ROLLOUT.md
+++ b/APERTUS_ROLLOUT.md
@@ -1,8 +1,8 @@
 # Apertus Support Rollout
 
-**Status:** plan landed; PRs 1–4 not started.
+**Status:** PR 1 in flight (skainet-cli routing fix).
 **Owner:** unassigned.
-**Plan PR:** this commit.
+**Plan PR:** #91 (merged).
 
 ## Context
 
@@ -23,7 +23,7 @@ The architecture / library layer itself is solid:
 
 ## Staged delivery
 
-- [ ] **PR 1 — `fix(apertus): route through OptimizedLLMRuntime + apertusNetwork()`** (correctness fix)
+- [x] **PR 1 — `fix(apertus): route through OptimizedLLMRuntime + apertusNetwork()`** (correctness fix) — this PR
 - [ ] **PR 2 — `docs(apertus): document chat template format`** (research)
 - [ ] **PR 3 — `feat(apertus): tool calling support`** (implementation, depends on PR 2)
 - [ ] **PR 4 — `feat(kapertus): rebuild CLI under llm-apps/`** (parity, optional)

--- a/llm-apps/skainet-cli/build.gradle.kts
+++ b/llm-apps/skainet-cli/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     // Inference modules (for network loaders)
     implementation(project(":llm-inference:llama"))
     implementation(project(":llm-inference:gemma"))
+    implementation(project(":llm-inference:apertus"))
 
     // SKaiNET core libraries
     implementation(libs.skainet.lang.core)

--- a/llm-apps/skainet-cli/src/main/kotlin/sk/ainet/apps/skainet/cli/Main.kt
+++ b/llm-apps/skainet-cli/src/main/kotlin/sk/ainet/apps/skainet/cli/Main.kt
@@ -10,6 +10,7 @@ import sk.ainet.apps.llm.OptimizedLLMRuntime
 import sk.ainet.apps.llm.Tokenizer
 import sk.ainet.apps.llm.UnifiedModelLoader
 import sk.ainet.apps.llm.generate
+import sk.ainet.models.apertus.ApertusNetworkLoader
 import sk.ainet.models.gemma.Gemma4WeightLoader
 import sk.ainet.models.gemma.Gemma4Weights
 import sk.ainet.models.gemma.GemmaNetworkLoader
@@ -163,10 +164,15 @@ fun main(args: Array<String>) {
             memSegFactory.close()
         })
 
-        // Load model based on detected family. Gemma routes through the DSL
-        // pipeline (gemmaNetwork() + OptimizedLLMRuntime, Phase 5d parity);
-        // everything else (LLaMA, Qwen, Apertus, ...) takes the LlamaRuntime
-        // path which supports NATIVE_OPTIMIZED quant tensors for low-RAM loads.
+        // Load model based on detected family. Gemma and Apertus route
+        // through the DSL pipeline (their respective network() builder +
+        // OptimizedLLMRuntime); everything else (LLaMA, Qwen, ...) takes
+        // the LlamaRuntime path which supports NATIVE_OPTIMIZED quant
+        // tensors for low-RAM loads. Apertus had previously fallen
+        // through to the LlamaRuntime branch — that runtime doesn't
+        // implement Apertus's xIELU activation, QK-Norm, or ungated FFN,
+        // so logits silently diverged from the checkpoint's intent. See
+        // APERTUS_ROLLOUT.md (PR 1) for the rollout context.
         val runtime: InferenceRuntime<FP32> = if (modelInfo.family == ModelFamily.GEMMA) {
             println("Loading Gemma GGUF model from $modelPath via gemmaNetwork() + OptimizedLLMRuntime (NATIVE_OPTIMIZED)...")
             if (cliArgs.contextLength != null) {
@@ -179,6 +185,16 @@ fun main(args: Array<String>) {
             @Suppress("UNCHECKED_CAST")
             val converted = convertGemmaWeightsToMemSeg(rawWeights, ctx, quantArena) as Gemma4Weights<FP32, Float>
             val model = GemmaNetworkLoader.fromWeights(ctx, converted, FP32::class)
+            OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
+        } else if (modelInfo.family == ModelFamily.APERTUS) {
+            println("Loading Apertus GGUF model from $modelPath via apertusNetwork() + OptimizedLLMRuntime (NATIVE_OPTIMIZED)...")
+            if (cliArgs.contextLength != null) {
+                println("  --context flag currently ignored on the Apertus path; uses model default.")
+            }
+            val model = ApertusNetworkLoader.fromGguf(
+                randomAccessProvider = { JvmRandomAccessSource.open(modelPath.toString()) },
+                quantPolicy = QuantPolicy.NATIVE_OPTIMIZED
+            ).load<FP32, Float>(ctx)
             OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
         } else {
             val acceptedArchitectures = modelInfo.family.architectures + setOf(modelInfo.architecture)


### PR DESCRIPTION
## Summary

PR 1 of the Apertus rollout (see [APERTUS_ROLLOUT.md](APERTUS_ROLLOUT.md)). Fixes the silent correctness bug where `skainet-cli` routed every non-Gemma model — including Apertus — through the deprecated `LlamaRuntime` branch (`Main.kt:170-217`). `LlamaRuntime` doesn't implement Apertus's xIELU activation, QK-Norm (RMSNorm on Q and K before RoPE), or ungated FFN; loading an Apertus checkpoint through it produces silently-wrong logits.

## Change

Adds an Apertus arm parallel to the existing Gemma arm:

```kotlin
} else if (modelInfo.family == ModelFamily.APERTUS) {
    val model = ApertusNetworkLoader.fromGguf(
        randomAccessProvider = { JvmRandomAccessSource.open(modelPath.toString()) },
        quantPolicy = QuantPolicy.NATIVE_OPTIMIZED
    ).load<FP32, Float>(ctx)
    OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
}
```

`ApertusNetworkLoader.load` is `suspend`; `main()` is already inside `runBlocking`, so no plumbing changes needed.

## Build wiring

- `llm-apps/skainet-cli/build.gradle.kts`: add `implementation(project(":llm-inference:apertus"))` so `ApertusNetworkLoader` is on the compile classpath. Mirrors how `llama` and `gemma` inference modules are pulled in.

## Untouched

- `ApertusRuntime.kt` hand-coded path stays `@Deprecated`. Migration to `OptimizedLLMRuntime + apertusNetwork()` is recommended but not forced.
- `LlamaRuntime` fallback still handles LLaMA / Mistral / Qwen. No behavior change for those.
- `ModelRegistry.kt:66` `supportsToolCalling=false` / `chatTemplateFamily="chatml"` unchanged — that's PR 2 / PR 3 of the rollout.

## Test plan

- [x] `./gradlew :llm-apps:skainet-cli:shadowJar` — green on develop, fat-jar built (BUILD SUCCESSFUL in 56s)
- [x] `./gradlew :llm-inference:apertus:commonTest` — 4 existing smoke tests still pass (no library-layer change)
- [ ] CI green
- [ ] End-to-end manual run with a real Apertus GGUF (requires checkpoint not on the dev machine; manual verification deferred to whoever has the model handy — the compile-time wiring is the load-bearing change, the existing `apertusNetwork()` machinery does the rest at runtime)

## Tracking

`APERTUS_ROLLOUT.md` PR 1 checkbox ticked; `Status:` header advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)