### PR TITLE
chore(deps): bump skainet to 0.23.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-skainet = "0.22.1"
+skainet = "0.23.0"
 agp = "9.2.0"
 jacksonDatabind = "2.21.3"
 jsonSchemaValidator = "3.0.2"


### PR DESCRIPTION
## Summary

Picks up two SKaiNET 0.23.0 changes that benefit this repo's consumers without any source changes here:

- **K/N `createRandomAccessSource` now has a POSIX-`pread` implementation** ([SKaiNET#591](https://github.com/SKaiNET-developers/SKaiNET/pull/591)). K/N consumers can now load GGUFs above the ~2 GiB Kotlin `ByteArray` ceiling. The `randomAccessProvider` overloads on `*NetworkLoader.fromGguf(...)` and the `fromRandomAccessSource(...)` variant on `GGUFTokenizer` already exist in this repo — they just couldn't actually open a file on macOS / Linux / iOS native targets before 0.23.0. Verified end-to-end against `Qwen3-1.7B-Q8_0.gguf` (1.8 GiB) on macOS arm64: previously OOMed at construction; now loads.
- **Lazy zero-init for parameter placeholders** ([SKaiNET#588](https://github.com/SKaiNET-developers/SKaiNET/pull/588)). Ends real-model load-time OOMs in the DSL builders that the network loaders in this repo sit on top of (Apertus-8B Q4_K_S previously needed ~27 GB of FP32 zeros eagerly allocated; now loads in 12 GB heap).

## Test plan

- [x] `./gradlew :llm-runtime:kllama:compileKotlinJvm :llm-runtime:kllama:compileKotlinMacosArm64`
- [x] `./gradlew :llm-agent:compileKotlinJvm`
- [x] `./gradlew :llm-inference:llama:compileKotlinJvm :llm-inference:qwen:compileKotlinJvm`

All clean (only pre-existing `LlamaRuntime` deprecation warnings, unrelated). No source changes — pure version bump.

## Follow-ups (separate PRs)

- Migrate this repo's own native CLIs (`kllama` etc.) from `LlamaIngestion.load { source }` + `GGUFTokenizer.fromSource(...)` to the streaming siblings (`loadStreaming(randomAccessProvider)`, `fromRandomAccessSource(...)`) so they can actually open larger GGUFs on K/N.