### PR TITLE
feat(apertus): tool calling support

### DIFF
--- a/APERTUS_ROLLOUT.md
+++ b/APERTUS_ROLLOUT.md
@@ -1,8 +1,8 @@
 # Apertus Support Rollout
 
-**Status:** PR 2 in flight (chat-template documentation).
+**Status:** PR 3 in flight (tool-calling support).
 **Owner:** unassigned.
-**Plan PR:** #91 (merged). PR 1: #92 (merged).
+**Plan PR:** #91 (merged). PR 1: #92 (merged). PR 2: #93 (merged).
 
 ## Context
 
@@ -24,8 +24,8 @@ The architecture / library layer itself is solid:
 ## Staged delivery
 
 - [x] **PR 1 — `fix(apertus): route through OptimizedLLMRuntime + apertusNetwork()`** (correctness fix) — #92
-- [x] **PR 2 — `docs(apertus): document chat template format`** (research) — this PR
-- [ ] **PR 3 — `feat(apertus): tool calling support`** (implementation, depends on PR 2)
+- [x] **PR 2 — `docs(apertus): document chat template format`** (research) — #93
+- [x] **PR 3 — `feat(apertus): tool calling support`** (implementation, depends on PR 2) — this PR
 - [ ] **PR 4 — `feat(kapertus): rebuild CLI under llm-apps/`** (parity, optional)
 
 Each PR ticks its own checkbox when merged. `Status:` at the top of this doc reflects the most recent merged PR.

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ApertusChatTemplate.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ApertusChatTemplate.kt
@@ -1,0 +1,328 @@
+package sk.ainet.apps.kllama.chat
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Chat template for Apertus models (Swiss AI / EPFL).
+ *
+ * Implements the prompt format documented in
+ * `docs/specs/apertus-chat-template.md`, sourced from
+ * `swiss-ai/Apertus-8B-Instruct-2509`'s `chat_template.jinja`. Apertus
+ * has its own role tokens — `<|system_start|>`, `<|developer_start|>`,
+ * `<|user_start|>`, `<|assistant_start|>`, `<|inner_prefix|>`,
+ * `<|tools_prefix|>` — and renders tool definitions as
+ * **TypeScript-style type declarations**, NOT JSON Schema.
+ *
+ * Construction params let callers override pieces that the Jinja
+ * template injects dynamically:
+ *
+ * @param defaultSystemPrompt The text used when the caller doesn't
+ *   supply a system message. Apertus is trained on the literal default
+ *   string `"You are Apertus, a helpful assistant created by the
+ *   SwissAI initiative.\nKnowledge cutoff: 2024-04\nCurrent date: ..."`.
+ *   Override only if the caller has a verified alternative; the model
+ *   may behave worse with a different system prompt.
+ * @param currentDate Date string substituted into the default system
+ *   prompt at the `Current date:` line. Defaults to a fixed value so
+ *   tests are deterministic; production callers can pass today's date
+ *   via the auxiliary [withCurrentDate] helper if they want.
+ * @param enableThinking Whether to emit `Deliberation: enabled` (vs
+ *   `disabled`) in the developer block. Defaults to `false`. Apertus's
+ *   thinking mode is documented but not yet exercised by SKaiNET's
+ *   agent loop, so the safe default is `disabled`.
+ *
+ * Limitations vs the upstream Jinja template (carried as TODOs for
+ * future hardening):
+ * - The TypeScript type renderer covers `string`, `number`, `integer`,
+ *   `boolean`, primitive `array`, and shallow `object` (object with
+ *   primitive properties). `oneOf`, `nullable`, deep-nested objects,
+ *   `enum`, and union arrays fall back to `any`.
+ * - Multi-block assistant content (`thoughts` / `tool_calls` /
+ *   `tool_outputs` / `response` blocks) isn't expressible in our
+ *   [ChatMessage] model, which carries `content: String` plus optional
+ *   `toolCalls: List<ToolCall>?`. The renderer maps the latter to the
+ *   `<|tools_prefix|>...<|tools_suffix|>` form and treats `TOOL` role
+ *   messages as `[output]` continuations of the current assistant
+ *   turn — equivalent to Apertus's "Shape 1 string + tool_calls"
+ *   handling for our current callers.
+ */
+public class ApertusChatTemplate(
+    private val defaultSystemPrompt: String? = null,
+    private val currentDate: String = "2026-05-01",
+    private val enableThinking: Boolean = false,
+) : ChatTemplate {
+
+    override fun apply(
+        messages: List<ChatMessage>,
+        tools: List<ToolDefinition>,
+        addGenerationPrompt: Boolean,
+    ): String = buildString {
+        // BOS at the very start; Apertus's tokenizer_config has add_bos_token=true
+        // and the Jinja emits {{ bos_token }} as the first token.
+        append("<s>")
+
+        // System block — caller-supplied or default
+        val (system, rest) = if (messages.isNotEmpty() && messages[0].role == ChatRole.SYSTEM) {
+            messages[0].content to messages.drop(1)
+        } else {
+            renderDefaultSystemPrompt() to messages
+        }
+        append(SYSTEM_START).append(system).append(SYSTEM_END)
+
+        // Developer block — always emitted, even with no tools / disabled thinking
+        append(DEVELOPER_START)
+        append("Deliberation: ").append(if (enableThinking) "enabled\n" else "disabled\n")
+        if (tools.isNotEmpty()) {
+            append("Tool Capabilities:\n")
+            append(renderTools(tools))
+        } else {
+            append("Tool Capabilities: disabled")
+        }
+        append(DEVELOPER_END)
+
+        // Per-message turns
+        var inAssistant = false
+        var inToolOutputs = false
+        for (message in rest) {
+            when (message.role) {
+                ChatRole.SYSTEM -> {
+                    // Multiple system messages aren't part of the spec; skip silently.
+                    // The Jinja raises in that case; we degrade to a no-op for forward
+                    // compatibility with callers that pass duplicate system prompts.
+                }
+                ChatRole.USER -> {
+                    if (inToolOutputs) {
+                        append(']')
+                        inToolOutputs = false
+                    }
+                    if (inAssistant) {
+                        append(ASSISTANT_END)
+                        inAssistant = false
+                    }
+                    append(USER_START).append(message.content).append(USER_END)
+                }
+                ChatRole.ASSISTANT -> {
+                    if (!inAssistant) {
+                        append(ASSISTANT_START)
+                        inAssistant = true
+                    }
+                    if (inToolOutputs) {
+                        append(']')
+                        inToolOutputs = false
+                    }
+                    append(message.content)
+                    val tcs = message.toolCalls
+                    if (!tcs.isNullOrEmpty()) {
+                        append(TOOLS_PREFIX).append('[')
+                        for ((index, call) in tcs.withIndex()) {
+                            if (index > 0) append(", ")
+                            append('{').append('"').append(call.name).append("\": ")
+                            append(call.arguments.toString())
+                            append('}')
+                        }
+                        append(']').append(TOOLS_SUFFIX)
+                    }
+                }
+                ChatRole.TOOL -> {
+                    // Tool outputs render as [output1, output2, ...] inside the
+                    // current assistant turn — matches the Jinja's `role == 'tool'`
+                    // branch which keeps `ns.in_tool` open across consecutive tool
+                    // messages.
+                    if (!inAssistant) {
+                        // Defensive: open an assistant turn if the caller forgot to.
+                        append(ASSISTANT_START)
+                        inAssistant = true
+                    }
+                    if (!inToolOutputs) {
+                        append('[')
+                        inToolOutputs = true
+                    } else {
+                        append(", ")
+                    }
+                    append(message.content)
+                }
+            }
+        }
+        if (inToolOutputs) {
+            append(']')
+        }
+        if (inAssistant) {
+            append(ASSISTANT_END)
+        }
+        if (addGenerationPrompt) {
+            append(ASSISTANT_START)
+        }
+    }
+
+    override fun parseToolCalls(text: String): List<ToolCall> =
+        ApertusToolCallParserStrategy.parse(text)
+
+    override fun containsToolCall(text: String): Boolean =
+        ApertusToolCallParserStrategy.containsToolCall(text)
+
+    /**
+     * Apertus uses `<|inner_prefix|>...<|inner_suffix|>` to wrap
+     * deliberation / chain-of-thought. Strip when feeding back into a
+     * subsequent prompt or surfacing to a non-debugging UI.
+     */
+    override fun parseThinkingBlocks(text: String): List<String> {
+        val results = mutableListOf<String>()
+        var idx = 0
+        while (true) {
+            val start = text.indexOf(INNER_PREFIX, idx)
+            if (start < 0) break
+            val end = text.indexOf(INNER_SUFFIX, start + INNER_PREFIX.length)
+            if (end < 0) break
+            results.add(text.substring(start + INNER_PREFIX.length, end))
+            idx = end + INNER_SUFFIX.length
+        }
+        return results
+    }
+
+    override fun stripThinking(text: String): String {
+        val sb = StringBuilder(text.length)
+        var idx = 0
+        while (true) {
+            val start = text.indexOf(INNER_PREFIX, idx)
+            if (start < 0) {
+                sb.append(text, idx, text.length)
+                break
+            }
+            sb.append(text, idx, start)
+            val end = text.indexOf(INNER_SUFFIX, start + INNER_PREFIX.length)
+            if (end < 0) {
+                // Unterminated thinking block — keep the original content.
+                sb.append(text, start, text.length)
+                break
+            }
+            idx = end + INNER_SUFFIX.length
+        }
+        return sb.toString()
+    }
+
+    /** Build a copy with [date] substituted into the default system prompt. */
+    public fun withCurrentDate(date: String): ApertusChatTemplate =
+        ApertusChatTemplate(defaultSystemPrompt, date, enableThinking)
+
+    private fun renderDefaultSystemPrompt(): String =
+        defaultSystemPrompt
+            ?: "You are Apertus, a helpful assistant created by the SwissAI initiative.\n" +
+                "Knowledge cutoff: 2024-04\n" +
+                "Current date: $currentDate"
+
+    /**
+     * Render a list of [ToolDefinition] as TypeScript-style type
+     * declarations. Mirrors the Jinja `render_tools` macro for the
+     * cases we currently need; complex schemas (oneOf, nullable, enum,
+     * union arrays, deep nesting) collapse to `any`.
+     */
+    private fun renderTools(tools: List<ToolDefinition>): String = buildString {
+        for ((toolIndex, tool) in tools.withIndex()) {
+            append("// ").append(tool.description).append('\n')
+            append("type ").append(tool.name).append(" = ")
+            val properties = (tool.parameters["properties"] as? JsonObject)
+            val required = (tool.parameters["required"] as? JsonArray)
+                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                ?.toSet()
+                ?: emptySet()
+            if (properties.isNullOrEmpty()) {
+                append("() => any;")
+            } else {
+                append("(_: {\n")
+                val entries = properties.entries.toList()
+                for ((idx, entry) in entries.withIndex()) {
+                    val (paramName, paramSpec) = entry
+                    val paramObj = paramSpec as? JsonObject
+                    val description = paramObj?.get("description")?.jsonPrimitive?.contentOrNull
+                    if (description != null) {
+                        append("// ").append(description).append('\n')
+                    }
+                    append(paramName)
+                    if (paramName !in required) append('?')
+                    append(": ").append(renderTypescriptType(paramObj))
+                    if (idx < entries.size - 1) append(",\n") else append('\n')
+                }
+                append("}) => any;")
+            }
+            if (toolIndex < tools.size - 1) append('\n')
+        }
+    }
+
+    private fun renderTypescriptType(spec: JsonObject?): String {
+        if (spec == null) return "any"
+        val type = spec["type"]?.jsonPrimitive?.contentOrNull
+        val nullable = spec["nullable"]?.let { runCatching { (it as? JsonPrimitive)?.boolean }.getOrNull() } == true
+        val base = when (type) {
+            "string" -> {
+                val enum = spec["enum"] as? JsonArray
+                if (enum != null && enum.isNotEmpty()) {
+                    enum.joinToString(prefix = "\"", postfix = "\"", separator = "\" | \"") {
+                        it.jsonPrimitive.contentOrNull.orEmpty()
+                    }
+                } else {
+                    "string"
+                }
+            }
+            "number", "integer" -> "number"
+            "boolean" -> "boolean"
+            "array" -> renderArrayType(spec)
+            "object" -> renderObjectType(spec)
+            else -> "any"
+        }
+        return if (nullable) "$base | null" else base
+    }
+
+    private fun renderArrayType(spec: JsonObject): String {
+        val items = spec["items"] as? JsonObject ?: return "any[]"
+        return when (items["type"]?.jsonPrimitive?.contentOrNull) {
+            "string" -> "string[]"
+            "number", "integer" -> "number[]"
+            "boolean" -> "boolean[]"
+            else -> "any[]"
+        }
+    }
+
+    private fun renderObjectType(spec: JsonObject): String {
+        val properties = spec["properties"] as? JsonObject ?: return "object"
+        if (properties.isEmpty()) return "object"
+        val required = (spec["required"] as? JsonArray)
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?.toSet()
+            ?: emptySet()
+        return buildString {
+            append("{\n")
+            val entries = properties.entries.toList()
+            for ((idx, entry) in entries.withIndex()) {
+                val (name, valueSpec) = entry
+                append(name)
+                if (name !in required) append('?')
+                append(": ")
+                append(renderTypescriptType(valueSpec as? JsonObject))
+                if (idx < entries.size - 1) append(", ") else append('\n')
+            }
+            append('}')
+        }
+    }
+
+    public companion object {
+        public const val SYSTEM_START: String = "<|system_start|>"
+        public const val SYSTEM_END: String = "<|system_end|>"
+        public const val DEVELOPER_START: String = "<|developer_start|>"
+        public const val DEVELOPER_END: String = "<|developer_end|>"
+        public const val USER_START: String = "<|user_start|>"
+        public const val USER_END: String = "<|user_end|>"
+        public const val ASSISTANT_START: String = "<|assistant_start|>"
+        public const val ASSISTANT_END: String = "<|assistant_end|>"
+        public const val INNER_PREFIX: String = "<|inner_prefix|>"
+        public const val INNER_SUFFIX: String = "<|inner_suffix|>"
+        public const val TOOLS_PREFIX: String = "<|tools_prefix|>"
+        public const val TOOLS_SUFFIX: String = "<|tools_suffix|>"
+    }
+}

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ApertusToolCallParserStrategy.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ApertusToolCallParserStrategy.kt
@@ -1,0 +1,71 @@
+package sk.ainet.apps.kllama.chat
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+
+/**
+ * Parses Apertus tool calls from model output.
+ *
+ * Apertus emits tool calls between special tokens:
+ *
+ *   `<|tools_prefix|>[{"<tool_name>": <args_json>}, ...]<|tools_suffix|>`
+ *
+ * - The bracket contains a JSON array.
+ * - Each element is a JSON object with **exactly one** key: the tool
+ *   name. The value is the args object.
+ * - Multiple parallel tool calls in one assistant turn are
+ *   comma-separated objects in the array.
+ *
+ * Args are real JSON (not stringified TypeScript), so we can parse
+ * with `kotlinx.serialization`. See `docs/specs/apertus-chat-template.md`
+ * for the format derivation.
+ *
+ * The parser tolerates leading / trailing whitespace inside the
+ * bracket and ignores any text outside the `<|tools_prefix|>` /
+ * `<|tools_suffix|>` markers.
+ */
+public object ApertusToolCallParserStrategy : ToolCallParserStrategy {
+
+    override val formatName: String = "apertus"
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    override fun parse(text: String): List<ToolCall> {
+        val start = text.indexOf(ApertusChatTemplate.TOOLS_PREFIX)
+        if (start < 0) return emptyList()
+        val arrayStart = start + ApertusChatTemplate.TOOLS_PREFIX.length
+        val end = text.indexOf(ApertusChatTemplate.TOOLS_SUFFIX, arrayStart)
+        if (end < 0) return emptyList()
+        val payload = text.substring(arrayStart, end).trim()
+        if (payload.isEmpty()) return emptyList()
+
+        val parsed = runCatching { json.parseToJsonElement(payload) }.getOrNull() ?: return emptyList()
+        val array = parsed as? JsonArray ?: return emptyList()
+
+        val calls = mutableListOf<ToolCall>()
+        for ((index, element) in array.withIndex()) {
+            val obj = element as? JsonObject ?: continue
+            // Single-key object: name -> args
+            if (obj.size != 1) continue
+            val (name, argsElement) = obj.entries.first()
+            val args = argsElement as? JsonObject ?: continue
+            calls.add(
+                ToolCall(
+                    id = "apertus-tool-call-$index",
+                    name = name,
+                    arguments = args,
+                )
+            )
+        }
+        return calls
+    }
+
+    override fun containsToolCall(text: String): Boolean =
+        text.contains(ApertusChatTemplate.TOOLS_PREFIX) &&
+            text.contains(ApertusChatTemplate.TOOLS_SUFFIX)
+}

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ApertusToolCallingSupport.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ApertusToolCallingSupport.kt
@@ -1,0 +1,34 @@
+package sk.ainet.apps.kllama.chat
+
+/**
+ * Tool-calling support for the Apertus family (Swiss AI / EPFL).
+ *
+ * Wires up [ApertusChatTemplate] for prompt formatting and
+ * [ApertusToolCallParserStrategy] for parsing tool-call output. See
+ * `docs/specs/apertus-chat-template.md` for the format reference.
+ */
+public class ApertusToolCallingSupport : ToolCallingSupport {
+    override val family: String = "apertus"
+
+    private val template: ApertusChatTemplate = ApertusChatTemplate()
+
+    override fun supports(metadata: ModelMetadata): Boolean {
+        val f = metadata.family?.lowercase()
+        if (f == "apertus") return true
+        val arch = metadata.architecture?.lowercase()
+        if (arch == "apertus") return true
+        // Disambiguating chat-template marker: Apertus is the only family
+        // that uses `<|assistant_start|>` (vs llama3's <|start_header_id|>,
+        // chatml's <|im_start|>, gemma's <start_of_turn>).
+        val tpl = metadata.chatTemplate ?: return false
+        return tpl.contains("<|assistant_start|>")
+    }
+
+    override fun createChatTemplate(): ChatTemplate = template
+
+    override fun parseToolCalls(content: String): List<ToolCall> =
+        ApertusToolCallParserStrategy.parse(content)
+
+    override fun toolCallingMode(metadata: ModelMetadata): ToolCallingMode =
+        ToolCallingMode.NATIVE
+}

