### PR TITLE
refactor: rename Llama* generic loaders to Decoder*

### DIFF
--- a/llm-apps/skainet-cli/src/main/kotlin/sk/ainet/apps/skainet/cli/Main.kt
+++ b/llm-apps/skainet-cli/src/main/kotlin/sk/ainet/apps/skainet/cli/Main.kt
@@ -25,7 +25,7 @@ import sk.ainet.io.model.QuantPolicy
 import sk.ainet.lang.tensor.data.MemorySegmentTensorDataFactory
 import sk.ainet.lang.types.FP32
 import sk.ainet.models.llama.LlamaRuntime
-import sk.ainet.models.llama.LlamaWeightLoader
+import sk.ainet.models.llama.DecoderGgufWeightLoader
 import sk.ainet.models.llama.LlamaWeightMapper
 import sk.ainet.models.llama.MemSegWeightConverter
 import java.lang.foreign.Arena
@@ -198,7 +198,7 @@ fun main(args: Array<String>) {
             OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
         } else {
             val acceptedArchitectures = modelInfo.family.architectures + setOf(modelInfo.architecture)
-            val loader = LlamaWeightLoader(
+            val loader = DecoderGgufWeightLoader(
                 randomAccessProvider = { JvmRandomAccessSource.open(modelPath.toString()) },
                 quantPolicy = QuantPolicy.NATIVE_OPTIMIZED,
                 acceptedArchitectures = acceptedArchitectures

--- a/llm-inference/apertus/src/jvmTest/kotlin/sk/ainet/models/apertus/ApertusWeightLoaderQuantizedShapeTest.kt
+++ b/llm-inference/apertus/src/jvmTest/kotlin/sk/ainet/models/apertus/ApertusWeightLoaderQuantizedShapeTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertEquals
  * `ctx.fromByteArray` would size-mismatch.
  *
  * The fix makes NATIVE_OPTIMIZED wrap the bytes with `Shape(bytes.size)`
- * (mirroring the LlamaWeightLoader pattern). This test pins that contract.
+ * (mirroring the DecoderGgufWeightLoader pattern). This test pins that contract.
  */
 class ApertusWeightLoaderQuantizedShapeTest {
 

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma3nWeightLoader.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma3nWeightLoader.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 /**
  * Adapter that loads Gemma 3n weights from GGUF files.
  *
- * Key differences from LlamaWeightLoader:
+ * Key differences from DecoderGgufWeightLoader:
  * - Architecture validation: accepts "gemma3n", "gemma3", "gemma" prefixes
  * - Variable intermediate (FFN) sizes per layer
  * - Per-layer embedding support
@@ -703,7 +703,7 @@ public class Gemma3nWeightLoader private constructor(
         }
     }
 
-    // ============== Tensor conversion using LlamaWeightLoader.Dequant ==============
+    // ============== Tensor conversion using DecoderGgufWeightLoader.Dequant ==============
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : DType, V> readerTensorToTensor(

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4WeightLoader.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4WeightLoader.kt
@@ -879,7 +879,7 @@ public class Gemma4WeightLoader private constructor(
                     }
                     QuantPolicy.NATIVE_OPTIMIZED -> {
                         // Store raw quantized bytes with a 1-D byte shape (matches
-                        // LlamaWeightLoader). The factory would otherwise reject the
+                        // DecoderGgufWeightLoader). The factory would otherwise reject the
                         // 2-D logical shape because `byte count != elements`. Downstream
                         // converters (MemSegWeightConverter for Llama, GemmaMemSegConverter
                         // for Gemma) recover the logical shape from the metadata.

--- a/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/DecoderGgufWeightLoader.kt
+++ b/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/DecoderGgufWeightLoader.kt
@@ -40,7 +40,7 @@ public data class LlamaModelMetadata(
     override val eosTokenId: Int = 2,
 ) : sk.ainet.lang.nn.dsl.decoder.DecoderModelMetadata
 
-public data class LlamaWeights<T : DType, V>(
+public data class DecoderGgufWeights<T : DType, V>(
     val metadata: LlamaModelMetadata,
     val tensors: Map<String, Tensor<T, V>>,
     val quantTypes: Map<String, GGMLQuantizationType> = emptyMap()
@@ -71,7 +71,7 @@ public object LlamaTensorNames {
  * naming scheme. Validation covers metadata presence and basic shape consistency for the tensors
  * we materialize.
  */
-public class LlamaWeightLoader private constructor(
+public class DecoderGgufWeightLoader private constructor(
     private val sourceProvider: (() -> Source)?,
     private val randomAccessProvider: (() -> RandomAccessSource)?,
     private val loadTensorData: Boolean = true,
@@ -122,7 +122,7 @@ public class LlamaWeightLoader private constructor(
 
     /**
      * Backward-compatible companion delegating to shared [DequantOps].
-     * Existing callers (e.g. `LlamaWeightLoader.dequantF16(raw)`) continue to work.
+     * Existing callers (e.g. `DecoderGgufWeightLoader.dequantF16(raw)`) continue to work.
      */
     public companion object Dequant {
         internal fun transposeColumnMajorToRowMajor(data: FloatArray, rows: Int, cols: Int): FloatArray =
@@ -168,18 +168,18 @@ public class LlamaWeightLoader private constructor(
     public suspend fun <T : DType, V> loadToMap(
         ctx: ExecutionContext,
         dtype: KClass<T>
-    ): LlamaWeights<T, V> {
+    ): DecoderGgufWeights<T, V> {
         val byName = linkedMapOf<String, Tensor<T, V>>()
         val quantTypes = linkedMapOf<String, GGMLQuantizationType>()
         val meta = loadFromGguf(ctx, dtype, { name, tensor -> byName[name] = tensor }) { name, qt ->
             quantTypes[name] = qt
         }
-        return LlamaWeights(meta, byName, quantTypes)
+        return DecoderGgufWeights(meta, byName, quantTypes)
     }
 
     public suspend inline fun <reified T : DType, V> loadToMap(
         ctx: ExecutionContext
-    ): LlamaWeights<T, V> = loadToMap(ctx, T::class)
+    ): DecoderGgufWeights<T, V> = loadToMap(ctx, T::class)
 
     // ============== Streaming API (for large files >2GB) ==============
 
@@ -207,18 +207,18 @@ public class LlamaWeightLoader private constructor(
     public suspend fun <T : DType, V> loadToMapStreaming(
         ctx: ExecutionContext,
         dtype: KClass<T>
-    ): LlamaWeights<T, V> {
+    ): DecoderGgufWeights<T, V> {
         val byName = linkedMapOf<String, Tensor<T, V>>()
         val quantTypes = linkedMapOf<String, GGMLQuantizationType>()
         val meta = loadFromStreamingGguf(ctx, dtype, { name, tensor -> byName[name] = tensor }) { name, qt ->
             quantTypes[name] = qt
         }
-        return LlamaWeights(meta, byName, quantTypes)
+        return DecoderGgufWeights(meta, byName, quantTypes)
     }
 
     public suspend inline fun <reified T : DType, V> loadToMapStreaming(
         ctx: ExecutionContext
-    ): LlamaWeights<T, V> = loadToMapStreaming(ctx, T::class)
+    ): DecoderGgufWeights<T, V> = loadToMapStreaming(ctx, T::class)
 
     private fun <T : DType, V> loadFromGguf(
         ctx: ExecutionContext,

--- a/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/DecoderSafeTensorsLoader.kt
+++ b/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/DecoderSafeTensorsLoader.kt
@@ -5,7 +5,7 @@ import sk.ainet.io.RandomAccessSource
 import sk.ainet.models.llama.LlamaModelMetadata
 import sk.ainet.models.llama.LlamaRuntimeWeights
 import sk.ainet.models.llama.LlamaWeightMapper
-import sk.ainet.models.llama.LlamaWeights
+import sk.ainet.models.llama.DecoderGgufWeights
 import sk.ainet.models.llama.LlamaTensorNames
 import sk.ainet.io.model.DataType
 import sk.ainet.io.safetensors.StreamingSafeTensorsReader
@@ -28,7 +28,7 @@ import kotlin.reflect.KClass
  * - Shape normalization ([1, dim] norms → [dim])
  * - Tied word embeddings (output.weight = token_embd.weight)
  */
-public class LlamaSafeTensorsLoader<T : DType>(
+public class DecoderSafeTensorsLoader<T : DType>(
     private val ctx: ExecutionContext,
     private val dtype: KClass<T>,
     private val metadata: LlamaModelMetadata,
@@ -39,7 +39,7 @@ public class LlamaSafeTensorsLoader<T : DType>(
      * Load weights from SafeTensors file into a flat tensor map with GGUF-canonical names.
      * Useful for feeding into [WeightMapper] with a [WeightNameResolver].
      */
-    public fun loadToMap(randomAccessProvider: () -> RandomAccessSource): LlamaWeights<T, Float> {
+    public fun loadToMap(randomAccessProvider: () -> RandomAccessSource): DecoderGgufWeights<T, Float> {
         val tensors = mutableMapOf<String, Tensor<T, Float>>()
 
         StreamingSafeTensorsReader.open(randomAccessProvider()).use { reader ->
@@ -104,7 +104,7 @@ public class LlamaSafeTensorsLoader<T : DType>(
             println("  Tied: ${LlamaTensorNames.OUTPUT_WEIGHT} → ${LlamaTensorNames.TOKEN_EMBEDDINGS}")
         }
 
-        return LlamaWeights<T, Float>(
+        return DecoderGgufWeights<T, Float>(
             metadata = metadata,
             tensors = tensors
         )

--- a/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/LlamaNetworkLoader.kt
+++ b/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/LlamaNetworkLoader.kt
@@ -60,7 +60,7 @@ public class LlamaNetworkLoader @PublishedApi internal constructor(
         ) : WeightsProvider
 
         data class Preloaded<T : DType, V>(
-            val weights: LlamaWeights<T, V>
+            val weights: DecoderGgufWeights<T, V>
         ) : WeightsProvider
     }
 
@@ -94,9 +94,9 @@ public class LlamaNetworkLoader @PublishedApi internal constructor(
             WeightsProvider.SafeTensors(randomAccessProvider, metadata, tiedEmbeddings), debug
         )
 
-        /** Build from already-loaded [LlamaWeights] (GGUF-canonical tensor names). */
+        /** Build from already-loaded [DecoderGgufWeights] (GGUF-canonical tensor names). */
         public inline fun <reified T : DType, V> fromWeights(
-            weights: LlamaWeights<T, V>,
+            weights: DecoderGgufWeights<T, V>,
             debug: Boolean = false
         ): Module<T, V> = LlamaNetworkLoader(
             WeightsProvider.Preloaded(weights), debug
@@ -112,23 +112,23 @@ public class LlamaNetworkLoader @PublishedApi internal constructor(
     public suspend inline fun <reified T : DType, V> load(
         ctx: ExecutionContext
     ): Module<T, V> {
-        val weights: LlamaWeights<T, V> = when (val wp = weightsProvider) {
+        val weights: DecoderGgufWeights<T, V> = when (val wp = weightsProvider) {
             is WeightsProvider.GgufSource -> {
-                val loader = LlamaWeightLoader(wp.sourceProvider, quantPolicy = wp.quantPolicy)
+                val loader = DecoderGgufWeightLoader(wp.sourceProvider, quantPolicy = wp.quantPolicy)
                 loader.loadToMap<T, V>(ctx)
             }
             is WeightsProvider.GgufRandomAccess -> {
-                val loader = LlamaWeightLoader(wp.randomAccessProvider, quantPolicy = wp.quantPolicy)
+                val loader = DecoderGgufWeightLoader(wp.randomAccessProvider, quantPolicy = wp.quantPolicy)
                 loader.loadToMapStreaming<T, V>(ctx)
             }
             is WeightsProvider.SafeTensors -> {
-                val loader = LlamaSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
+                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
                 @Suppress("UNCHECKED_CAST")
-                loader.loadToMap(wp.randomAccessProvider) as LlamaWeights<T, V>
+                loader.loadToMap(wp.randomAccessProvider) as DecoderGgufWeights<T, V>
             }
             is WeightsProvider.Preloaded<*, *> -> {
                 @Suppress("UNCHECKED_CAST")
-                wp.weights as LlamaWeights<T, V>
+                wp.weights as DecoderGgufWeights<T, V>
             }
         }
 
@@ -140,7 +140,7 @@ public class LlamaNetworkLoader @PublishedApi internal constructor(
      */
     @PublishedApi
     internal inline fun <reified T : DType, V> applyWeightsToNetwork(
-        weights: LlamaWeights<T, V>
+        weights: DecoderGgufWeights<T, V>
     ): Module<T, V> {
         val model = llamaNetwork<T, V>(weights.metadata)
 

--- a/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/LlamaRuntimeWeights.kt
+++ b/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/LlamaRuntimeWeights.kt
@@ -42,7 +42,7 @@ public data class LlamaRuntimeWeights<T : DType>(
  */
 public object LlamaWeightMapper {
 
-    public fun <T : DType> map(weights: LlamaWeights<T, Float>): LlamaRuntimeWeights<T> {
+    public fun <T : DType> map(weights: DecoderGgufWeights<T, Float>): LlamaRuntimeWeights<T> {
         val metadata = weights.metadata
         val headSize = metadata.embeddingLength / metadata.headCount
         require(headSize * metadata.headCount == metadata.embeddingLength) {
@@ -163,7 +163,7 @@ public suspend fun <T : DType> loadLlamaRuntimeWeights(
     quantPolicy: QuantPolicy = QuantPolicy.RAW_BYTES,
     allowQuantized: Boolean = false
 ): LlamaRuntimeWeights<T> {
-    val loader = LlamaWeightLoader(
+    val loader = DecoderGgufWeightLoader(
         sourceProvider = sourceProvider,
         quantPolicy = quantPolicy
     )
@@ -190,7 +190,7 @@ public suspend fun <T : DType> loadLlamaRuntimeWeightsDequantized(
     sourceProvider: () -> Source,
     dtype: KClass<T>
 ): LlamaRuntimeWeights<T> {
-    val loader = LlamaWeightLoader(
+    val loader = DecoderGgufWeightLoader(
         sourceProvider = sourceProvider,
         quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32
     )
@@ -227,7 +227,7 @@ public suspend fun <T : DType> loadLlamaRuntimeWeightsStreaming(
     allowQuantized: Boolean = false,
     acceptedArchitectures: Set<String> = setOf("llama")
 ): LlamaRuntimeWeights<T> {
-    val loader = LlamaWeightLoader(
+    val loader = DecoderGgufWeightLoader(
         randomAccessProvider = randomAccessProvider,
         quantPolicy = quantPolicy,
         acceptedArchitectures = acceptedArchitectures
@@ -256,7 +256,7 @@ public suspend fun <T : DType> loadLlamaRuntimeWeightsDequantizedStreaming(
     randomAccessProvider: () -> RandomAccessSource,
     dtype: KClass<T>
 ): LlamaRuntimeWeights<T> {
-    val loader = LlamaWeightLoader(
+    val loader = DecoderGgufWeightLoader(
         randomAccessProvider = randomAccessProvider,
         quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32
     )

--- a/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/MmapLlamaLoader.kt
+++ b/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/MmapLlamaLoader.kt
@@ -66,12 +66,12 @@ public class MmapLlamaLoader(
      * @param T the data type (must be FP32 for mmap loading)
      * @param V the value type (Float for FP32)
      * @param ctx execution context (used to wrap TensorData with ops)
-     * @return LlamaWeights containing mmap-backed tensors
+     * @return DecoderGgufWeights containing mmap-backed tensors
      */
     public fun <T : DType, V> loadToMap(
         ctx: ExecutionContext,
         dtype: KClass<T>
-    ): LlamaWeights<T, V> {
+    ): DecoderGgufWeights<T, V> {
         require(dtype == FP32::class) {
             "MmapLlamaLoader currently supports FP32 tensors only (got ${dtype.simpleName})"
         }
@@ -102,12 +102,12 @@ public class MmapLlamaLoader(
             }
         }
 
-        return LlamaWeights(metadata, tensors)
+        return DecoderGgufWeights(metadata, tensors)
     }
 
     public inline fun <reified T : DType, V> loadToMap(
         ctx: ExecutionContext
-    ): LlamaWeights<T, V> = loadToMap(ctx, T::class)
+    ): DecoderGgufWeights<T, V> = loadToMap(ctx, T::class)
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : DType, V> createMmapTensor(
@@ -134,7 +134,7 @@ public class MmapLlamaLoader(
                 error(
                     "MmapLlamaLoader only supports F32 tensors directly. " +
                     "Tensor ${rt.name} has type ${rt.tensorType}. " +
-                    "Use the streaming LlamaWeightLoader with DEQUANTIZE_TO_FP32 policy for quantized models."
+                    "Use the streaming DecoderGgufWeightLoader with DEQUANTIZE_TO_FP32 policy for quantized models."
                 )
             }
         }
@@ -145,7 +145,7 @@ public class MmapLlamaLoader(
         fileChannel.close()
     }
 
-    // Reuse validation logic from LlamaWeightLoader
+    // Reuse validation logic from DecoderGgufWeightLoader
     private fun metadataFromGguf(
         fields: Map<String, sk.ainet.io.gguf.ReaderField>,
         tensors: List<ReaderTensor>

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaDslPipelineTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaDslPipelineTest.kt
@@ -83,7 +83,7 @@ class LlamaDslPipelineTest {
     @Test
     fun `weight loading maps all parameters`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
 
         // Should not throw — all required weights mapped
         val model = LlamaNetworkLoader.fromWeights(weights)
@@ -95,7 +95,7 @@ class LlamaDslPipelineTest {
     @Test
     fun `DIRECT mode forward produces finite logits with correct shape`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = LlamaNetworkLoader.fromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(
@@ -122,7 +122,7 @@ class LlamaDslPipelineTest {
     @Test
     fun `DIRECT mode forward is deterministic`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
 
         // Build two independent runtimes from the same weights
         val model1 = LlamaNetworkLoader.fromWeights(weights)
@@ -144,7 +144,7 @@ class LlamaDslPipelineTest {
     @Test
     fun `generate produces valid token sequence`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = LlamaNetworkLoader.fromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(
@@ -173,7 +173,7 @@ class LlamaDslPipelineTest {
     @Test
     fun `logits change with different input tokens`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = LlamaNetworkLoader.fromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaQuantDequantTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaQuantDequantTest.kt
@@ -15,7 +15,7 @@ class LlamaQuantDequantTest {
                 else -> 0x88.toByte()
             }
         }.toList()
-        val out = LlamaWeightLoader.dequantQ4_0(raw, 32)
+        val out = DecoderGgufWeightLoader.dequantQ4_0(raw, 32)
         assertContentEquals(FloatArray(32) { 0f }.toList(), out.toList())
     }
 
@@ -28,7 +28,7 @@ class LlamaQuantDequantTest {
                 else -> (idx - 1).toByte() // 1..32
             }
         }.toList()
-        val out = LlamaWeightLoader.dequantQ8_0(raw, 32)
+        val out = DecoderGgufWeightLoader.dequantQ8_0(raw, 32)
         val expected = FloatArray(32) { (it + 1).toFloat() }
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -43,7 +43,7 @@ class LlamaQuantDequantTest {
                 else -> 0x00
             }
         }.toList()
-        val out = LlamaWeightLoader.dequantQ5_0(raw, 32)
+        val out = DecoderGgufWeightLoader.dequantQ5_0(raw, 32)
         assertContentEquals(FloatArray(32) { 0f }.toList(), out.toList())
     }
 
@@ -56,7 +56,7 @@ class LlamaQuantDequantTest {
                 else -> 0x00
             }
         }.toList()
-        val out = LlamaWeightLoader.dequantQ4_1(raw, 32)
+        val out = DecoderGgufWeightLoader.dequantQ4_1(raw, 32)
         assertContentEquals(FloatArray(32) { 2f }.toList(), out.toList())
     }
 
@@ -73,7 +73,7 @@ class LlamaQuantDequantTest {
         raw[4] = 0x00; raw[5] = 0x00; raw[6] = 0x00; raw[7] = 0x00
         // qs[0..3] = 1, 2, 3, 4
         raw[8] = 0x01; raw[9] = 0x02; raw[10] = 0x03; raw[11] = 0x04
-        val out = LlamaWeightLoader.dequantQ8_1(raw.toList(), 32)
+        val out = DecoderGgufWeightLoader.dequantQ8_1(raw.toList(), 32)
         val expected = FloatArray(32) { idx ->
             when (idx) {
                 0 -> 1f; 1 -> 2f; 2 -> 3f; 3 -> 4f
@@ -92,7 +92,7 @@ class LlamaQuantDequantTest {
                 else -> 0x88.toByte()
             }
         }.toList()
-        val out = LlamaWeightLoader.dequantIQ4NL(raw, 32)
+        val out = DecoderGgufWeightLoader.dequantIQ4NL(raw, 32)
         assertContentEquals(FloatArray(32) { 1f }.toList(), out.toList())
     }
 
@@ -105,7 +105,7 @@ class LlamaQuantDequantTest {
         raw[4] = 0x01 // scales_l first nibble -> ls 33 for block 0
         // qs = 0x88 so value = 1 when dl != 0
         repeat(128) { raw[8 + it] = 0x88.toByte() }
-        val out = LlamaWeightLoader.dequantIQ4XS(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantIQ4XS(raw.toList(), 256)
         val expected = FloatArray(256) { idx -> if (idx < 32) 1f else 0f }
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -120,7 +120,7 @@ class LlamaQuantDequantTest {
         raw[4] = 0xF0.toByte()
         // block 0 codes = 1 (0b01) for all 16 values -> bytes 0x55
         repeat(4) { raw[20 + it] = 0x55.toByte() }
-        val out = LlamaWeightLoader.dequantQ2K(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantQ2K(raw.toList(), 256)
         val expected = FloatArray(256) { if (it < 16) 1f else 0f }
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -134,7 +134,7 @@ class LlamaQuantDequantTest {
         repeat(64) { raw[34 + it] = 0xFF.toByte() }
         // scales all 0x3F -> scale index 63 for every block
         repeat(12) { raw[98 + it] = 0xFF.toByte() }
-        val out = LlamaWeightLoader.dequantQ3K(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantQ3K(raw.toList(), 256)
         val expected = FloatArray(256) { 6f } // q=3, scale=d*1=2 => 6
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -150,7 +150,7 @@ class LlamaQuantDequantTest {
         raw[5] = 0x01
         // block 0 codes = 15 -> bytes 0xFF for first 32 bytes of qs (64 vals)
         repeat(32) { raw[16 + it] = 0xFF.toByte() }
-        val out = LlamaWeightLoader.dequantQ4K(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantQ4K(raw.toList(), 256)
         val expected = FloatArray(256) { if (it < 64) 15f else 0f }
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -166,7 +166,7 @@ class LlamaQuantDequantTest {
         // qh high bits set for first 32 weights
         repeat(4) { raw[16 + it] = 0xFF.toByte() }
         // qs low nibbles zero
-        val out = LlamaWeightLoader.dequantQ5K(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantQ5K(raw.toList(), 256)
         val expected = FloatArray(256) { if (it < 32) 16f else 0f }
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -202,7 +202,7 @@ class LlamaQuantDequantTest {
         repeat(128) { raw[it] = 0x11.toByte() }
         repeat(64) { raw[128 + it] = 0xAA.toByte() }
 
-        val out = LlamaWeightLoader.dequantQ6K(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantQ6K(raw.toList(), 256)
         val expected = FloatArray(256) { 1f }
         assertContentEquals(expected.toList(), out.toList())
     }
@@ -213,7 +213,7 @@ class LlamaQuantDequantTest {
         // d = 1.0f
         raw[0] = 0x00; raw[1] = 0x00; raw[2] = 0x80.toByte(); raw[3] = 0x3F
         raw[4] = 0x01; raw[5] = 0x02; raw[6] = 0x03; raw[7] = 0x04
-        val out = LlamaWeightLoader.dequantQ8K(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantQ8K(raw.toList(), 256)
         val expected = FloatArray(256) { idx ->
             when (idx) {
                 0 -> 1f
@@ -234,7 +234,7 @@ class LlamaQuantDequantTest {
         val raw = ByteArray(66) { 0x00 }
         raw[64] = 0x00  // scale low byte
         raw[65] = 0x3C  // scale high byte (f16 1.0)
-        val out = LlamaWeightLoader.dequantTQ2_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ2_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { -1f }.toList(), out.toList())
     }
 
@@ -244,7 +244,7 @@ class LlamaQuantDequantTest {
         // Scale = 1.0
         val raw = ByteArray(66) { 0x55 }
         raw[64] = 0x00; raw[65] = 0x3C
-        val out = LlamaWeightLoader.dequantTQ2_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ2_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { 0f }.toList(), out.toList())
     }
 
@@ -254,7 +254,7 @@ class LlamaQuantDequantTest {
         // Scale = 1.0
         val raw = ByteArray(66) { 0xAA.toByte() }
         raw[64] = 0x00; raw[65] = 0x3C
-        val out = LlamaWeightLoader.dequantTQ2_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ2_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { 1f }.toList(), out.toList())
     }
 
@@ -263,7 +263,7 @@ class LlamaQuantDequantTest {
         // All twos (+1) with scale = 2.0 (0x4000)
         val raw = ByteArray(66) { 0xAA.toByte() }
         raw[64] = 0x00; raw[65] = 0x40  // f16 2.0
-        val out = LlamaWeightLoader.dequantTQ2_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ2_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { 2f }.toList(), out.toList())
     }
 
@@ -275,7 +275,7 @@ class LlamaQuantDequantTest {
         val raw = ByteArray(66) { 0x55 }  // default to zeros
         raw[0] = 0xE4.toByte()  // 11_10_01_00: v0=-1, v1=0, v2=+1, v3=+2 (if 3 is allowed)
         raw[64] = 0x00; raw[65] = 0x3C  // scale = 1.0
-        val out = LlamaWeightLoader.dequantTQ2_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ2_0(raw.toList(), 256)
         // First 4 elements: (0-1)=-1, (1-1)=0, (2-1)=+1, (3-1)=+2
         kotlin.test.assertEquals(-1f, out[0], 0.001f)
         kotlin.test.assertEquals(0f, out[1], 0.001f)
@@ -290,7 +290,7 @@ class LlamaQuantDequantTest {
         // All 2-bit bytes = 0 means remaining 16 values are also -1
         val raw = ByteArray(54) { 0x00 }
         raw[52] = 0x00; raw[53] = 0x3C  // scale = 1.0
-        val out = LlamaWeightLoader.dequantTQ1_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ1_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { -1f }.toList(), out.toList())
     }
 
@@ -303,7 +303,7 @@ class LlamaQuantDequantTest {
         repeat(48) { raw[it] = 0x79 }  // base-3 all ones
         repeat(4) { raw[48 + it] = 0x55 }  // 2-bit all ones
         raw[52] = 0x00; raw[53] = 0x3C  // scale = 1.0
-        val out = LlamaWeightLoader.dequantTQ1_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ1_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { 0f }.toList(), out.toList())
     }
 
@@ -315,7 +315,7 @@ class LlamaQuantDequantTest {
         repeat(48) { raw[it] = 0xF2.toByte() }  // base-3 all twos
         repeat(4) { raw[48 + it] = 0xAA.toByte() }  // 2-bit all twos
         raw[52] = 0x00; raw[53] = 0x3C  // scale = 1.0
-        val out = LlamaWeightLoader.dequantTQ1_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ1_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { 1f }.toList(), out.toList())
     }
 
@@ -326,7 +326,7 @@ class LlamaQuantDequantTest {
         repeat(48) { raw[it] = 0xF2.toByte() }  // base-3 all twos
         repeat(4) { raw[48 + it] = 0xAA.toByte() }  // 2-bit all twos
         raw[52] = 0x00; raw[53] = 0x40  // scale = 2.0
-        val out = LlamaWeightLoader.dequantTQ1_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ1_0(raw.toList(), 256)
         assertContentEquals(FloatArray(256) { 2f }.toList(), out.toList())
     }
 
@@ -338,7 +338,7 @@ class LlamaQuantDequantTest {
         raw[0] = 0x66  // first 5 values: -1, 0, +1, -1, 0
         repeat(4) { raw[48 + it] = 0x55 }  // 2-bit all ones
         raw[52] = 0x00; raw[53] = 0x3C  // scale = 1.0
-        val out = LlamaWeightLoader.dequantTQ1_0(raw.toList(), 256)
+        val out = DecoderGgufWeightLoader.dequantTQ1_0(raw.toList(), 256)
         kotlin.test.assertEquals(-1f, out[0], 0.001f)
         kotlin.test.assertEquals(0f, out[1], 0.001f)
         kotlin.test.assertEquals(1f, out[2], 0.001f)

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaWeightMapperTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaWeightMapperTest.kt
@@ -54,7 +54,7 @@ class LlamaWeightMapperTest {
             LlamaTensorNames.ffnUp(0) to tensor(Shape(8, 4), 32, 90f)            // [ff_dim, dim]
         )
 
-        val runtime = LlamaWeightMapper.map(LlamaWeights(metadata, tensors))
+        val runtime = LlamaWeightMapper.map(DecoderGgufWeights(metadata, tensors))
         assertEquals(metadata, runtime.metadata)
         assertEquals(1, runtime.layers.size)
 
@@ -103,7 +103,7 @@ class LlamaWeightMapperTest {
             LlamaTensorNames.ffnUp(0) to tensor(Shape(8, 4), 32, 90f)
         )
 
-        val runtime: LlamaRuntimeWeights<FP16> = LlamaWeightMapper.map(LlamaWeights(metadata, tensors))
+        val runtime: LlamaRuntimeWeights<FP16> = LlamaWeightMapper.map(DecoderGgufWeights(metadata, tensors))
         assertEquals(metadata, runtime.metadata)
         assertEquals(1, runtime.layers.size)
 

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/StateManagementTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/StateManagementTest.kt
@@ -90,17 +90,17 @@ class StateManagementTest {
     )
 
     private fun createDirectRuntime(): OptimizedLLMRuntime<FP32> {
-        val model = LlamaNetworkLoader.fromWeights(LlamaWeights(metadata, buildWeights()))
+        val model = LlamaNetworkLoader.fromWeights(DecoderGgufWeights(metadata, buildWeights()))
         return OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
     }
 
     private fun createOptimizedRuntime(): OptimizedLLMRuntime<FP32> {
-        val model = LlamaNetworkLoader.fromWeights(LlamaWeights(metadata, buildWeights()))
+        val model = LlamaNetworkLoader.fromWeights(DecoderGgufWeights(metadata, buildWeights()))
         return OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.OPTIMIZED, FP32::class)
     }
 
     private fun createHybridRuntime(): OptimizedLLMRuntime<FP32> {
-        val model = LlamaNetworkLoader.fromWeights(LlamaWeights(metadata, buildWeights()))
+        val model = LlamaNetworkLoader.fromWeights(DecoderGgufWeights(metadata, buildWeights()))
         return OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.HYBRID, FP32::class)
     }
 

--- a/llm-inference/qwen/src/commonMain/kotlin/sk/ainet/models/qwen/QwenNetworkLoader.kt
+++ b/llm-inference/qwen/src/commonMain/kotlin/sk/ainet/models/qwen/QwenNetworkLoader.kt
@@ -11,9 +11,9 @@ import sk.ainet.io.weights.WeightTensor
 import sk.ainet.lang.nn.Module
 import sk.ainet.lang.types.DType
 import sk.ainet.models.llama.LlamaModelMetadata
-import sk.ainet.models.llama.LlamaSafeTensorsLoader
-import sk.ainet.models.llama.LlamaWeightLoader
-import sk.ainet.models.llama.LlamaWeights
+import sk.ainet.models.llama.DecoderSafeTensorsLoader
+import sk.ainet.models.llama.DecoderGgufWeightLoader
+import sk.ainet.models.llama.DecoderGgufWeights
 import kotlin.jvm.JvmName
 
 /**
@@ -21,7 +21,7 @@ import kotlin.jvm.JvmName
  * with weights from GGUF or SafeTensors files via [WeightMapper] + [LlamaGGUFNameResolver].
  *
  * Qwen3 uses the same GGUF tensor naming (`blk.N.*`) and weight structure as LLaMA,
- * so loading delegates to [LlamaWeightLoader] for GGUF and [LlamaSafeTensorsLoader]
+ * so loading delegates to [DecoderGgufWeightLoader] for GGUF and [DecoderSafeTensorsLoader]
  * for SafeTensors. The network is built via [qwenNetwork] which delegates to [llamaNetwork].
  *
  * Usage:
@@ -64,7 +64,7 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
         ) : WeightsProvider
 
         data class Preloaded<T : DType, V>(
-            val weights: LlamaWeights<T, V>
+            val weights: DecoderGgufWeights<T, V>
         ) : WeightsProvider
     }
 
@@ -98,9 +98,9 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
             WeightsProvider.SafeTensors(randomAccessProvider, metadata, tiedEmbeddings), debug
         )
 
-        /** Build from already-loaded [LlamaWeights] (GGUF-canonical tensor names). */
+        /** Build from already-loaded [DecoderGgufWeights] (GGUF-canonical tensor names). */
         public inline fun <reified T : DType, V> fromWeights(
-            weights: LlamaWeights<T, V>,
+            weights: DecoderGgufWeights<T, V>,
             debug: Boolean = false
         ): Module<T, V> = QwenNetworkLoader(
             WeightsProvider.Preloaded(weights), debug
@@ -116,9 +116,9 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
     public suspend inline fun <reified T : DType, V> load(
         ctx: ExecutionContext
     ): Module<T, V> {
-        val weights: LlamaWeights<T, V> = when (val wp = weightsProvider) {
+        val weights: DecoderGgufWeights<T, V> = when (val wp = weightsProvider) {
             is WeightsProvider.GgufSource -> {
-                val loader = LlamaWeightLoader(
+                val loader = DecoderGgufWeightLoader(
                     wp.sourceProvider,
                     quantPolicy = wp.quantPolicy,
                     acceptedArchitectures = QWEN_ARCHITECTURES
@@ -126,7 +126,7 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
                 loader.loadToMap<T, V>(ctx)
             }
             is WeightsProvider.GgufRandomAccess -> {
-                val loader = LlamaWeightLoader(
+                val loader = DecoderGgufWeightLoader(
                     wp.randomAccessProvider,
                     quantPolicy = wp.quantPolicy,
                     acceptedArchitectures = QWEN_ARCHITECTURES
@@ -134,13 +134,13 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
                 loader.loadToMapStreaming<T, V>(ctx)
             }
             is WeightsProvider.SafeTensors -> {
-                val loader = LlamaSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
+                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
                 @Suppress("UNCHECKED_CAST")
-                loader.loadToMap(wp.randomAccessProvider) as LlamaWeights<T, V>
+                loader.loadToMap(wp.randomAccessProvider) as DecoderGgufWeights<T, V>
             }
             is WeightsProvider.Preloaded<*, *> -> {
                 @Suppress("UNCHECKED_CAST")
-                wp.weights as LlamaWeights<T, V>
+                wp.weights as DecoderGgufWeights<T, V>
             }
         }
 
@@ -158,7 +158,7 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
      */
     @PublishedApi
     internal inline fun <reified T : DType, V> applyWeightsToNetwork(
-        weights: LlamaWeights<T, V>
+        weights: DecoderGgufWeights<T, V>
     ): Module<T, V> {
         val hasQkNorm = weights.tensors.keys.any { it.endsWith(".attn_q_norm.weight") }
         val model = qwenNetwork<T, V>(weights.metadata, qkNorm = hasQkNorm)

--- a/llm-inference/qwen/src/jvmTest/kotlin/sk/ainet/models/qwen/QwenDslPipelineTest.kt
+++ b/llm-inference/qwen/src/jvmTest/kotlin/sk/ainet/models/qwen/QwenDslPipelineTest.kt
@@ -12,7 +12,7 @@ import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.types.FP32
 import sk.ainet.models.llama.LlamaModelMetadata
 import sk.ainet.models.llama.LlamaTensorNames
-import sk.ainet.models.llama.LlamaWeights
+import sk.ainet.models.llama.DecoderGgufWeights
 
 /**
  * Self-contained end-to-end test for the Qwen DSL pipeline:
@@ -85,7 +85,7 @@ class QwenDslPipelineTest {
     @Test
     fun `weight loading maps all parameters`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
 
         val model = QwenNetworkLoader.fromWeights(weights)
 
@@ -95,7 +95,7 @@ class QwenDslPipelineTest {
     @Test
     fun `DIRECT mode forward produces finite logits with correct shape`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = QwenNetworkLoader.fromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(
@@ -122,7 +122,7 @@ class QwenDslPipelineTest {
     @Test
     fun `DIRECT mode forward is deterministic`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
 
         val model1 = QwenNetworkLoader.fromWeights(weights)
         val runtime1 = OptimizedLLMRuntime(model1, ctx, OptimizedLLMMode.DIRECT, FP32::class)
@@ -142,7 +142,7 @@ class QwenDslPipelineTest {
     @Test
     fun `generate produces valid token sequence`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = QwenNetworkLoader.fromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(
@@ -171,7 +171,7 @@ class QwenDslPipelineTest {
     @Test
     fun `logits change with different input tokens`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = QwenNetworkLoader.fromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)

--- a/llm-inference/voxtral/src/commonMain/kotlin/sk/ainet/models/voxtral/VoxtralNetworkLoader.kt
+++ b/llm-inference/voxtral/src/commonMain/kotlin/sk/ainet/models/voxtral/VoxtralNetworkLoader.kt
@@ -12,9 +12,9 @@ import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.types.DType
 import sk.ainet.models.llama.LlamaModelMetadata
-import sk.ainet.models.llama.LlamaSafeTensorsLoader
-import sk.ainet.models.llama.LlamaWeightLoader
-import sk.ainet.models.llama.LlamaWeights
+import sk.ainet.models.llama.DecoderSafeTensorsLoader
+import sk.ainet.models.llama.DecoderGgufWeightLoader
+import sk.ainet.models.llama.DecoderGgufWeights
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 
@@ -23,8 +23,8 @@ import kotlin.reflect.KClass
  * with weights from GGUF or SafeTensors files.
  *
  * Voxtral's text backbone uses the same LLaMA architecture and GGUF tensor naming
- * as Mistral/LLaMA, so weight loading delegates to [LlamaWeightLoader] for GGUF
- * and [LlamaSafeTensorsLoader] for SafeTensors. Tensor names are mapped via
+ * as Mistral/LLaMA, so weight loading delegates to [DecoderGgufWeightLoader] for GGUF
+ * and [DecoderSafeTensorsLoader] for SafeTensors. Tensor names are mapped via
  * [VoxtralHfTensorNameMapper] for SafeTensors and [VoxtralGGUFNameResolver] for
  * DSL weight mapping.
  *
@@ -68,7 +68,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
         ) : WeightsProvider
 
         data class Preloaded<T : DType, V>(
-            val weights: LlamaWeights<T, V>
+            val weights: DecoderGgufWeights<T, V>
         ) : WeightsProvider
     }
 
@@ -102,9 +102,9 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
             WeightsProvider.SafeTensors(randomAccessProvider, metadata, tiedEmbeddings), debug
         )
 
-        /** Build backbone from already-loaded [LlamaWeights] (GGUF-canonical tensor names). */
+        /** Build backbone from already-loaded [DecoderGgufWeights] (GGUF-canonical tensor names). */
         public inline fun <reified T : DType, V> backboneFromWeights(
-            weights: LlamaWeights<T, V>,
+            weights: DecoderGgufWeights<T, V>,
             debug: Boolean = false
         ): Module<T, V> = VoxtralNetworkLoader(
             WeightsProvider.Preloaded(weights), debug
@@ -112,7 +112,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
 
         /** Build acoustic runtime from already-loaded weights. */
         public inline fun <reified T : DType> acousticFromWeights(
-            weights: LlamaWeights<T, Float>,
+            weights: DecoderGgufWeights<T, Float>,
             acousticMetadata: LlamaModelMetadata,
             ctx: ExecutionContext,
             nCodebooks: Int = 36,
@@ -135,7 +135,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
     public suspend inline fun <reified T : DType, V> loadBackbone(
         ctx: ExecutionContext
     ): Module<T, V> {
-        val weights: LlamaWeights<T, V> = loadWeights(ctx)
+        val weights: DecoderGgufWeights<T, V> = loadWeights(ctx)
         return applyWeightsToBackbone(weights)
     }
 
@@ -145,24 +145,24 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
     @PublishedApi
     internal suspend inline fun <reified T : DType, V> loadWeights(
         ctx: ExecutionContext
-    ): LlamaWeights<T, V> {
+    ): DecoderGgufWeights<T, V> {
         return when (val wp = weightsProvider) {
             is WeightsProvider.GgufSource -> {
-                val loader = LlamaWeightLoader(wp.sourceProvider, quantPolicy = wp.quantPolicy)
+                val loader = DecoderGgufWeightLoader(wp.sourceProvider, quantPolicy = wp.quantPolicy)
                 loader.loadToMap<T, V>(ctx)
             }
             is WeightsProvider.GgufRandomAccess -> {
-                val loader = LlamaWeightLoader(wp.randomAccessProvider, quantPolicy = wp.quantPolicy)
+                val loader = DecoderGgufWeightLoader(wp.randomAccessProvider, quantPolicy = wp.quantPolicy)
                 loader.loadToMapStreaming<T, V>(ctx)
             }
             is WeightsProvider.SafeTensors -> {
-                val loader = LlamaSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
+                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
                 @Suppress("UNCHECKED_CAST")
-                loader.loadToMap(wp.randomAccessProvider) as LlamaWeights<T, V>
+                loader.loadToMap(wp.randomAccessProvider) as DecoderGgufWeights<T, V>
             }
             is WeightsProvider.Preloaded<*, *> -> {
                 @Suppress("UNCHECKED_CAST")
-                wp.weights as LlamaWeights<T, V>
+                wp.weights as DecoderGgufWeights<T, V>
             }
         }
     }
@@ -172,7 +172,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
      */
     @PublishedApi
     internal inline fun <reified T : DType, V> applyWeightsToBackbone(
-        weights: LlamaWeights<T, V>
+        weights: DecoderGgufWeights<T, V>
     ): Module<T, V> {
         val model = voxtralBackboneNetwork<T, V>(weights.metadata)
 
@@ -225,7 +225,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
         nCodebooks: Int = 36,
         codebookLevels: Int = 21
     ): VoxtralAcousticRuntime<T> {
-        val weights: LlamaWeights<T, Float> = loadWeights(ctx)
+        val weights: DecoderGgufWeights<T, Float> = loadWeights(ctx)
         val acousticModel = voxtralAcousticNetwork<T, Float>(acousticMetadata)
         return buildAcousticRuntime(weights, acousticModel, acousticMetadata, ctx, T::class, nCodebooks, codebookLevels)
     }
@@ -239,7 +239,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
      */
     @PublishedApi
     internal fun <T : DType> buildAcousticRuntime(
-        weights: LlamaWeights<T, Float>,
+        weights: DecoderGgufWeights<T, Float>,
         @Suppress("UNUSED_PARAMETER") acousticModel: Module<T, Float>,
         acousticMetadata: LlamaModelMetadata,
         ctx: ExecutionContext,

--- a/llm-inference/voxtral/src/commonMain/kotlin/sk/ainet/models/voxtral/VoxtralSafeTensorsLoader.kt
+++ b/llm-inference/voxtral/src/commonMain/kotlin/sk/ainet/models/voxtral/VoxtralSafeTensorsLoader.kt
@@ -9,7 +9,7 @@ import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.types.DType
 import sk.ainet.models.llama.LlamaModelMetadata
 import sk.ainet.models.llama.LlamaTensorNames
-import sk.ainet.models.llama.LlamaWeights
+import sk.ainet.models.llama.DecoderGgufWeights
 import kotlin.math.pow
 import kotlin.reflect.KClass
 
@@ -17,11 +17,11 @@ import kotlin.reflect.KClass
  * Loads Voxtral weights from SafeTensors format, capturing ALL tensor types:
  * backbone, acoustic model, and codec.
  *
- * Unlike [LlamaSafeTensorsLoader] which only maps backbone tensors,
+ * Unlike [DecoderSafeTensorsLoader] which only maps backbone tensors,
  * this loader uses [VoxtralHfTensorNameMapper] to capture the full model
  * including acoustic model and codec weights.
  *
- * Backbone + acoustic tensors are stored in [LlamaWeights.tensors] with
+ * Backbone + acoustic tensors are stored in [DecoderGgufWeights.tensors] with
  * canonical names. Codec tensors are returned separately via [loadAll].
  */
 public class VoxtralSafeTensorsLoader<T : DType>(
@@ -36,7 +36,7 @@ public class VoxtralSafeTensorsLoader<T : DType>(
      */
     public data class VoxtralWeights<T : DType>(
         /** Backbone weights (LLaMA-compatible, for DSL weight mapping). */
-        val backbone: LlamaWeights<T, Float>,
+        val backbone: DecoderGgufWeights<T, Float>,
         /** All tensors by canonical name (backbone + acoustic + codec). */
         val allTensors: Map<String, Tensor<T, Float>>
     )
@@ -111,7 +111,7 @@ public class VoxtralSafeTensorsLoader<T : DType>(
             }
         }
 
-        // Split into backbone weights (for LlamaWeights compat) and full map.
+        // Split into backbone weights (for DecoderGgufWeights compat) and full map.
         // Exclude non-backbone tensors: acoustic, codec, and audio codebook embeddings.
         val backboneTensors = allTensors.filterKeys { name ->
             !name.startsWith("acoustic.") &&
@@ -119,7 +119,7 @@ public class VoxtralSafeTensorsLoader<T : DType>(
                 !name.startsWith("audio_codebook_embeddings.")
         }
 
-        val backbone = LlamaWeights<T, Float>(
+        val backbone = DecoderGgufWeights<T, Float>(
             metadata = metadata,
             tensors = backboneTensors
         )
@@ -127,7 +127,7 @@ public class VoxtralSafeTensorsLoader<T : DType>(
         return VoxtralWeights(backbone = backbone, allTensors = allTensors)
     }
 
-    // ========== Dequantization helpers (same as LlamaSafeTensorsLoader) ==========
+    // ========== Dequantization helpers (same as DecoderSafeTensorsLoader) ==========
 
     private fun normalizeNormShape(shape: List<Long>): Shape {
         return if (shape.size == 2 && shape[0] == 1L) {

--- a/llm-inference/voxtral/src/jvmTest/kotlin/sk/ainet/models/voxtral/VoxtralDslPipelineTest.kt
+++ b/llm-inference/voxtral/src/jvmTest/kotlin/sk/ainet/models/voxtral/VoxtralDslPipelineTest.kt
@@ -12,7 +12,7 @@ import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.types.FP32
 import sk.ainet.models.llama.LlamaModelMetadata
 import sk.ainet.models.llama.LlamaTensorNames
-import sk.ainet.models.llama.LlamaWeights
+import sk.ainet.models.llama.DecoderGgufWeights
 
 /**
  * Self-contained end-to-end test for the Voxtral backbone DSL pipeline:
@@ -89,7 +89,7 @@ class VoxtralDslPipelineTest {
     @Test
     fun `backbone weight loading maps all parameters`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
 
         val model = VoxtralNetworkLoader.backboneFromWeights(weights)
 
@@ -99,7 +99,7 @@ class VoxtralDslPipelineTest {
     @Test
     fun `backbone DIRECT mode forward produces finite logits with correct shape`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = VoxtralNetworkLoader.backboneFromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(
@@ -126,7 +126,7 @@ class VoxtralDslPipelineTest {
     @Test
     fun `backbone DIRECT mode forward is deterministic`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
 
         val model1 = VoxtralNetworkLoader.backboneFromWeights(weights)
         val runtime1 = OptimizedLLMRuntime(model1, ctx, OptimizedLLMMode.DIRECT, FP32::class)
@@ -146,7 +146,7 @@ class VoxtralDslPipelineTest {
     @Test
     fun `backbone generate produces valid token sequence`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = VoxtralNetworkLoader.backboneFromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(
@@ -175,7 +175,7 @@ class VoxtralDslPipelineTest {
     @Test
     fun `backbone logits change with different input tokens`() {
         val tensors = buildWeightTensors()
-        val weights = LlamaWeights<FP32, Float>(metadata, tensors)
+        val weights = DecoderGgufWeights<FP32, Float>(metadata, tensors)
         val model = VoxtralNetworkLoader.backboneFromWeights(weights)
 
         val runtime = OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class)

--- a/llm-runtime/kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaIngestion.kt
+++ b/llm-runtime/kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaIngestion.kt
@@ -7,7 +7,7 @@ import sk.ainet.models.llama.LlamaModelMetadata
 import sk.ainet.models.llama.LlamaRuntimeWeights
 import sk.ainet.io.model.QuantPolicy
 import sk.ainet.models.llama.loadLlamaRuntimeWeights
-import sk.ainet.models.llama.LlamaSafeTensorsLoader
+import sk.ainet.models.llama.DecoderSafeTensorsLoader
 import sk.ainet.models.llama.loadLlamaRuntimeWeightsStreaming
 import sk.ainet.lang.types.DType
 import kotlin.reflect.KClass
@@ -79,7 +79,7 @@ public class LlamaIngestion<T : DType>(
         metadata: LlamaModelMetadata,
         tiedEmbeddings: Boolean = false
     ): LlamaRuntimeWeights<T> {
-        val loader = LlamaSafeTensorsLoader(
+        val loader = DecoderSafeTensorsLoader(
             ctx = ctx,
             dtype = dtype,
             metadata = metadata,

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
@@ -36,7 +36,7 @@ import sk.ainet.apps.kllama.chat.ModelMetadata
 import sk.ainet.apps.llm.InferenceRuntime
 import sk.ainet.apps.llm.generate
 import sk.ainet.io.gguf.StreamingGGUFReader
-import sk.ainet.models.llama.LlamaWeightLoader
+import sk.ainet.models.llama.DecoderGgufWeightLoader
 import sk.ainet.models.llama.LlamaWeightMapper
 
 private enum class ModelFormat { GGUF, SAFETENSORS, BIN }
@@ -361,10 +361,10 @@ fun main(args: Array<String>) {
         var binVocabSize: Int = 0
 
         if (format == ModelFormat.GGUF && isQwen) {
-            // --- Qwen: LlamaWeightLoader with Qwen architectures → LlamaRuntime ---
+            // --- Qwen: DecoderGgufWeightLoader with Qwen architectures → LlamaRuntime ---
             // Same path as kqwen CLI — uses off-heap MemSeg for quantized tensors.
             val qwenArchitectures = setOf("qwen2", "qwen3", "qwen35")
-            val loader = LlamaWeightLoader(
+            val loader = DecoderGgufWeightLoader(
                 randomAccessProvider = { JvmRandomAccessSource.open(modelPath.toString()) },
                 quantPolicy = QuantPolicy.NATIVE_OPTIMIZED,
                 acceptedArchitectures = qwenArchitectures

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/java/KLlamaJava.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/java/KLlamaJava.kt
@@ -7,7 +7,7 @@ import sk.ainet.apps.kllama.*
 import sk.ainet.models.llama.LlamaConfigParser
 import sk.ainet.models.llama.LlamaRuntime
 import sk.ainet.models.llama.LlamaRuntimeWeights
-import sk.ainet.models.llama.LlamaSafeTensorsLoader
+import sk.ainet.models.llama.DecoderSafeTensorsLoader
 import sk.ainet.models.llama.MemSegWeightConverter
 import sk.ainet.models.llama.loadLlamaRuntimeWeightsStreaming
 import sk.ainet.context.DirectCpuExecutionContext

--- a/llm-runtime/kqwen/src/commonMain/kotlin/sk/ainet/apps/kqwen/QwenIngestion.kt
+++ b/llm-runtime/kqwen/src/commonMain/kotlin/sk/ainet/apps/kqwen/QwenIngestion.kt
@@ -4,7 +4,7 @@ import sk.ainet.context.ExecutionContext
 import sk.ainet.io.RandomAccessSource
 import sk.ainet.io.model.QuantPolicy
 import sk.ainet.models.llama.LlamaRuntimeWeights
-import sk.ainet.models.llama.LlamaWeightLoader
+import sk.ainet.models.llama.DecoderGgufWeightLoader
 import sk.ainet.models.llama.LlamaWeightMapper
 import sk.ainet.lang.types.DType
 import kotlin.reflect.KClass
@@ -17,7 +17,7 @@ public data class QwenLoadConfig(
 /**
  * Facade for loading Qwen2/Qwen3 models from GGUF files.
  *
- * Qwen uses the same tensor layout as LLaMA, so this delegates to [LlamaWeightLoader]
+ * Qwen uses the same tensor layout as LLaMA, so this delegates to [DecoderGgufWeightLoader]
  * with `acceptedArchitectures = setOf("qwen2", "qwen3")`.
  */
 public class QwenIngestion<T : DType>(
@@ -34,7 +34,7 @@ public class QwenIngestion<T : DType>(
      * Parses metadata only (~1MB memory), loads tensors on-demand.
      */
     public suspend fun loadStreaming(randomAccessProvider: () -> RandomAccessSource): LlamaRuntimeWeights<T> {
-        val loader = LlamaWeightLoader(
+        val loader = DecoderGgufWeightLoader(
             randomAccessProvider = randomAccessProvider,
             quantPolicy = config.quantPolicy,
             acceptedArchitectures = QWEN_ARCHITECTURES


### PR DESCRIPTION
## Summary
- Mechanical rename of the loaders in `:llm-inference:llama` that have always been *de-facto* shared across the decoder LLM family (Llama, Qwen, Mistral, Voxtral). Their names are now consistent with their role.
  - `LlamaWeightLoader` → `DecoderGgufWeightLoader`
  - `LlamaWeights` → `DecoderGgufWeights`
  - `LlamaSafeTensorsLoader` → `DecoderSafeTensorsLoader`
- 22 files touched, **+134 / -134 lines** — the diff is symmetrical because it's pure identifier rename. No API change beyond the names; generic params, reified inlines, and call sites all preserved. Two source files renamed via `git mv` to keep history.
- Independent of #110 (collapse `*NetworkDef`) — both target `develop`. They will conflict on a single line in the renamed `DecoderGgufWeightLoader.kt` (where #110 added `: DecoderModelMetadata` to `LlamaModelMetadata`); whichever lands second resolves trivially.

## Intentionally NOT renamed
- **`LlamaModelMetadata`** — still in flux. Each model's eventual per-arch metadata (`Qwen3ModelMetadata`, `MistralModelMetadata`, …) implementing `DecoderModelMetadata` is a separate naming decision.
- **`LlamaWeightMapper` / `LlamaRuntimeWeights` / `LlamaLayerWeights`** — produce the legacy `LlamaRuntime`'s runtime format. Genuinely Llama-runtime-specific; deleted in Phase 4 along with `LlamaRuntime`.
- **`LlamaTensorNames` / `LlamaGgufTensorNames`** — tensor-name constants for Llama-family GGUF naming. Renaming them is more clutter than clarity.
- **`LlamaConfigParser`** — HF `config.json` parser; each architecture has its own.

## Test plan
- [x] `./gradlew :llm-core:jvmTest :llm-inference:{llama,qwen,voxtral,apertus,gemma,bert}:jvmTest :llm-runtime:{kllama,kqwen}:jvmTest :llm-api:jvmTest :llm-agent:jvmTest`
- All pass; only pre-existing `@Deprecated` warnings about `LlamaRuntime` (will be deleted in Phase 4).
- [ ] CI green on PR.

Refs the no-model-duplication plan and the closed #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)