### PR TITLE
feat(llm-core): shared decoder transformer body + DecoderModelMetadata

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderModelMetadata.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderModelMetadata.kt
@@ -1,0 +1,57 @@
+package sk.ainet.lang.nn.dsl.decoder
+
+/**
+ * Architecture-neutral metadata for decoder-only transformer models.
+ *
+ * Captures the structural shape (dim, heads, layers, FFN size, vocab, context)
+ * plus the architecture-specific knobs that show up consistently across
+ * decoder LLMs (RoPE base, RMSNorm epsilon, BOS/EOS token ids).
+ *
+ * Per-architecture metadata types (`LlamaModelMetadata`, `VoxtralModelMetadata`,
+ * etc.) implement this so that [decoderTransformerNetwork] can build a network
+ * from any of them without depending on a specific model module.
+ *
+ * QK-norm and FFN kind are not on this interface — they are *behavioral*
+ * choices passed explicitly to [decoderTransformerNetwork] by each model's
+ * `xNetwork(metadata)` function.
+ */
+public interface DecoderModelMetadata {
+    /** Hidden / embedding dimension (`d_model`). */
+    public val embeddingLength: Int
+
+    /** Maximum sequence length the model was trained for. */
+    public val contextLength: Int
+
+    /** Number of transformer layers. */
+    public val blockCount: Int
+
+    /** Number of attention heads in Q. */
+    public val headCount: Int
+
+    /** Number of KV heads (for GQA / MQA — equal to [headCount] for MHA). */
+    public val kvHeadCount: Int
+
+    /** FFN intermediate dimension. */
+    public val feedForwardLength: Int
+
+    /**
+     * Per-head dimension if explicitly specified by the model file;
+     * otherwise null, in which case `embeddingLength / headCount` is used.
+     */
+    public val ropeDimensionCount: Int?
+
+    /** Vocabulary size. */
+    public val vocabSize: Int
+
+    /** RoPE frequency base (typically 10_000 for Llama, 1_000_000 for Qwen3). */
+    public val ropeFreqBase: Float
+
+    /** RMSNorm epsilon. */
+    public val rmsNormEps: Float
+
+    /** Beginning-of-sequence token id. */
+    public val bosTokenId: Int
+
+    /** End-of-sequence token id. */
+    public val eosTokenId: Int
+}

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderTransformerNetwork.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderTransformerNetwork.kt
@@ -1,0 +1,92 @@
+package sk.ainet.lang.nn.dsl.decoder
+
+import sk.ainet.apps.llm.HybridTransformerBlock
+import sk.ainet.lang.nn.DefaultNeuralNetworkExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.dsl.NeuralNetworkDslImpl
+import sk.ainet.lang.nn.dsl.StageImpl
+import sk.ainet.lang.nn.dsl.embedding
+import sk.ainet.lang.nn.dsl.multiHeadAttention
+import sk.ainet.lang.nn.dsl.residual
+import sk.ainet.lang.nn.dsl.rmsNorm
+import sk.ainet.lang.nn.dsl.sequential
+import sk.ainet.lang.nn.dsl.swiGluFFN
+import sk.ainet.lang.nn.transformer.VoidDense
+import sk.ainet.lang.types.DType
+
+/**
+ * Architecture-neutral decoder-only transformer body builder.
+ *
+ * Architecture: `Embedding → N × (RMSNorm → MHA(RoPE, KVCache, [QK-norm]) →
+ * Residual → RMSNorm → SwiGLU FFN → Residual) → RMSNorm → output Dense`.
+ *
+ * Each model's `xNetwork(metadata)` function should call this with that
+ * model's specific knobs. Per-model `*NetworkDef.kt` files are expected to
+ * be thin (≤ 10 lines) — all composition happens here.
+ *
+ * Currently FFN is hardcoded to SwiGLU (Llama / Qwen / Mistral / Gemma all
+ * use it). When a model with a different FFN variant lands, add an
+ * `ffnKind` parameter rather than copying this builder.
+ *
+ * @param metadata model shape (dim, heads, layers, vocab, …)
+ * @param ropeBase RoPE rotary frequency base. Llama: 10_000, Qwen3: 1_000_000.
+ * @param eps RMSNorm epsilon. Typically 1e-5 (Llama) or 1e-6 (Qwen3).
+ * @param qkNorm whether to apply per-head RMSNorm to Q and K post-projection.
+ *   Qwen3: true. Llama / Mistral: false.
+ * @param qkNormUnitOffset whether the QK-norm uses unit-offset weights
+ *   (Gemma-style). Defaults to false.
+ * @param maxInferenceLen sequence length used to size the KV cache and RoPE
+ *   tables. Capped at min(metadata.contextLength, 4096) by default.
+ */
+public inline fun <reified T : DType, V> decoderTransformerNetwork(
+    metadata: DecoderModelMetadata,
+    ropeBase: Float = metadata.ropeFreqBase,
+    eps: Float = metadata.rmsNormEps,
+    qkNorm: Boolean = false,
+    qkNormUnitOffset: Boolean = false,
+    maxInferenceLen: Int = minOf(metadata.contextLength, 4096),
+): Module<T, V> {
+    val dim = metadata.embeddingLength
+    val nHeads = metadata.headCount
+    val nKVHeads = metadata.kvHeadCount
+    val nLayers = metadata.blockCount
+    val ffnDim = metadata.feedForwardLength
+    val seqLen = maxInferenceLen
+    val vocabSize = metadata.vocabSize
+    val headDim = metadata.ropeDimensionCount ?: (dim / nHeads)
+
+    return sequential<T, V> {
+        val dslImpl = this as NeuralNetworkDslImpl<T, V>
+        dslImpl.embedding(vocabSize, dim, id = "token_embd")
+
+        val nnCtx = DefaultNeuralNetworkExecutionContext()
+        for (layer in 0 until nLayers) {
+            val stage = StageImpl<T, V>(nnCtx, "blk.$layer", T::class)
+            stage.rmsNorm(dim, eps, id = "attn_norm")
+            stage.multiHeadAttention(
+                dim = dim,
+                nHeads = nHeads,
+                nKVHeads = nKVHeads,
+                causal = true,
+                qkNorm = qkNorm,
+                qkNormUnitOffset = qkNormUnitOffset,
+                id = "attn",
+            ) {
+                rope(headDim, seqLen, base = ropeBase)
+                kvCache(seqLen, nKVHeads, headDim)
+            }
+            stage.residual()
+
+            stage.rmsNorm(dim, eps, id = "ffn_norm")
+            stage.swiGluFFN(dim, ffnDim, id = "ffn")
+            stage.residual()
+
+            dslImpl.modules += HybridTransformerBlock(stage.modules.toList(), name = "blk.$layer")
+        }
+
+        dslImpl.rmsNorm(dim, eps, id = "output_norm")
+        // VoidDense placeholder — avoids allocating a [vocabSize, dim] zero
+        // tensor before WeightMapper binds the real `output.weight`.
+        dslImpl.modules += VoidDense<T, V>("output", vocabSize, dim)
+    }
+}

