### PR TITLE
feat(apertus): block-major TensorData wiring for NATIVE_OPTIMIZED Q4_K E2E

### DIFF
--- a/llm-inference/apertus/src/commonMain/kotlin/sk/ainet/models/apertus/ApertusRuntimeWeights.kt
+++ b/llm-inference/apertus/src/commonMain/kotlin/sk/ainet/models/apertus/ApertusRuntimeWeights.kt
@@ -136,12 +136,32 @@ public data class ApertusQuantizedRuntimeWeights(
 
 /**
  * Intermediate weight container used during loading.
+ *
+ * @property quantTypes For each tensor that was quantized in the source GGUF,
+ *   the original [sk.ainet.io.gguf.GGMLQuantizationType]. Empty when the
+ *   loader fully dequantized everything (e.g. `QuantPolicy.DEQUANTIZE_TO_FP32`).
+ *   Populated under `NATIVE_OPTIMIZED` so the JVM-side
+ *   `ApertusMemSegConverter` can wrap each tensor in the right
+ *   block-major TensorData (Q4_KBlockTensorData / Q6_KBlockTensorData / …)
+ *   before the model runs.
+ * @property logicalShapes Logical `[out, in]` shapes of every tensor, indexed
+ *   by tensor name. Under `NATIVE_OPTIMIZED` the actual stored
+ *   `tensors[name].shape` is byte-level rank-1, so the converter needs the
+ *   logical shape from this side-map to compute the relayout target shape.
+ * @property quantBytes Raw quantized payload bytes keyed by tensor name.
+ *   The loader stashes these alongside the byte-shape tensors in `tensors`
+ *   so the converter can re-wrap them in the right `Q*_KBlockTensorData`
+ *   without having to dig the bytes back out of the loader's intermediate
+ *   `Int8 [byteCount]` tensor.
  */
 public data class ApertusWeights<T : DType, V>(
     val metadata: ApertusModelMetadata,
     val tensors: Map<String, Tensor<T, V>>,
     val xieluParams: Map<Int, ApertusXIELUParams> = emptyMap(),
-    val preTransposed: Boolean = false
+    val preTransposed: Boolean = false,
+    val quantTypes: Map<String, sk.ainet.io.gguf.GGMLQuantizationType> = emptyMap(),
+    val logicalShapes: Map<String, sk.ainet.lang.tensor.Shape> = emptyMap(),
+    val quantBytes: Map<String, ByteArray> = emptyMap()
 )
 
 /**

--- a/llm-inference/apertus/src/commonMain/kotlin/sk/ainet/models/apertus/ApertusWeightLoader.kt
+++ b/llm-inference/apertus/src/commonMain/kotlin/sk/ainet/models/apertus/ApertusWeightLoader.kt
@@ -115,18 +115,36 @@ public class ApertusWeightLoader private constructor(
         val tensorByName = reader.tensors.associateBy { it.name }
         val byName = linkedMapOf<String, Tensor<T, V>>()
         val xieluParams = mutableMapOf<Int, ApertusXIELUParams>()
+        val quantTypes = linkedMapOf<String, GGMLQuantizationType>()
+        val logicalShapes = linkedMapOf<String, Shape>()
+        val quantBytes = linkedMapOf<String, ByteArray>()
+        val nativeOptimized = quantPolicy == QuantPolicy.NATIVE_OPTIMIZED
 
         // Load required tensors
         requiredTensorNames(metadata).forEach { name ->
             val rt = tensorByName[name]
                 ?: error("Missing required tensor in GGUF payload: $name")
-            byName[name] = loadReaderTensor(ctx, dtype, reader, rt, name)
+            if (nativeOptimized && shouldDeferToConverterReader(name, rt)) {
+                val raw = if (rt.data.isEmpty()) reader.materialize(rt) else rt.data
+                quantBytes[name] = DequantOps.toByteArray(raw, rt.name)
+                trackQuantInfo(name, rt, quantTypes, logicalShapes)
+            } else {
+                byName[name] = loadReaderTensor(ctx, dtype, reader, rt, name)
+                trackQuantInfo(name, rt, quantTypes, logicalShapes)
+            }
         }
 
         // Load optional rope_freqs tensor
         tensorByName[ApertusTensorNames.ROPE_FREQS]?.let { rt ->
-            byName[ApertusTensorNames.ROPE_FREQS] =
-                loadReaderTensor(ctx, dtype, reader, rt, ApertusTensorNames.ROPE_FREQS)
+            if (nativeOptimized && shouldDeferToConverterReader(ApertusTensorNames.ROPE_FREQS, rt)) {
+                val raw = if (rt.data.isEmpty()) reader.materialize(rt) else rt.data
+                quantBytes[ApertusTensorNames.ROPE_FREQS] = DequantOps.toByteArray(raw, rt.name)
+                trackQuantInfo(ApertusTensorNames.ROPE_FREQS, rt, quantTypes, logicalShapes)
+            } else {
+                byName[ApertusTensorNames.ROPE_FREQS] =
+                    loadReaderTensor(ctx, dtype, reader, rt, ApertusTensorNames.ROPE_FREQS)
+                trackQuantInfo(ApertusTensorNames.ROPE_FREQS, rt, quantTypes, logicalShapes)
+            }
         }
 
         // Extract xIELU params: try metadata fields first, then per-layer tensors
@@ -135,7 +153,15 @@ public class ApertusWeightLoader private constructor(
             extractXIELUParamsFromReader(reader, tensorByName, metadata.blockCount, xieluParams)
         }
 
-        return ApertusWeights(metadata, byName, xieluParams, preTransposed)
+        return ApertusWeights(
+            metadata = metadata,
+            tensors = byName,
+            xieluParams = xieluParams,
+            preTransposed = preTransposed,
+            quantTypes = quantTypes,
+            logicalShapes = logicalShapes,
+            quantBytes = quantBytes
+        )
     }
 
     // ============== Streaming loading ==============
@@ -159,17 +185,37 @@ public class ApertusWeightLoader private constructor(
             val tensorByName = reader.tensors.associateBy { it.name }
             val byName = linkedMapOf<String, Tensor<T, V>>()
             val xieluParams = mutableMapOf<Int, ApertusXIELUParams>()
+            val quantTypes = linkedMapOf<String, GGMLQuantizationType>()
+            val logicalShapes = linkedMapOf<String, Shape>()
+            val quantBytes = linkedMapOf<String, ByteArray>()
+            val nativeOptimized = quantPolicy == QuantPolicy.NATIVE_OPTIMIZED
 
             requiredTensorNames(metadata).forEach { name ->
                 val st = tensorByName[name]
                     ?: error("Missing required tensor in GGUF payload: $name")
-                byName[name] = loadStreamingTensor(ctx, dtype, reader, st, name)
+                if (nativeOptimized && shouldDeferToConverter(name, st)) {
+                    // The JVM `ApertusMemSegConverter` will wrap these bytes in
+                    // the right block-major TensorData. Skip the intermediate
+                    // byte-shape `Int8` tensor — it'd just double the heap
+                    // footprint and gets immediately discarded by the converter.
+                    quantBytes[name] = reader.loadTensorData(st)
+                    trackQuantInfo(name, st, quantTypes, logicalShapes)
+                } else {
+                    byName[name] = loadStreamingTensor(ctx, dtype, reader, st, name)
+                    trackQuantInfo(name, st, quantTypes, logicalShapes)
+                }
             }
 
             // Load optional rope_freqs tensor
             tensorByName[ApertusTensorNames.ROPE_FREQS]?.let { st ->
-                byName[ApertusTensorNames.ROPE_FREQS] =
-                    loadStreamingTensor(ctx, dtype, reader, st, ApertusTensorNames.ROPE_FREQS)
+                if (nativeOptimized && shouldDeferToConverter(ApertusTensorNames.ROPE_FREQS, st)) {
+                    quantBytes[ApertusTensorNames.ROPE_FREQS] = reader.loadTensorData(st)
+                    trackQuantInfo(ApertusTensorNames.ROPE_FREQS, st, quantTypes, logicalShapes)
+                } else {
+                    byName[ApertusTensorNames.ROPE_FREQS] =
+                        loadStreamingTensor(ctx, dtype, reader, st, ApertusTensorNames.ROPE_FREQS)
+                    trackQuantInfo(ApertusTensorNames.ROPE_FREQS, st, quantTypes, logicalShapes)
+                }
             }
 
             // Extract xIELU params: try metadata fields first, then per-layer tensors
@@ -178,8 +224,94 @@ public class ApertusWeightLoader private constructor(
                 extractXIELUParamsFromStreaming(reader, tensorByName, metadata.blockCount, xieluParams)
             }
 
-            ApertusWeights(metadata, byName, xieluParams, preTransposed)
+            ApertusWeights(
+                metadata = metadata,
+                tensors = byName,
+                xieluParams = xieluParams,
+                preTransposed = preTransposed,
+                quantTypes = quantTypes,
+                logicalShapes = logicalShapes,
+                quantBytes = quantBytes
+            )
         }
+    }
+
+    /**
+     * Records the original GGUF tensor type and logical `[out, in]` shape so
+     * the JVM-side `ApertusMemSegConverter` can wrap each tensor in the right
+     * block-major TensorData. We only track tensors that are actually
+     * quantized — F32 / F16 / BF16 don't need converter dispatch.
+     *
+     * The token embedding is always force-dequant'd to FP32 in
+     * [loadStreamingTensor] / [loadReaderTensor] (for the gather lookup), so
+     * we deliberately skip it here even though the GGUF tensor type is Q4_K /
+     * Q6_K. This keeps the converter from re-wrapping a tensor that's
+     * already in the right form.
+     */
+    /**
+     * Convert a GGUF-stored shape `[in, out]` to the logical PyTorch
+     * `[out, in]` shape every downstream API in this codebase assumes
+     * (`Linear.init`, `Embedding`, `Gemma4WeightMapper`, `WeightMapper`,
+     * etc.). GGUF lists dimensions fastest-varying-first; PyTorch lists them
+     * fastest-varying-last. Reversing the dim list flips between the two
+     * conventions. Norm-style rank-1 tensors are unaffected.
+     */
+    private fun logicalShape(ggufDims: List<UInt>): Shape =
+        Shape(*ggufDims.map { it.toInt() }.reversed().toIntArray())
+
+    /**
+     * Whether the JVM-side `ApertusMemSegConverter` will replace the tensor's
+     * stored value, in which case the loader skips the intermediate
+     * byte-shape `Int8` wrapping to avoid double-buffering 5 GB of bytes on
+     * Apertus-8B-class models. The converter handles every quantized type
+     * except `TOKEN_EMBEDDINGS` (already force-dequant'd by the loader).
+     */
+    private fun shouldDeferToConverter(name: String, st: StreamingTensorInfo): Boolean {
+        if (name == ApertusTensorNames.TOKEN_EMBEDDINGS) return false
+        return when (st.tensorType) {
+            GGMLQuantizationType.F32,
+            GGMLQuantizationType.F16,
+            GGMLQuantizationType.BF16 -> false
+            else -> true
+        }
+    }
+
+    private fun shouldDeferToConverterReader(name: String, rt: ReaderTensor): Boolean {
+        if (name == ApertusTensorNames.TOKEN_EMBEDDINGS) return false
+        return when (rt.tensorType) {
+            GGMLQuantizationType.F32,
+            GGMLQuantizationType.F16,
+            GGMLQuantizationType.BF16 -> false
+            else -> true
+        }
+    }
+
+    private fun trackQuantInfo(
+        name: String,
+        st: StreamingTensorInfo,
+        quantTypes: MutableMap<String, GGMLQuantizationType>,
+        logicalShapes: MutableMap<String, Shape>
+    ) {
+        if (name == ApertusTensorNames.TOKEN_EMBEDDINGS) return
+        if (st.tensorType == GGMLQuantizationType.F32) return
+        if (st.tensorType == GGMLQuantizationType.F16) return
+        if (st.tensorType == GGMLQuantizationType.BF16) return
+        quantTypes[name] = st.tensorType
+        logicalShapes[name] = logicalShape(st.shape)
+    }
+
+    private fun trackQuantInfo(
+        name: String,
+        rt: ReaderTensor,
+        quantTypes: MutableMap<String, GGMLQuantizationType>,
+        logicalShapes: MutableMap<String, Shape>
+    ) {
+        if (name == ApertusTensorNames.TOKEN_EMBEDDINGS) return
+        if (rt.tensorType == GGMLQuantizationType.F32) return
+        if (rt.tensorType == GGMLQuantizationType.F16) return
+        if (rt.tensorType == GGMLQuantizationType.BF16) return
+        quantTypes[name] = rt.tensorType
+        logicalShapes[name] = logicalShape(rt.shape)
     }
 
     // ============== Quantized (lazy-dequant) loading ==============
@@ -273,7 +405,7 @@ public class ApertusWeightLoader private constructor(
         reader: GGUFReader,
         rt: ReaderTensor
     ): Tensor<FP32, Float> {
-        val shape = Shape(*rt.shape.map { it.toInt() }.toIntArray())
+        val shape = logicalShape(rt.shape)
         val raw = if (rt.data.isEmpty()) reader.materialize(rt) else rt.data
         val floats = when (rt.tensorType) {
             GGMLQuantizationType.F32 -> (raw as List<Float>).toFloatArray()
@@ -289,7 +421,7 @@ public class ApertusWeightLoader private constructor(
 
     /** Keep a tensor as raw quantized bytes for lazy dequantization. */
     private fun readerTensorToQuantized(reader: GGUFReader, rt: ReaderTensor): QuantizedTensor {
-        val shape = Shape(*rt.shape.map { it.toInt() }.toIntArray())
+        val shape = logicalShape(rt.shape)
         val raw = if (rt.data.isEmpty()) reader.materialize(rt) else rt.data
         val bytes = DequantOps.toByteArray(raw, rt.name)
         return QuantizedTensor(bytes, rt.tensorType, shape, rt.nElements)
@@ -301,7 +433,7 @@ public class ApertusWeightLoader private constructor(
         reader: StreamingGGUFReader,
         st: StreamingTensorInfo
     ): Tensor<FP32, Float> {
-        val shape = Shape(*st.shape.map { it.toInt() }.toIntArray())
+        val shape = logicalShape(st.shape)
         val bytes = reader.loadTensorData(st)
         val floats = when (st.tensorType) {
             GGMLQuantizationType.F32 -> DequantOps.bytesToFloatArray(bytes)
@@ -317,7 +449,7 @@ public class ApertusWeightLoader private constructor(
         reader: StreamingGGUFReader,
         st: StreamingTensorInfo
     ): QuantizedTensor {
-        val shape = Shape(*st.shape.map { it.toInt() }.toIntArray())
+        val shape = logicalShape(st.shape)
         val bytes = reader.loadTensorData(st)
         return QuantizedTensor(bytes, st.tensorType, shape, st.nElements.toInt())
     }
@@ -584,7 +716,7 @@ public class ApertusWeightLoader private constructor(
             st.tensorType != GGMLQuantizationType.F16 &&
             st.tensorType != GGMLQuantizationType.BF16
         ) {
-            val shape = Shape(*st.shape.map { it.toInt() }.toIntArray())
+            val shape = logicalShape(st.shape)
             val bytes = reader.loadTensorData(st)
             val floats = DequantOps.dequantFromBytes(bytes, st.tensorType, st.nElements.toInt())
             return createTensor(ctx, dtype, shape, floats)
@@ -605,7 +737,7 @@ public class ApertusWeightLoader private constructor(
             rt.tensorType != GGMLQuantizationType.F16 &&
             rt.tensorType != GGMLQuantizationType.BF16
         ) {
-            val shape = Shape(*rt.shape.map { it.toInt() }.toIntArray())
+            val shape = logicalShape(rt.shape)
             val raw = if (rt.data.isEmpty()) reader.materialize(rt) else rt.data
             val bytes: ByteArray = DequantOps.toByteArray(raw, rt.name)
             val floats = DequantOps.dequantFromBytes(bytes, rt.tensorType, rt.nElements)
@@ -621,7 +753,7 @@ public class ApertusWeightLoader private constructor(
         reader: GGUFReader,
         rt: ReaderTensor
     ): Tensor<T, V> {
-        val shape = Shape(*rt.shape.map { it.toInt() }.toIntArray())
+        val shape = logicalShape(rt.shape)
         return when (rt.tensorType) {
             GGMLQuantizationType.F32 -> {
                 val floats = (if (rt.data.isEmpty()) reader.materialize(rt) else rt.data) as List<Float>
@@ -691,7 +823,7 @@ public class ApertusWeightLoader private constructor(
         reader: StreamingGGUFReader,
         st: StreamingTensorInfo
     ): Tensor<T, V> {
-        val shape = Shape(*st.shape.map { it.toInt() }.toIntArray())
+        val shape = logicalShape(st.shape)
         val bytes = reader.loadTensorData(st)
 
         return when (st.tensorType) {
@@ -760,36 +892,26 @@ public class ApertusWeightLoader private constructor(
     /**
      * Create a tensor from dequantized float data.
      *
-     * For 2D tensors from GGUF (stored column-major with shape [out, in]):
-     * - Normal mode: transposes to row-major [in, out] (requires `.t()` in runtime)
-     * - Pre-transposed mode: interprets column-major as row-major [in, out] directly,
-     *   skipping the data transpose. The weights can then be used directly in matmul
-     *   without `.t()`, saving ~50% memory.
+     * Builds a `Tensor<T, V>` from the dequantized FP32 floats. The caller is
+     * expected to have already converted the GGUF dim list to the logical
+     * PyTorch `[out, in]` shape via [logicalShape] — no transpose happens here.
+     *
+     * Earlier revisions of this method transposed the 2D data on the
+     * assumption that the loader passed it the raw GGUF `[in, out]` shape
+     * (treated as column-major). That pre-dated the fix to reverse shapes in
+     * the loader; the transpose here was actively scrambling tensor data on
+     * top of an already-reversed layout, but unit tests never caught it
+     * because they construct weights via [ApertusNetworkLoader.fromWeights]
+     * with synthetic FP32 tensors, bypassing this path entirely.
      */
     @Suppress("UNCHECKED_CAST")
     private fun <T : DType, V> createTensor(
         ctx: ExecutionContext,
         dtype: KClass<T>,
-        originalShape: Shape,
+        logicalShape: Shape,
         data: FloatArray
-    ): Tensor<T, V> {
-        return if (originalShape.rank == 2) {
-            val rows = originalShape[0]
-            val cols = originalShape[1]
-            if (preTransposed) {
-                // Column-major [out, in] is equivalent to row-major [in, out]
-                // Skip data transpose — weights are already in matmul-ready layout
-                val newShape = Shape(cols, rows)
-                ctx.fromFloatArray<T, Float>(newShape, dtype, data) as Tensor<T, V>
-            } else {
-                val transposed = DequantOps.transposeColumnMajorToRowMajor(data, rows, cols)
-                val newShape = Shape(cols, rows)
-                ctx.fromFloatArray<T, Float>(newShape, dtype, transposed) as Tensor<T, V>
-            }
-        } else {
-            ctx.fromFloatArray<T, Float>(originalShape, dtype, data) as Tensor<T, V>
-        }
-    }
+    ): Tensor<T, V> = ctx.fromFloatArray<T, Float>(logicalShape, dtype, data) as Tensor<T, V>
+
 
     // ============== Field helpers ==============
 

--- a/llm-inference/apertus/src/jvmMain/kotlin/sk/ainet/models/apertus/ApertusMemSegConverter.kt
+++ b/llm-inference/apertus/src/jvmMain/kotlin/sk/ainet/models/apertus/ApertusMemSegConverter.kt
@@ -1,0 +1,176 @@
+package sk.ainet.models.apertus
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.gguf.GGMLQuantizationType
+import sk.ainet.io.gguf.dequant.DequantOps
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.Q4_KBlockTensorData
+import sk.ainet.lang.tensor.data.Q4MemorySegmentTensorData
+import sk.ainet.lang.tensor.data.Q6_KBlockTensorData
+import sk.ainet.lang.tensor.data.Q8MemorySegmentTensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.types.FP32
+import java.lang.foreign.Arena
+
+/**
+ * JVM-side post-processor that converts the raw byte-shape quantized tensors
+ * returned by [ApertusWeightLoader] under `QuantPolicy.NATIVE_OPTIMIZED` into
+ * proper block-major / MemorySegment-backed [TensorData] wrappers that the
+ * SIMD / FFM matmul kernels can consume directly.
+ *
+ * Without this step, every Q/K/V/O attention projection and FFN matmul in
+ * the DSL `apertusNetwork()` forward path fails — `linearProject` calls
+ * `ops.matmul(input, ops.transpose(weight))`, but `transpose` rejects the
+ * rank-1 byte tensors the loader produces under `NATIVE_OPTIMIZED`. With
+ * this step, each quantized weight ends up as the right wrapper:
+ *
+ * - `Q4_K` → [Q4_KBlockTensorData] (relayout from GGUF row-major
+ *   `[row, block]` order to the input-block-major `[block, row]` order
+ *   `JvmQuantizedVectorKernels.matmulQ4_KVec` expects). 144-byte blocks.
+ * - `Q6_K` → [Q6_KBlockTensorData]. 210-byte blocks.
+ * - `Q4_0` → [Q4MemorySegmentTensorData] (arena-allocated, 64-byte aligned).
+ * - `Q8_0` → [Q8MemorySegmentTensorData].
+ * - `Q5_K` → fallback: dequant to FP32. Apertus-8B-Instruct-2509 Q4_K_S has
+ *   8 Q5_K tensors out of 324 total — the cost is negligible. `skainet-lang-core`
+ *   has no `Q5_KBlockTensorData` yet; once it does, this branch can switch
+ *   to the packed path.
+ * - Anything else → leave the raw byte tensor in place and warn. The forward
+ *   pass will likely fail downstream, but we don't want to silently dequant
+ *   tensors we don't recognise.
+ *
+ * The token embedding (`token_embd.weight`) is **not** in the
+ * `quantTypes` map by construction — [ApertusWeightLoader] force-dequants
+ * it during loading because `Embedding.gather` requires the logical
+ * `[vocab, dim]` shape. Float tensors (norms, output_norm, …) likewise
+ * pass through this converter unchanged.
+ *
+ * Usage — caller manages the [Arena] lifecycle (the MemorySegment-backed
+ * tensors are valid only while the Arena is open):
+ * ```kotlin
+ * val raw = ApertusWeightLoader.fromRandomAccess(...)
+ *     .loadToMap<FP32, Float>(ctx)
+ * Arena.ofShared().use { arena ->
+ *     val converted = convertApertusWeightsToMemSeg(raw, ctx, arena)
+ *     val model = ApertusNetworkLoader.fromWeights(ctx, converted)
+ *     // ... forward / generate ...
+ * }
+ * ```
+ */
+public fun <T : DType, V> convertApertusWeightsToMemSeg(
+    weights: ApertusWeights<T, V>,
+    ctx: ExecutionContext,
+    arena: Arena
+): ApertusWeights<T, V> {
+    if (weights.quantTypes.isEmpty()) return weights
+
+    // Drain the loader's quant-bytes sidecar as we go so each ~MB byte buffer
+    // is eligible for GC the moment the converter has wrapped (and possibly
+    // relaid) it. Without this we'd hold ~5 GB of raw bytes plus another
+    // ~5 GB of relaid bytes in heap simultaneously on Apertus-8B Q4_K_S.
+    val drainable = HashMap(weights.quantBytes)
+
+    val newTensors = LinkedHashMap(weights.tensors)
+    for ((name, qt) in weights.quantTypes) {
+        val logicalShape = weights.logicalShapes[name] ?: continue
+        val bytes = drainable.remove(name) ?: continue
+        newTensors[name] = convertOne(qt, name, ctx, arena, logicalShape, bytes)
+    }
+    // Drop quantBytes / logicalShapes / quantTypes from the result — they
+    // were one-shot inputs to this converter; carrying them through wastes
+    // ~5 GB of heap on real models.
+    return weights.copy(
+        tensors = newTensors,
+        quantTypes = emptyMap(),
+        logicalShapes = emptyMap(),
+        quantBytes = emptyMap()
+    )
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T : DType, V> convertOne(
+    qt: GGMLQuantizationType,
+    name: String,
+    ctx: ExecutionContext,
+    arena: Arena,
+    logicalShape: Shape,
+    bytes: ByteArray
+): Tensor<T, V> {
+    val advertisedDtype = FP32::class
+    return when (qt) {
+        GGMLQuantizationType.Q4_0 -> {
+            val data = Q4MemorySegmentTensorData.fromRawBytes(logicalShape, bytes, arena)
+            ctx.fromData(data as TensorData<FP32, Float>, advertisedDtype) as Tensor<T, V>
+        }
+
+        GGMLQuantizationType.Q8_0 -> {
+            val data = Q8MemorySegmentTensorData.fromRawBytes(logicalShape, bytes, arena)
+            ctx.fromData(data as TensorData<FP32, Float>, advertisedDtype) as Tensor<T, V>
+        }
+
+        GGMLQuantizationType.Q4_K -> {
+            val relaid = relayoutKSeriesRowMajorToBlockMajor(bytes, logicalShape, BYTES_PER_Q4_K_BLOCK)
+            val data = Q4_KBlockTensorData.fromRawBytes(logicalShape, relaid)
+            ctx.fromData(data as TensorData<FP32, Float>, advertisedDtype) as Tensor<T, V>
+        }
+
+        GGMLQuantizationType.Q6_K -> {
+            val relaid = relayoutKSeriesRowMajorToBlockMajor(bytes, logicalShape, BYTES_PER_Q6_K_BLOCK)
+            val data = Q6_KBlockTensorData.fromRawBytes(logicalShape, relaid)
+            ctx.fromData(data as TensorData<FP32, Float>, advertisedDtype) as Tensor<T, V>
+        }
+
+        GGMLQuantizationType.Q5_K -> {
+            // No packed-path kernel yet — dequant. Apertus-8B Q4_K_S has only 8
+            // of these (~250 MB total dequantised), so the memory cost is small.
+            val floats = DequantOps.dequantFromBytes(bytes, qt, logicalShape.volume)
+            ctx.fromFloatArray<FP32, Float>(logicalShape, advertisedDtype, floats) as Tensor<T, V>
+        }
+
+        else -> {
+            error("ApertusMemSegConverter: unsupported quant type $qt for '$name'. Add a wrapper or fall back to dequant.")
+        }
+    }
+}
+
+private const val BYTES_PER_Q4_K_BLOCK = 144
+private const val BYTES_PER_Q6_K_BLOCK = 210
+private const val K_SERIES_BLOCK_SIZE = 256
+
+/**
+ * Re-layout GGUF K-series bytes from row-major block order
+ * (block at row `r`, block index `b` within the row → byte offset
+ * `(r * blocksPerRow + b) * bytesPerBlock`) to the input-block-major layout
+ * the `matmulQ{K}_Vec` kernels index via `(blockIdx * outDim + r) * bytesPerBlock`.
+ *
+ * For a weight of shape `[outDim, inDim]` with `inDim % 256 == 0`, this is
+ * a 2D block-level transpose of the `[outDim, inDim/256]` block grid. Bytes
+ * inside a block are untouched.
+ */
+internal fun relayoutKSeriesRowMajorToBlockMajor(
+    bytes: ByteArray,
+    shape: Shape,
+    bytesPerBlock: Int
+): ByteArray {
+    require(shape.rank == 2) { "K-series weight must be 2D, got rank ${shape.rank}" }
+    val outDim = shape[0]
+    val inDim = shape[1]
+    require(inDim % K_SERIES_BLOCK_SIZE == 0) {
+        "K-series weight inDim ($inDim) must be a multiple of $K_SERIES_BLOCK_SIZE"
+    }
+    val blocksPerRow = inDim / K_SERIES_BLOCK_SIZE
+    val expected = outDim.toLong() * blocksPerRow.toLong() * bytesPerBlock.toLong()
+    require(bytes.size.toLong() >= expected) {
+        "K-series byte buffer size ${bytes.size} < expected $expected for shape [$outDim, $inDim] @ ${bytesPerBlock}B/block"
+    }
+    val out = ByteArray(bytes.size)
+    for (r in 0 until outDim) {
+        for (b in 0 until blocksPerRow) {
+            val srcOff = (r * blocksPerRow + b) * bytesPerBlock
+            val dstOff = (b * outDim + r) * bytesPerBlock
+            System.arraycopy(bytes, srcOff, out, dstOff, bytesPerBlock)
+        }
+    }
+    return out
+}

--- a/llm-inference/apertus/src/jvmTest/kotlin/sk/ainet/models/apertus/ApertusRealGgufLoadingTest.kt
+++ b/llm-inference/apertus/src/jvmTest/kotlin/sk/ainet/models/apertus/ApertusRealGgufLoadingTest.kt
@@ -2,12 +2,16 @@ package sk.ainet.models.apertus
 
 import kotlinx.coroutines.runBlocking
 import sk.ainet.apps.llm.ModelFamily
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
 import sk.ainet.apps.llm.UnifiedModelLoader
 import sk.ainet.context.DirectCpuExecutionContext
 import sk.ainet.io.JvmRandomAccessSource
 import sk.ainet.io.gguf.StreamingGGUFReader
 import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
 import java.io.File
+import java.lang.foreign.Arena
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -180,33 +184,138 @@ class ApertusRealGgufLoadingTest {
         println("[real-load fromGguf NATIVE_OPTIMIZED] top-modules=${topNames.size}")
     }
 
-    /**
-     * End-to-end inference (forward / generate / tool calling) is intentionally
-     * NOT covered here.
-     *
-     * `ApertusNetworkLoader.fromGguf().load()` succeeds end-to-end (verified by
-     * the test above), and the embedding lookup works after the
-     * `loadStreamingTensor` token-embd dequant special case. But the rest of
-     * the forward pass — Q/K/V/O projections, FFN matmuls — relies on the
-     * standard `linearProject(ops, input, weight) = ops.matmul(input, ops.transpose(weight))`
-     * helper, which assumes a logical rank-2 weight. Under
-     * `QuantPolicy.NATIVE_OPTIMIZED` the loader stores quantized weights as
-     * raw byte-level rank-1 `Int8` tensors so the native FFM kernels can
-     * address the block layout directly — but `ops.transpose(byteShape)` then
-     * fails.
-     *
-     * Gemma's Q4_K end-to-end test works because Gemma's loader uses
-     * `Q4_KBlockTensorData(logicalShape, blockMajorBytes)` with a lazy
-     * `transpose` override and a quant-aware `matmul` dispatch (see
-     * `GemmaDslQ4KTest`, `relayoutQ4_KRowMajorToBlockMajor`). Apertus's
-     * loader stores raw Int8 bytes instead, so `linearProject` blows up at
-     * the first attention projection.
-     *
-     * Tracking issue: see the upstream / transformers follow-up — the
-     * Apertus loader needs per-quant-type tensor-data wrappers
-     * (`Q4_KBlockTensorData` / `Q5_KBlockTensorData` / `Q6_KBlockTensorData`)
-     * with row-major → block-major relayout, mirroring Gemma's path.
-     */
+    @Test
+    fun `forward pass on real Apertus produces finite logits of vocab size`() = runBlocking {
+        val file = modelFile ?: run {
+            println("[skip] Apertus GGUF not found.")
+            return@runBlocking
+        }
+        val maxHeapGb = Runtime.getRuntime().maxMemory() / (1024L * 1024L * 1024L)
+        if (maxHeapGb < 8) {
+            println("[skip] heap=$maxHeapGb GB < 8 GB; rerun with -PapertusTestMaxHeap=12g")
+            return@runBlocking
+        }
+
+        val ctx = DirectCpuExecutionContext.create()
+        val info = UnifiedModelLoader.peek { JvmRandomAccessSource.open(file) }
+
+        // load → convert → fromWeights — the converter wraps each quantized
+        // weight in the right block-major TensorData (Q4_K / Q6_K / Q4_0 / Q8_0)
+        // so the SIMD matmul kernels can dispatch directly. Without it the
+        // first attention projection blows up with "Transpose requires at least
+        // 2 dimensions" because NATIVE_OPTIMIZED stores raw byte-shape rank-1
+        // tensors that the standard transpose+matmul path can't consume.
+        Arena.ofShared().use { arena ->
+            val raw = ApertusWeightLoader.fromRandomAccess(
+                randomAccessProvider = { JvmRandomAccessSource.open(file) },
+                quantPolicy = QuantPolicy.NATIVE_OPTIMIZED
+            ).loadToMap<FP32, Float>(ctx)
+
+            println("[real-forward weights] tensors=${raw.tensors.size} quantTypes=${raw.quantTypes.size} xielu=${raw.xieluParams.size}")
+            raw.xieluParams[0]?.let { p ->
+                println("[real-forward xielu0] alpha_p=${p.alphaP} alpha_n=${p.alphaN} beta=${p.beta} eps=${p.eps}")
+            }
+            raw.tensors[ApertusTensorNames.TOKEN_EMBEDDINGS]?.let { t ->
+                println("[real-forward token_embd shape] ${t.shape}")
+            }
+
+            val converted = convertApertusWeightsToMemSeg(raw, ctx, arena)
+            val model = ApertusNetworkLoader.fromWeights(ctx, converted)
+
+            val runtime = OptimizedLLMRuntime(
+                model = model,
+                ctx = ctx,
+                mode = OptimizedLLMMode.DIRECT,
+                dtype = FP32::class
+            )
+
+            val bosTokenId = (info.fields["tokenizer.ggml.bos_token_id"] as? Number)?.toInt()
+                ?: (info.fields["tokenizer.ggml.bos_token_id"] as? UInt)?.toInt()
+                ?: 1
+            val logits = runtime.forward(bosTokenId)
+
+            assertEquals(info.vocabSize, logits.shape[logits.shape.rank - 1],
+                "last logit dim must equal vocabSize=${info.vocabSize}, got shape ${logits.shape}")
+
+            val buf = logits.data.copyToFloatArray()
+            var nonZero = 0
+            var nan = 0
+            var inf = 0
+            var max = Float.NEGATIVE_INFINITY
+            var min = Float.POSITIVE_INFINITY
+            for (v in buf) {
+                if (v.isNaN()) nan++
+                else if (!v.isFinite()) inf++
+                else {
+                    if (v != 0f) nonZero++
+                    if (v > max) max = v
+                    if (v < min) min = v
+                }
+            }
+            println("[real-forward] vocab=${info.vocabSize} nan=$nan inf=$inf non-zero=$nonZero/${buf.size} min=$min max=$max")
+            assertEquals(0, nan, "logits must not contain NaN")
+            assertEquals(0, inf, "logits must not contain ±Inf")
+            assertTrue(nonZero > buf.size / 2,
+                "expected a broad logit distribution; got $nonZero/${buf.size} non-zero (min=$min max=$max)")
+            assertTrue(max > min,
+                "logits look constant (min=$min max=$max) — model didn't actually run")
+        }
+    }
+
+    @Test
+    fun `greedy generate on real Apertus produces in-vocab token sequence`() = runBlocking {
+        val file = modelFile ?: run {
+            println("[skip] Apertus GGUF not found.")
+            return@runBlocking
+        }
+        val maxHeapGb = Runtime.getRuntime().maxMemory() / (1024L * 1024L * 1024L)
+        if (maxHeapGb < 8) {
+            println("[skip] heap=$maxHeapGb GB < 8 GB; rerun with -PapertusTestMaxHeap=12g")
+            return@runBlocking
+        }
+
+        val ctx = DirectCpuExecutionContext.create()
+        val info = UnifiedModelLoader.peek { JvmRandomAccessSource.open(file) }
+
+        Arena.ofShared().use { arena ->
+            val raw = ApertusWeightLoader.fromRandomAccess(
+                randomAccessProvider = { JvmRandomAccessSource.open(file) },
+                quantPolicy = QuantPolicy.NATIVE_OPTIMIZED
+            ).loadToMap<FP32, Float>(ctx)
+            val converted = convertApertusWeightsToMemSeg(raw, ctx, arena)
+            val model = ApertusNetworkLoader.fromWeights(ctx, converted)
+
+            val bosTokenId = (info.fields["tokenizer.ggml.bos_token_id"] as? Number)?.toInt()
+                ?: (info.fields["tokenizer.ggml.bos_token_id"] as? UInt)?.toInt()
+                ?: 1
+            val runtime = OptimizedLLMRuntime(
+                model = model,
+                ctx = ctx,
+                mode = OptimizedLLMMode.DIRECT,
+                dtype = FP32::class,
+                bos = bosTokenId
+            )
+
+            val steps = 4
+            val generated = mutableListOf<Int>()
+            runtime.generate(
+                prompt = intArrayOf(bosTokenId),
+                steps = steps,
+                temperature = 0f
+            ) { tokenId -> generated.add(tokenId) }
+
+            assertEquals(steps, generated.size, "must emit exactly $steps tokens")
+            for (tokenId in generated) {
+                assertTrue(tokenId in 0 until info.vocabSize,
+                    "generated token $tokenId out of [0, ${info.vocabSize})")
+            }
+            // Greedy on real weights should not collapse to the same token every step.
+            assertTrue(generated.toSet().size > 1,
+                "greedy collapsed to a single token across $steps steps: $generated")
+
+            println("[real-generate greedy] tokens=$generated")
+        }
+    }
 
     private fun locateModel(): File? {
         System.getenv("APERTUS_GGUF_PATH")?.let { p ->


### PR DESCRIPTION
## Summary

Towards #100. Three connected fixes that mirror Gemma's Q4_K end-to-end path so the standard transformer DSL forward can consume Apertus quantized weights instead of crashing at the first matmul.

## What's in

1. **Per-tensor quant sidecar on `ApertusWeights`** — new `quantTypes` / `logicalShapes` / `quantBytes` fields. Default empty; non-`NATIVE_OPTIMIZED` callers see no change.

2. **New jvmMain `ApertusMemSegConverter`** mirroring `GemmaMemSegConverter`:
   - `Q4_K` → `Q4_KBlockTensorData` with row-major → block-major relayout (144 B/block)
   - `Q6_K` → `Q6_KBlockTensorData` (210 B/block)
   - `Q4_0` / `Q8_0` → `Q4MemorySegmentTensorData` / `Q8MemorySegmentTensorData`
   - `Q5_K` → fallback to FP32 dequant (no packed kernel yet; Apertus-8B Q4_K_S has only 8 of these)
   Drains the loader's `quantBytes` as it goes and drops the sidecar maps from the result so we don't carry 5 GB of one-shot byte data through the runtime.

3. **Loader produces logical `[out, in]` shapes, not GGUF `[in, out]`** — fixes two long-standing latent bugs:
   - GGUF lists dims fastest-varying-first; the rest of this codebase follows PyTorch `[out, in]`. Added `logicalShape()` helper that reverses (mirrors Gemma's `reversedShape`); replaced every loader callsite.
   - `createTensor` was running `transposeColumnMajorToRowMajor` on every 2D tensor and flipping its shape on top of the un-reversed input. After the shape fix, that transpose was actively scrambling data. Simplified to a direct `fromFloatArray` with the logical shape.
   Neither tripped a unit test because Apertus DSL pipeline tests use synthetic FP32 weights via `fromWeights`, bypassing this whole loading path.

## End-to-end status against `unsloth/Apertus-8B-Instruct-2509-GGUF` Q4_K_S

| Stage | Result |
|---|---|
| `peek()` / tensor presence / `loadQuantized()` | ✅ |
| `ApertusNetworkLoader.fromGguf().load()` (module build) | ✅ 12 GB heap |
| **Embedding lookup** (token_embd dequant + gather) | ✅ produces correct `[1, dim]` per-token vector |
| Q4_K transpose + matmul through attention projections | ✅ no longer throws |
| Full `forward(BOS)` runs to completion | ✅ ~30 s, 18 GB heap |
| Logits are finite | ❌ all-NaN — **xIELU formula / param-space mismatch, tracked in #103** |

## Why merge as-is

The activation (#103) is an independent thread — formula audit against the HF Apertus reference, not loader work. Everything in this PR is necessary and correct for the loader/converter side; punting the merge until #103 is solved would block any other Apertus loader work that depends on the corrected shapes and the converter API.

When #103 lands, the existing `forward pass on real Apertus produces finite logits` and `greedy generate` smoke tests in `ApertusRealGgufLoadingTest` should pass without additional loader changes.

## Test plan

- [x] `peek detects apertus architecture and reads metadata fields` — ✅
- [x] `streaming reader exposes every tensor required by the apertus loader` — ✅
- [x] `loadQuantized fully populates ApertusQuantizedWeights from real GGUF` — ✅
- [x] `ApertusNetworkLoader fromGguf builds module from real Q4_K_S GGUF` — ✅ (12 GB heap)
- [ ] `forward pass on real Apertus produces finite logits of vocab size` — ❌ NaN, blocked on #103
- [ ] `greedy generate on real Apertus produces in-vocab token sequence` — ❌ blocked on #103
- [ ] xIELU formula audit vs HF Apertus reference — #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)