### PR TITLE
chore(release): prepare 0.23.1 — version-align with SKaiNET 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,108 @@
+# Changelog
+
+All notable changes to **SKaiNET-transformers** are documented here. The
+version line is kept in lock-step with the underlying SKaiNET engine
+(`sk.ainet.core:*`) — a transformers `X.Y.Z` ships against engine `X.Y.Z`.
+
+The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.23.1] — 2026-05-04
+
+Version-aligned with **SKaiNET 0.23.1**.
+
+### Added
+
+- **Apertus end-to-end.** Real-GGUF loading now works on top of skainet 0.23.x's
+  block-major Q4_K `TensorData` wiring. Routing fix to go through
+  `OptimizedLLMRuntime` + `apertusNetwork()`, plus chat template, tool calling,
+  and integration tests against `Apertus-8B-Q4_K_S`. See
+  [`APERTUS_ROLLOUT.md`](APERTUS_ROLLOUT.md).
+- **Gemma 4 chat-model JVM facade** (`Gemma4ChatModel`) for embedded text-only
+  deployments. `close()` now propagates to the mmap arena. The PLE mmap path
+  consumes upstream `loadTensorStorageMapped` rather than maintaining a fork.
+- **Multi-id EOS / stop-token support** in the chat layer — needed for templates
+  that emit several end-of-sequence markers (e.g. ChatML / Apertus).
+- **End-to-end smoke test** in `llm-test/llm-test-java`
+  (`Llama3LeafSmokeTest`) that wires LEAF (`mdbr-leaf-mt`, via `KBertJava`) and
+  Llama 3.2-1B (`KLlamaJava`) in one JVM, gated on env vars / cache fallbacks
+  so CI without the checkpoints cleanly skips.
+- **Apertus tool calling** as a first-class family alongside Llama 3, Gemma 4,
+  Qwen, and ChatML/Hermes.
+
+### Changed
+
+- `gradle/libs.versions.toml` `skainet` pin: 0.22.1 → **0.23.1**.
+- `VERSION_NAME`: 0.21.1 → **0.23.1** (no 0.22.x transformers release was tagged;
+  the version line jumps to keep the engine and consumer artifacts in sync).
+- `kllama-cli` and `skainet-cli` shadow-jar builds now apply the
+  `ServiceLoader` `META-INF/services` merge fix-up so the priority-100
+  `skainet-backend-native-cpu` provider is picked up at runtime.
+- `llm-test/llm-test-java` `maxHeapSize` 8g → 16g — the previous cap OOM'd
+  while loading both Llama 3.2-1B + LEAF in a single JVM.
+
+### Fixed
+
+- `fix(apertus): force-dequant token_embd under NATIVE_OPTIMIZED` — Apertus
+  was producing garbage on quantized embeddings; we now dequant the token
+  embedding tensor regardless of policy, matching upstream behaviour.
+- `fix(tokenizer): auto-detect SentencePiece marker in fromTokenizerJson` —
+  models that ship a `tokenizer.json` without the explicit
+  `pre_tokenizer.type = SentencePiece` marker now decode correctly.
+- `fix(gemma4): produce coherent text on real SafeTensors checkpoint` — the
+  loader path for full HF-format Gemma 4 checkpoints (not just the GGUF
+  variant) now produces coherent generations end-to-end.
+- `fix(apertus): route through OptimizedLLMRuntime + apertusNetwork()` —
+  the legacy direct-runtime path was bypassed; Apertus now flows through the
+  optimized DAG runtime like every other family.
+
+### Tests / CI
+
+- `test(apertus): real-GGUF loader integration test against Apertus-8B-Q4_K_S`.
+- `test(apertus): pin weight-loader fixes with regression tests`.
+- `test(kgemma): fast tokenizer parity guard against HF reference`.
+- `test(kgemma): tighten tool-call probe budget + add env override`.
+- Native-cpu provider now wired into the `qwen` and `llama` JVM test runs so
+  the priority-100 FFM kernels are exercised during CI.
+
+### Docs
+
+- `docs(apertus): document chat-template format` plus the staged-rollout plan
+  at the repo root (`APERTUS_ROLLOUT.md`).
+- README refreshed: lead with native FFM CPU performance numbers, current
+  release coordinates at 0.23.1, "What's new" section in place of the previous
+  "In develop, not in X yet" callout.
+
+### Removed
+
+- `chore(apertus): close out rollout — remove deprecated runtimes`. The
+  pre-rollout direct-runtime entry points for Apertus are gone.
+
+## [0.21.1] — 2026-04-30
+
+Hotfix release: add missing `POM_NAME` for the `apertus`, `voxtral`, and
+`llm-performance` modules so Maven Central publishing succeeds.
+
+## [0.21.0] — 2026-04-29
+
+Version-aligned with **SKaiNET 0.21.0**.
+
+- `chore(release): bump SKaiNET to 0.21.0, prepare transformers 0.21.0` —
+  mirror the engine version in the transformers line so the coupling is
+  explicit for Maven Central consumers. Engine highlights (delivered via
+  the bump): Panama Vector FP32 matmul kernel auto-discovered via
+  `ServiceLoader`, `ScratchPool` SPI, Q4_K SIMD-fused matmul kernel,
+  Q6_K dequant via `ByteVector ql` + `qh` extraction, canonical ggml
+  layout for Q4_K + Q5_K, FP32 `MemSeg` arena leak fix.
+- `VERSION_NAME` jumps 0.18.0 → 0.21.0 to align tags with the engine; no
+  0.17.0 / 0.19.x / 0.20.0 transformers releases were ever tagged.
+
+## [0.18.0] — earlier
+
+Last published transformers release before the engine-aligned version line.
+See `git log v0.16.0..0.18.0` for details.
+
+[0.23.1]: https://github.com/SKaiNET-developers/SKaiNET-transformers/releases/tag/0.23.1
+[0.21.1]: https://github.com/SKaiNET-developers/SKaiNET-transformers/releases/tag/0.21.1
+[0.21.0]: https://github.com/SKaiNET-developers/SKaiNET-transformers/releases/tag/0.21.0
+[0.18.0]: https://github.com/SKaiNET-developers/SKaiNET-transformers/releases/tag/0.18.0

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ High-performance LLM application layer on top of the [SKaiNET](https://github.co
 
 ## Current release
 
-The current release is **0.21.1**. Coordinates:
+The current release is **0.23.1**, version-aligned with the matching SKaiNET engine release. Coordinates:
 
 ```kotlin
 dependencies {
-    implementation("sk.ainet.transformers:llm-core:0.21.1")
-    implementation("sk.ainet.transformers:llm-runtime-kllama:0.21.1") // or kgemma, etc.
-    implementation("sk.ainet.transformers:llm-agent:0.21.1")          // chat templates + tool calling
+    implementation("sk.ainet.transformers:llm-core:0.23.1")
+    implementation("sk.ainet.transformers:llm-runtime-kllama:0.23.1") // or kgemma, kqwen, kapertus
+    implementation("sk.ainet.transformers:llm-agent:0.23.1")          // chat templates + tool calling
 }
 ```
 
-The matching SKaiNET engine is **0.22.1**. To opt in to the native FFM CPU provider (recommended for JVM consumers):
+To opt in to the native FFM CPU provider (recommended for JVM consumers):
 
 ```kotlin
 dependencies {
-    implementation("sk.ainet.core:skainet-backend-cpu:0.22.1")        // priority-50 Panama Vector
-    implementation("sk.ainet.core:skainet-backend-native-cpu:0.22.1") // priority-100 FFM (auto-discovered)
+    implementation("sk.ainet.core:skainet-backend-cpu:0.23.1")        // priority-50 Panama Vector
+    implementation("sk.ainet.core:skainet-backend-native-cpu:0.23.1") // priority-100 FFM (auto-discovered)
 }
 ```
 
@@ -96,11 +96,16 @@ try (KLlamaSession session = KLlamaJava.loadGGUF(modelPath, /* systemPrompt */ n
 
 See `llm-test/llm-test-java/src/test/java/.../KLlamaJavaToolCallingTest.java` for a runnable reference.
 
-## In develop, not in 0.21.1 yet
+## What's new in 0.23.1
 
-- **Apertus support.** Routing fix, chat template, tool calling all merged on `develop`. See [`APERTUS_ROLLOUT.md`](APERTUS_ROLLOUT.md). Real-checkpoint loading has known gaps tracked separately.
-- **Gemma 4 chat-model JVM facade** (`Gemma4ChatModel`) for embedded text-only deployments.
-- **Sharded SafeTensors `loadTensorStorageMapped`** for >2 GB models (consumed by Gemma 4 PLE mmap path).
+- **Apertus end-to-end.** Routing fix (now goes through `OptimizedLLMRuntime` + `apertusNetwork()`), chat template + tool calling, and real-GGUF loading on top of skainet 0.23.1's block-major Q4_K `TensorData` wiring. See [`APERTUS_ROLLOUT.md`](APERTUS_ROLLOUT.md).
+- **Gemma 4 chat-model JVM facade** (`Gemma4ChatModel`) for embedded text-only deployments, with `close()` propagating to the mmap arena and the PLE mmap path consuming upstream `loadTensorStorageMapped`.
+- **Multi-id EOS / stop-token support** in the chat layer — required for templates that emit several end markers.
+- **Tokenizer auto-detect for SentencePiece** in `fromTokenizerJson`, fixing decoding for models that omit the explicit marker.
+- **End-to-end smoke test** in `llm-test/llm-test-java` that wires LEAF (`KBertJava`) and Llama 3 (`KLlamaJava`) in one JVM.
+- **`skainet-cli` and `kllama-cli` shadow-jar `ServiceLoader` fix-up** so the priority-100 native-cpu provider is picked up post-merge.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full set of changes.
 
 ## Engine
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.transformers
-VERSION_NAME=0.21.1
+VERSION_NAME=0.23.1
 
 POM_DESCRIPTION=SKaiNET-transformers
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-skainet = "0.23.0"
+skainet = "0.23.1"
 agp = "9.2.0"
 jacksonDatabind = "2.21.3"
 jsonSchemaValidator = "3.0.2"

--- a/llm-test/llm-test-java/build.gradle.kts
+++ b/llm-test/llm-test-java/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testImplementation(project(":llm-runtime:kllama"))
     testImplementation(project(":llm-agent"))
     testImplementation(project(":llm-inference:llama"))
+    testImplementation(project(":llm-inference:bert"))
 
     // SKaiNET runtime needed by KLlamaJava (JVM target)
     testImplementation(libs.skainet.lang.core)
@@ -31,5 +32,5 @@ tasks.test {
         "--add-modules", "jdk.incubator.vector",
     )
     minHeapSize = "2g"
-    maxHeapSize = "8g"
+    maxHeapSize = "16g"
 }

--- a/llm-test/llm-test-java/src/test/java/sk/ainet/transformers/java/Llama3LeafSmokeTest.java
+++ b/llm-test/llm-test-java/src/test/java/sk/ainet/transformers/java/Llama3LeafSmokeTest.java
@@ -1,0 +1,132 @@
+package sk.ainet.transformers.java;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import sk.ainet.apps.kllama.java.GenerationConfig;
+import sk.ainet.apps.kllama.java.KLlamaJava;
+import sk.ainet.apps.kllama.java.KLlamaSession;
+import sk.ainet.models.bert.java.KBertJava;
+import sk.ainet.models.bert.java.KBertSession;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Fast smoke test that exercises both consumer surfaces in one JVM:
+ *   - LEAF (mdbr-leaf-mt) BERT embeddings via {@link KBertJava}
+ *   - Llama 3 chat generation via {@link KLlamaJava}
+ *
+ * Deliberately does not drive a full agent loop: tool-calling round-trips
+ * with a 1B-param model on CPU prefill the prompt 1–2k tokens per round,
+ * which pushes a "smoke" run into the 10+ minute range. The tool-calling
+ * surface is already covered by {@link KLlamaJavaToolCallingTest}.
+ *
+ * Gated on env vars / cache fallbacks so CI without the checkpoints skips:
+ *   LLAMA3_MODEL_PATH=/path/to/Llama-3.2-1B-Instruct-Q*.gguf
+ *   LEAF_MODEL_DIR=/path/to/MongoDB_mdbr-leaf-ir/   (model.safetensors + vocab.txt)
+ */
+class Llama3LeafSmokeTest {
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void leafEmbeddingAndLlama3GenerationBothWork() throws Exception {
+        Path leafDir = resolveLeafModelDir();
+        Path llamaPath = resolveLlama3Path();
+        assumeTrue(leafDir != null,
+                "No LEAF model dir found — set LEAF_MODEL_DIR or place mdbr-leaf-mt under ~/.deliverance/MongoDB_mdbr-leaf-ir/.");
+        assumeTrue(llamaPath != null,
+                "No Llama 3 GGUF found — set LLAMA3_MODEL_PATH or place a Llama-3.2-Instruct GGUF in the HF cache.");
+
+        // --- LEAF: embed three strings and check that paraphrases score higher
+        //           against each other than against an unrelated topic.
+        try (KBertSession bert = KBertJava.loadSafeTensors(leafDir)) {
+            float[] embA = bert.encode("How do I reset my password?");
+            float[] embB = bert.encode("What is the procedure to recover account access?");
+            float[] embC = bert.encode("The Pacific Ocean is the largest body of water on Earth.");
+
+            assertNotNull(embA, "LEAF returned null embedding for A");
+            assertTrue(embA.length > 0, "LEAF returned empty embedding for A");
+            assertTrue(embA.length == embB.length && embB.length == embC.length,
+                    "LEAF embedding dimensions inconsistent: " + embA.length + "/" + embB.length + "/" + embC.length);
+
+            float simParaphrase = cosineSimilarity(embA, embB);
+            float simUnrelated = cosineSimilarity(embA, embC);
+            assertTrue(simParaphrase > simUnrelated,
+                    "Expected paraphrase similarity (" + simParaphrase
+                            + ") to exceed unrelated similarity (" + simUnrelated + ")");
+        }
+
+        // --- Llama 3: generate a tiny continuation. We don't constrain the text
+        //           (1B model is noisy) — only that the call completes and emits
+        //           non-empty output within the token budget.
+        try (KLlamaSession session = KLlamaJava.loadGGUF(llamaPath, /* systemPrompt */ null)) {
+            GenerationConfig cfg = GenerationConfig.builder()
+                    .maxTokens(16)
+                    .temperature(0f) // greedy: deterministic + skips sampling overhead
+                    .build();
+
+            String response = session.generate("The capital of Slovakia is", cfg);
+
+            assertNotNull(response, "Llama 3 generate() returned null");
+            assertTrue(!response.isBlank(),
+                    "Llama 3 generate() returned blank/empty text");
+        }
+    }
+
+    private static Path resolveLlama3Path() {
+        String env = System.getenv("LLAMA3_MODEL_PATH");
+        if (env != null && !env.isBlank()) {
+            Path p = Path.of(env);
+            return Files.exists(p) ? p : null;
+        }
+        Path snapshotsDir = Path.of(System.getProperty("user.home"),
+                ".cache", "huggingface", "hub",
+                "models--bartowski--Llama-3.2-1B-Instruct-GGUF", "snapshots");
+        if (!Files.isDirectory(snapshotsDir)) return null;
+        File[] snapshots = snapshotsDir.toFile().listFiles(File::isDirectory);
+        if (snapshots == null) return null;
+        for (String name : new String[]{"Llama-3.2-1B-Instruct-Q4_K_M.gguf", "Llama-3.2-1B-Instruct-Q8_0.gguf"}) {
+            for (File s : snapshots) {
+                Path candidate = s.toPath().resolve(name);
+                if (Files.exists(candidate)) return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static Path resolveLeafModelDir() {
+        String env = System.getenv("LEAF_MODEL_DIR");
+        if (env != null && !env.isBlank()) {
+            Path p = Path.of(env);
+            return Files.isDirectory(p) ? p : null;
+        }
+        Path deliverance = Path.of(System.getProperty("user.home"),
+                ".deliverance", "MongoDB_mdbr-leaf-ir");
+        if (Files.isDirectory(deliverance)) return deliverance;
+        return null;
+    }
+
+    private static float cosineSimilarity(float[] a, float[] b) {
+        if (a.length != b.length) {
+            throw new IllegalArgumentException("Embedding dimensions must match: "
+                    + a.length + " vs " + b.length);
+        }
+        double dot = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+        double denom = Math.sqrt(normA) * Math.sqrt(normB);
+        if (denom < 1e-12) return 0f;
+        return (float) (dot / denom);
+    }
+}


### PR DESCRIPTION
## Summary
- Bumps `VERSION_NAME` from 0.21.1 to **0.23.1** and the `skainet` pin in `libs.versions.toml` from 0.23.0 to **0.23.1** so the transformers artifacts publish in lock-step with the engine release. Maven Central serves `sk.ainet.core:*:0.23.1`; verified `:llm-test:llm-test-java:dependencies` resolves cleanly.
- Refreshes the README "Current release" block (coordinates, no separate engine version line — they match) and replaces the stale "In develop, not in 0.21.1 yet" callout with a "What's new in 0.23.1" summary covering the Apertus rollout end-to-end, Gemma 4 chat-model JVM facade, multi-id EOS / stop-token support, SentencePiece auto-detect tokenizer fix, the new LEAF + Llama 3 smoke test, and the shadow-jar `ServiceLoader` fix-up for `kllama-cli` / `skainet-cli`.
- Adds `CHANGELOG.md` as the project's first canonical changelog (Keep-a-Changelog format). Detailed 0.23.1 entry; 0.21.1 / 0.21.0 / 0.18.0 included as historical anchors with pointers to git log.
- Carries forward the LEAF + Llama 3 load/inference smoke test (`Llama3LeafSmokeTest` in `llm-test/llm-test-java`) added on `develop` — verifies `KBertJava` (mdbr-leaf-mt) + `KLlamaJava` (Llama 3.2-1B) both load and emit in one JVM, gated on env vars / cache fallbacks. `maxHeapSize` bumped 8g → 16g for that module to fit both models.

No 0.22.x transformers tag was ever cut, so the version line jumps 0.21.1 → 0.23.1 to re-sync with the engine.

## Test plan
- [ ] `./gradlew check` on a clean workspace at this branch
- [ ] `./gradlew :llm-test:llm-test-java:test --tests sk.ainet.transformers.java.Llama3LeafSmokeTest` passes locally with the LEAF model + a Llama-3.2-1B GGUF in the standard caches (or the `LEAF_MODEL_DIR` / `LLAMA3_MODEL_PATH` env vars set); skips cleanly otherwise.
- [ ] CI green against published `sk.ainet.core:*:0.23.1`.
- [ ] Maven Central publishing dry-run / staging release of `sk.ainet.transformers:*:0.23.1` succeeds with the new POM names already in place from the 0.21.1 hotfix.
- [ ] Confirm the rendered README + CHANGELOG read correctly on the PR's "Files changed" preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)