### PR TITLE
chore(build): drop deprecated kotlin("stdlib-common") from KMP modules

### DIFF
--- a/llm-api/build.gradle.kts
+++ b/llm-api/build.gradle.kts
@@ -50,7 +50,6 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(kotlin("stdlib-common"))
             api(libs.kotlinx.coroutines)
         }
 

--- a/llm-core/build.gradle.kts
+++ b/llm-core/build.gradle.kts
@@ -43,7 +43,6 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(kotlin("stdlib-common"))
             implementation(libs.skainet.lang.core)
             implementation(libs.skainet.compile.dag)
             implementation(libs.skainet.compile.opt)

--- a/llm-performance/build.gradle.kts
+++ b/llm-performance/build.gradle.kts
@@ -51,10 +51,6 @@ kotlin {
     }
 
     sourceSets {
-        commonMain.dependencies {
-            api(kotlin("stdlib-common"))
-        }
-
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }


### PR DESCRIPTION
## Summary
- Removes `api(kotlin("stdlib-common"))` from `llm-api`, `llm-core`, and `llm-performance` `commonMain.dependencies`.
- Kotlin 2.x unified `kotlin-stdlib-common` into `kotlin-stdlib`, and the `kotlin-multiplatform` plugin auto-adds the stdlib to `commonMain`, so the explicit declaration is deprecated and redundant.

## Scope / non-claims
- This is a cleanup PR, **not** a fix for #105. The symptom described in #105 (`compileCommonMainKotlinMetadata` and `compileKotlinJs` failing with unresolved stdlib references) no longer reproduces on current `develop` — it appears to have been resolved indirectly by intervening changes (#106 / #107). The deprecated reference removed here was a *suspected* contributing factor and a latent footgun, not a confirmed root cause.
- No behavior change is expected for downstream consumers.

## Test plan
- [x] `./gradlew :llm-api:compileCommonMainKotlinMetadata :llm-api:compileKotlinJvm :llm-api:compileKotlinJs --rerun-tasks --no-build-cache`
- [x] Same for `:llm-core` and `:llm-performance` — all 9 tasks `BUILD SUCCESSFUL`, no `Unresolved reference` errors.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)