--- a/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallingSupportResolver.kt
+++ b/llm-agent/src/commonMain/kotlin/sk/ainet/apps/kllama/chat/ToolCallingSupportResolver.kt
@@ -21,6 +21,7 @@ public object ToolCallingSupportResolver {
         // and hand out the Gemma 2/3 template.
         Gemma4ToolCallingSupport(),
         GemmaToolCallingSupport(),
+        ApertusToolCallingSupport(),
         Llama3ToolCallingSupport(),
         ChatMLToolCallingSupport()
     )

--- a/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ApertusChatTemplateTest.kt
+++ b/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ApertusChatTemplateTest.kt
@@ -1,0 +1,200 @@
+package sk.ainet.apps.kllama.chat
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Structural tests for [ApertusChatTemplate]. These don't assert
+ * byte-for-byte parity with the upstream Jinja template (a real
+ * parity harness would need a Jinja runtime, which is JVM-only and
+ * not available in commonTest); instead they verify the canonical
+ * tokens land in the expected order for the four scenarios called
+ * out in `docs/specs/apertus-chat-template.md`.
+ *
+ * The canonical cases:
+ *   1. user-only (default system + disabled developer block)
+ *   2. system + user (caller-supplied system)
+ *   3. system + user + assistant string content
+ *   4. system + user + assistant with tool calls + tool message
+ */
+class ApertusChatTemplateTest {
+
+    private val fixedDate = "2026-05-01"
+
+    private fun template(): ApertusChatTemplate =
+        ApertusChatTemplate(currentDate = fixedDate)
+
+    @Test
+    fun case1_user_only_emits_default_system_and_disabled_developer_block() {
+        val out = template().apply(
+            messages = listOf(
+                ChatMessage(role = ChatRole.USER, content = "Hi")
+            ),
+            tools = emptyList(),
+            addGenerationPrompt = true,
+        )
+        // Sequence is: bos + system block (default) + developer block + user + assistant_start
+        val expected = buildString {
+            append("<s>")
+            append("<|system_start|>")
+            append("You are Apertus, a helpful assistant created by the SwissAI initiative.\n")
+            append("Knowledge cutoff: 2024-04\n")
+            append("Current date: $fixedDate")
+            append("<|system_end|>")
+            append("<|developer_start|>")
+            append("Deliberation: disabled\n")
+            append("Tool Capabilities: disabled")
+            append("<|developer_end|>")
+            append("<|user_start|>Hi<|user_end|>")
+            append("<|assistant_start|>")
+        }
+        assertEquals(expected, out)
+    }
+
+    @Test
+    fun case2_caller_supplied_system_replaces_default() {
+        val out = template().apply(
+            messages = listOf(
+                ChatMessage(role = ChatRole.SYSTEM, content = "You are a calculator."),
+                ChatMessage(role = ChatRole.USER, content = "1+1?"),
+            ),
+            tools = emptyList(),
+            addGenerationPrompt = true,
+        )
+        assertTrue(out.startsWith("<s><|system_start|>You are a calculator.<|system_end|>"), "system override missing: $out")
+        assertTrue(out.contains("<|developer_start|>Deliberation: disabled\nTool Capabilities: disabled<|developer_end|>"))
+        assertTrue(out.contains("<|user_start|>1+1?<|user_end|>"))
+        assertTrue(out.endsWith("<|assistant_start|>"))
+        assertTrue(!out.contains("Apertus"), "default system message must not leak when caller supplied one: $out")
+    }
+
+    @Test
+    fun case3_assistant_string_content_round_trips() {
+        val out = template().apply(
+            messages = listOf(
+                ChatMessage(role = ChatRole.SYSTEM, content = "Be helpful."),
+                ChatMessage(role = ChatRole.USER, content = "Hi"),
+                ChatMessage(role = ChatRole.ASSISTANT, content = "Hello there."),
+            ),
+            tools = emptyList(),
+            addGenerationPrompt = true,
+        )
+        // Assistant turn opens, content, closes, then a fresh assistant_start for generation
+        assertTrue(out.contains("<|assistant_start|>Hello there.<|assistant_end|>"), "assistant content not framed correctly: $out")
+        assertTrue(out.endsWith("<|assistant_start|>"), "missing trailing generation prompt: $out")
+    }
+
+    @Test
+    fun case3_assistant_string_content_no_generation_prompt() {
+        val out = template().apply(
+            messages = listOf(
+                ChatMessage(role = ChatRole.SYSTEM, content = "Be helpful."),
+                ChatMessage(role = ChatRole.USER, content = "Hi"),
+                ChatMessage(role = ChatRole.ASSISTANT, content = "Hello there."),
+            ),
+            tools = emptyList(),
+            addGenerationPrompt = false,
+        )
+        // No trailing assistant_start
+        assertTrue(out.endsWith("<|assistant_end|>"), "should end with assistant_end when no generation prompt: $out")
+    }
+
+    @Test
+    fun case4_tool_calls_in_assistant_emit_tools_prefix_array_suffix() {
+        val calc = ToolDefinition(
+            name = "calculator",
+            description = "Evaluate an arithmetic expression.",
+            parameters = buildJsonObject {
+                put("type", "object")
+                put("properties", buildJsonObject {
+                    put("expression", buildJsonObject {
+                        put("type", "string")
+                        put("description", "Expression like '1 + 2'.")
+                    })
+                })
+                put("required", buildJsonArray { add(JsonPrimitive("expression")) })
+            }
+        )
+        val out = template().apply(
+            messages = listOf(
+                ChatMessage(role = ChatRole.SYSTEM, content = "Use tools."),
+                ChatMessage(role = ChatRole.USER, content = "What is 1+1?"),
+                ChatMessage(
+                    role = ChatRole.ASSISTANT,
+                    content = "",
+                    toolCalls = listOf(
+                        ToolCall(
+                            id = "tc-0",
+                            name = "calculator",
+                            arguments = buildJsonObject { put("expression", "1+1") }
+                        )
+                    )
+                ),
+                ChatMessage(role = ChatRole.TOOL, content = "2"),
+                ChatMessage(role = ChatRole.ASSISTANT, content = "The answer is 2."),
+            ),
+            tools = listOf(calc),
+            addGenerationPrompt = true,
+        )
+        // Developer block lists the tool with TypeScript syntax
+        assertTrue(
+            out.contains("Tool Capabilities:\n// Evaluate an arithmetic expression.\ntype calculator = (_: {"),
+            "tool capabilities not rendered as TypeScript: $out",
+        )
+        assertTrue(out.contains("expression: string"), "expression param missing: $out")
+        // Assistant emits tool_calls block
+        assertTrue(
+            out.contains("""<|tools_prefix|>[{"calculator": {"expression":"1+1"}}]<|tools_suffix|>"""),
+            "tool call block missing or malformed: $out",
+        )
+        // Tool message renders as bracketed output continuing the same assistant turn
+        assertTrue(out.contains("<|tools_suffix|>[2]"), "tool output bracket missing: $out")
+        // Final response continues the SAME assistant turn (closes only at the end)
+        assertTrue(out.contains("The answer is 2."), "final response missing: $out")
+    }
+
+    @Test
+    fun add_generation_prompt_false_omits_trailing_assistant_start() {
+        val out = template().apply(
+            messages = listOf(ChatMessage(role = ChatRole.USER, content = "Hi")),
+            tools = emptyList(),
+            addGenerationPrompt = false,
+        )
+        assertTrue(!out.endsWith("<|assistant_start|>"), "trailing assistant_start should be absent: $out")
+    }
+
+    @Test
+    fun parseThinkingBlocks_extracts_inner_pairs() {
+        val text = "answer prefix<|inner_prefix|>step 1<|inner_suffix|>middle<|inner_prefix|>step 2<|inner_suffix|>tail"
+        val blocks = template().parseThinkingBlocks(text)
+        assertEquals(listOf("step 1", "step 2"), blocks)
+    }
+
+    @Test
+    fun stripThinking_removes_inner_blocks() {
+        val text = "before<|inner_prefix|>thoughts<|inner_suffix|>after"
+        assertEquals("beforeafter", template().stripThinking(text))
+    }
+
+    @Test
+    fun stripThinking_keeps_unterminated_block_intact() {
+        val text = "before<|inner_prefix|>oops"
+        assertEquals(text, template().stripThinking(text))
+    }
+
+    @Test
+    fun enable_thinking_flag_flips_developer_line() {
+        val out = ApertusChatTemplate(currentDate = fixedDate, enableThinking = true).apply(
+            messages = listOf(ChatMessage(role = ChatRole.USER, content = "Hi")),
+            tools = emptyList(),
+            addGenerationPrompt = true,
+        )
+        assertTrue(out.contains("Deliberation: enabled"), "enable_thinking=true should flip developer line: $out")
+    }
+}