--- a/llm-core/src/jvmTest/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderTransformerNetworkTest.kt
+++ b/llm-core/src/jvmTest/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderTransformerNetworkTest.kt
@@ -1,0 +1,102 @@
+package sk.ainet.lang.nn.dsl.decoder
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import sk.ainet.lang.types.FP32
+
+class DecoderTransformerNetworkTest {
+
+    private fun metadata(
+        layers: Int = 1,
+        ropeFreqBase: Float = 10_000f,
+        rmsNormEps: Float = 1e-5f,
+    ) = TestDecoderMetadata(
+        embeddingLength = 8,
+        contextLength = 32,
+        blockCount = layers,
+        headCount = 2,
+        kvHeadCount = 2,
+        feedForwardLength = 16,
+        ropeDimensionCount = 4,
+        vocabSize = 16,
+        ropeFreqBase = ropeFreqBase,
+        rmsNormEps = rmsNormEps,
+        bosTokenId = 1,
+        eosTokenId = 2,
+    )
+
+    @Test
+    fun `builds expected top-level module tree`() {
+        val model = decoderTransformerNetwork<FP32, Float>(metadata(layers = 2))
+
+        val topLevelNames = model.modules.map { it.name }
+        assertTrue("token_embd" in topLevelNames, "missing token_embd; got $topLevelNames")
+        assertTrue("blk.0" in topLevelNames, "missing blk.0")
+        assertTrue("blk.1" in topLevelNames, "missing blk.1; layers param not honored")
+        assertTrue("output_norm" in topLevelNames, "missing output_norm")
+        assertTrue("output" in topLevelNames, "missing output")
+        assertEquals(5, topLevelNames.size, "unexpected extras in module tree: $topLevelNames")
+    }
+
+    @Test
+    fun `qkNorm flag flips MHA q_norm and k_norm submodules on`() {
+        val withoutQkNorm = decoderTransformerNetwork<FP32, Float>(metadata(), qkNorm = false)
+        val withQkNorm = decoderTransformerNetwork<FP32, Float>(metadata(), qkNorm = true)
+
+        // The qkNorm submodules are nested inside the transformer block's MHA module.
+        // Searching the recursive child tree by name suffix is enough to confirm
+        // the parameter actually wires through.
+        assertTrue(
+            findAnyName(withoutQkNorm.modules) { it.endsWith(".q_norm") || it.endsWith(".k_norm") } == null,
+            "qkNorm=false should NOT add q_norm / k_norm modules"
+        )
+        assertTrue(
+            findAnyName(withQkNorm.modules) { it.endsWith(".q_norm") } != null,
+            "qkNorm=true should add a q_norm module"
+        )
+        assertTrue(
+            findAnyName(withQkNorm.modules) { it.endsWith(".k_norm") } != null,
+            "qkNorm=true should add a k_norm module"
+        )
+    }
+
+    @Test
+    fun `defaults pull ropeBase and eps from metadata`() {
+        // No assertion on the actual numeric ropeBase used inside RoPE
+        // (it's stored as a private field). What we can assert is that
+        // a metadata with non-default ropeFreqBase and rmsNormEps doesn't
+        // throw and produces the same structure.
+        val qwenLikeMeta = metadata(ropeFreqBase = 1_000_000f, rmsNormEps = 1e-6f)
+        val model = decoderTransformerNetwork<FP32, Float>(qwenLikeMeta)
+        assertTrue(model.modules.size == 4, "structure should be invariant to ropeBase / eps")
+    }
+
+    /** Recursively scan module tree for a name matching [predicate]. */
+    private fun findAnyName(
+        roots: List<sk.ainet.lang.nn.Module<*, *>>,
+        predicate: (String) -> Boolean,
+    ): String? {
+        for (m in roots) {
+            if (predicate(m.name)) return m.name
+            val found = findAnyName(m.modules, predicate)
+            if (found != null) return found
+        }
+        return null
+    }
+}
+
+private data class TestDecoderMetadata(
+    override val embeddingLength: Int,
+    override val contextLength: Int,
+    override val blockCount: Int,
+    override val headCount: Int,
+    override val kvHeadCount: Int,
+    override val feedForwardLength: Int,
+    override val ropeDimensionCount: Int?,
+    override val vocabSize: Int,
+    override val ropeFreqBase: Float,
+    override val rmsNormEps: Float,
+    override val bosTokenId: Int,
+    override val eosTokenId: Int,
+) : DecoderModelMetadata