--- a/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ApertusToolCallParserStrategyTest.kt
+++ b/llm-agent/src/commonTest/kotlin/sk/ainet/apps/kllama/chat/ApertusToolCallParserStrategyTest.kt
@@ -1,0 +1,111 @@
+package sk.ainet.apps.kllama.chat
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ApertusToolCallParserStrategy]. Format reference:
+ * `docs/specs/apertus-chat-template.md`. The parser scans for
+ * `<|tools_prefix|>...<|tools_suffix|>`, parses the inner JSON
+ * array, and emits one [ToolCall] per single-key object.
+ */
+class ApertusToolCallParserStrategyTest {
+
+    @Test
+    fun parses_single_tool_call() {
+        val text = """The answer:<|tools_prefix|>[{"calculator": {"expression": "1+1"}}]<|tools_suffix|>"""
+        val calls = ApertusToolCallParserStrategy.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("calculator", calls[0].name)
+        assertEquals("1+1", calls[0].arguments["expression"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun parses_multiple_parallel_tool_calls() {
+        val text = """<|tools_prefix|>[{"a": {"x": 1}}, {"b": {"y": "two"}}]<|tools_suffix|>"""
+        val calls = ApertusToolCallParserStrategy.parse(text)
+        assertEquals(2, calls.size)
+        assertEquals("a", calls[0].name)
+        assertEquals("b", calls[1].name)
+        assertEquals(1, calls[0].arguments["x"]?.jsonPrimitive?.content?.toInt())
+        assertEquals("two", calls[1].arguments["y"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun returns_empty_when_no_markers_present() {
+        val calls = ApertusToolCallParserStrategy.parse("plain text without tool calls")
+        assertTrue(calls.isEmpty())
+    }
+
+    @Test
+    fun returns_empty_when_payload_invalid_json() {
+        val text = "<|tools_prefix|>not valid json<|tools_suffix|>"
+        val calls = ApertusToolCallParserStrategy.parse(text)
+        assertTrue(calls.isEmpty(), "invalid payload must not crash: $text")
+    }
+
+    @Test
+    fun returns_empty_when_object_has_zero_or_multiple_keys() {
+        // Two-key object — Apertus's spec says exactly one key per object.
+        val text = """<|tools_prefix|>[{"a": {}, "b": {}}]<|tools_suffix|>"""
+        assertTrue(ApertusToolCallParserStrategy.parse(text).isEmpty())
+        // Empty object — also ignored.
+        val emptyObj = """<|tools_prefix|>[{}]<|tools_suffix|>"""
+        assertTrue(ApertusToolCallParserStrategy.parse(emptyObj).isEmpty())
+    }
+
+    @Test
+    fun returns_empty_when_only_one_marker_present() {
+        assertTrue(ApertusToolCallParserStrategy.parse("<|tools_prefix|>[{\"a\": {}}]").isEmpty())
+        assertTrue(ApertusToolCallParserStrategy.parse("[{\"a\": {}}]<|tools_suffix|>").isEmpty())
+    }
+
+    @Test
+    fun containsToolCall_requires_both_markers() {
+        assertTrue(ApertusToolCallParserStrategy.containsToolCall("<|tools_prefix|>[]<|tools_suffix|>"))
+        assertFalse(ApertusToolCallParserStrategy.containsToolCall("<|tools_prefix|>[]"))
+        assertFalse(ApertusToolCallParserStrategy.containsToolCall("[]<|tools_suffix|>"))
+        assertFalse(ApertusToolCallParserStrategy.containsToolCall("plain text"))
+    }
+
+    @Test
+    fun assigns_distinct_ids_to_each_call() {
+        val text = """<|tools_prefix|>[{"a": {}}, {"b": {}}, {"c": {}}]<|tools_suffix|>"""
+        val calls = ApertusToolCallParserStrategy.parse(text)
+        assertEquals(3, calls.size)
+        assertEquals(setOf("apertus-tool-call-0", "apertus-tool-call-1", "apertus-tool-call-2"), calls.map { it.id }.toSet())
+    }
+
+    @Test
+    fun ignores_text_outside_markers() {
+        val text = "preamble<|tools_prefix|>[{\"x\": {}}]<|tools_suffix|>postscript"
+        val calls = ApertusToolCallParserStrategy.parse(text)
+        assertEquals(1, calls.size)
+        assertEquals("x", calls[0].name)
+    }
+
+    @Test
+    fun resolver_picks_apertus_for_apertus_family() {
+        val md = ModelMetadata(family = "apertus", architecture = "apertus")
+        val support = ToolCallingSupportResolver.resolve(md)
+        assertNotNull(support)
+        assertEquals("apertus", support.family)
+    }
+
+    @Test
+    fun resolver_picks_apertus_for_apertus_chat_template_marker() {
+        val md = ModelMetadata(
+            family = null,
+            architecture = null,
+            chatTemplate = "...something with <|assistant_start|> in it..."
+        )
+        val support = ToolCallingSupportResolver.resolve(md)
+        assertNotNull(support)
+        assertEquals("apertus", support.family)
+    }
+}

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/ModelRegistry.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/ModelRegistry.kt
@@ -63,7 +63,7 @@ public enum class ModelFamily(
     LLAMA("llama", "LLaMA / Mistral", true, "llama3"),
     QWEN("qwen", "Qwen", true, "qwen"),
     GEMMA("gemma", "Gemma", true, "gemma"),
-    APERTUS("apertus", "Apertus", false, "apertus"),
+    APERTUS("apertus", "Apertus", true, "apertus"),
     BERT("bert", "BERT", false, null),
     VOXTRAL("voxtral", "Voxtral TTS", false, null),
     UNKNOWN("unknown", "Unknown", false, null);


### PR DESCRIPTION
## Summary

PR 3 of the Apertus rollout (see [APERTUS_ROLLOUT.md](APERTUS_ROLLOUT.md)). Lands the `ApertusChatTemplate` + `ApertusToolCallParserStrategy` + `ApertusToolCallingSupport` implementations against the format documented in PR 2 (`docs/specs/apertus-chat-template.md`). Wires them into `ToolCallingSupportResolver` and flips `ModelRegistry.APERTUS.supportsToolCalling=true`.

After this PR: `skainet-cli --agent --template=apertus` against an Apertus checkpoint emits properly-framed `<|tools_prefix|>[{"<tool>": <args>}]<|tools_suffix|>` tool calls and parses them back into `ToolCall` objects for invocation.

## What's added

- **`ApertusChatTemplate.kt`** — implements `ChatTemplate`. Hand-coded rendering of the Apertus format: BOS + system block + always-emitted developer block (carries `Deliberation:` + `Tool Capabilities:`) + per-message turns. TypeScript-style tool renderer for primitive/array/shallow-object; complex schemas collapse to `any`. Configurable `currentDate` so tests are deterministic.
- **`ApertusToolCallParserStrategy.kt`** — parses `<|tools_prefix|>[...]<|tools_suffix|>` JSON arrays into `ToolCall` instances. Resilient to invalid JSON and ignores multi-key/empty objects.
- **`ApertusToolCallingSupport.kt`** — wires template + parser into the `ToolCallingSupport` contract. `supports()` matches family or arch `"apertus"`, or chat_template containing `<|assistant_start|>` (Apertus's distinctive marker).

## What's modified

- **`ToolCallingSupportResolver.kt`** — registers `ApertusToolCallingSupport()` after `GemmaToolCallingSupport()` in the providers list.
- **`ModelRegistry.kt:66`** — `APERTUS.supportsToolCalling` `false` → `true`.

## Tests

**21 cases, all green:**

- `ApertusChatTemplateTest` (10) — covers the four canonical scenarios from the spec: user-only with default system + disabled developer block, caller-supplied system, assistant string content round-trip with and without generation prompt, full tool-calls flow with developer-block tool rendering + tools_prefix/suffix + bracketed tool output + final response. Plus `parseThinkingBlocks` / `stripThinking` / unterminated-block handling / `enable_thinking` flag.
- `ApertusToolCallParserStrategyTest` (11) — single + parallel tool calls, missing-marker / invalid-JSON resilience, single-key invariant, distinct call ID assignment, resolver dispatch by family and by chat_template marker.

```
$ ./gradlew :llm-agent:jvmTest --tests '*Apertus*'
ApertusChatTemplateTest[jvm]: tests=10 skipped=0 failures=0 errors=0
ApertusToolCallParserStrategyTest[jvm]: tests=11 skipped=0 failures=0 errors=0
```

## Test plan

- [x] `:llm-agent:jvmTest --tests '*Apertus*'` — 21/21 pass
- [ ] CI green
- [ ] End-to-end `skainet-cli -m <apertus.gguf> --agent --template=apertus` invocation against a real Apertus checkpoint — requires checkpoint not on the dev machine; manual verification deferred (the unit tests cover the load-bearing behavior — template rendering and tool-call parsing — so the integration risk is low)

## Limitations carried as source TODOs

1. **TypeScript renderer simplification.** The hand-coded renderer covers what the calculator + file-listing demo tools need (string, number, boolean, primitive arrays, shallow objects). `oneOf`, deep nesting, `enum`, union arrays, `nullable` all collapse to `any`. Acceptable until a consumer hits it.
2. **Byte-for-byte parity vs the Jinja template** would need a Jinja runtime (Pebble/jinjava); JVM-only, doesn't fit `commonTest`. Structural assertions cover the same observable behavior. A follow-up could add a JVM-only parity harness if divergence is reported.
3. **Multi-block assistant content** (the Jinja's `thoughts` / `tool_outputs` / `response` block model) isn't expressible in our `ChatMessage` data class — we map `toolCalls: List<ToolCall>?` to the tools_prefix/suffix form and treat TOOL role messages as bracketed continuations of the open assistant turn. Equivalent to the Jinja's "Shape 1 + tool_calls" handling.

## After this PR

PR 4 of the rollout (`feat(kapertus): rebuild CLI under llm-apps/`) is **optional polish** — the unified `skainet-cli` works correctly for Apertus after PRs 1-3. PR 4 only matters if there's a specific reason to ship a separate Apertus-only CLI binary. See `APERTUS_ROLLOUT.md` for the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)