### PR DESCRIPTION
## Summary
- Adds an architecture-neutral decoder-only transformer body builder (`decoderTransformerNetwork`) and a `DecoderModelMetadata` interface to `:llm-core`. Every per-model `xNetwork(metadata)` function can now compose it with that model's specific knobs (RoPE base, RMSNorm eps, QK-norm) instead of duplicating the transformer DAG.
- Today `qwenNetwork()` is a 3-line stub that delegates to `llamaNetwork()`, and `llamaNetwork()` hardcodes `eps = 1e-5f`, `qkNorm = false`, RoPE base = 10_000 — none of which are right for Qwen3. This PR is the foundation for collapsing both `*NetworkDef.kt` files into thin callers of the shared builder; that collapse and Llama-named loader rename ship as separate follow-up PRs per the no-model-duplication plan.

## Scope
- **Purely additive** — three new files in `:llm-core`; no existing source modified.
- `DecoderModelMetadata.kt` (interface) — common shape fields + `ropeFreqBase`, `rmsNormEps`, BOS/EOS that every decoder LLM in this repo carries.
- `DecoderTransformerNetwork.kt` (builder) — `Embedding → N × (RMSNorm → MHA(RoPE, KVCache, [QK-norm]) → Residual → RMSNorm → SwiGLU FFN → Residual) → RMSNorm → output Dense`. Knobs (`ropeBase`, `eps`, `qkNorm`) default from metadata so callers can override per-architecture.
- `DecoderTransformerNetworkTest.kt` — module-tree-shape tests with a synthetic in-test `DecoderModelMetadata` impl. The full integration with real `LlamaModelMetadata` lives in the follow-up `*NetworkDef` collapse PR (which adds `: DecoderModelMetadata` to that data class).

## Test plan
- [x] `./gradlew :llm-core:compileKotlinJvm :llm-core:compileCommonMainKotlinMetadata` — clean compile, only pre-existing warnings.
- [x] `./gradlew :llm-core:jvmTest` — 9 suites / 85 tests pass, including the 3 new ones in `DecoderTransformerNetworkTest`.
- [ ] CI green on PR.

Refs the closed #46. No behavior change for downstream consumers — nothing imports the new code yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)