### PR TITLE
feat(llama): add DecoderGgufMemSegConverter for the DSL inference path

### DIFF
--- a/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverter.kt
+++ b/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverter.kt
@@ -1,0 +1,126 @@
+package sk.ainet.models.llama
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.gguf.GGMLQuantizationType
+import sk.ainet.io.gguf.dequant.DequantOps
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.IntArrayTensorData
+import sk.ainet.lang.tensor.data.Q4MemorySegmentTensorData
+import sk.ainet.lang.tensor.data.Q8MemorySegmentTensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.types.FP32
+import java.lang.foreign.Arena
+
+/**
+ * Post-load converter for the DSL inference path.
+ *
+ * Counterpart to [MemSegWeightConverter] (which targets the legacy
+ * [LlamaRuntimeWeights] format), this one operates directly on
+ * [DecoderGgufWeights] — the GGUF-keyed tensor map produced by
+ * [DecoderGgufWeightLoader] under [sk.ainet.io.model.QuantPolicy.NATIVE_OPTIMIZED].
+ *
+ * Behavior per quant type:
+ * - **Q4_0 / Q8_0** → wrapped as [Q4MemorySegmentTensorData] /
+ *   [Q8MemorySegmentTensorData]. Upstream `DefaultCpuOpsJvm.matmul` detects
+ *   their markers and dispatches SIMD quant kernels at forward time.
+ * - **Q4_K / Q5_K / Q6_K** → dequantized to FP32. The packed K-quant kernels
+ *   are MemSeg-only on a hot path the DSL doesn't yet route through, so this
+ *   trades memory for correctness. Same trade-off the legacy converter
+ *   makes for K-quants.
+ * - **FP32 (no entry in `quantTypes`)** → passed through unchanged.
+ * - **Other quant types** → warning logged, passed through (will fail later
+ *   if the model actually hits them via matmul).
+ *
+ * Unlike the legacy [MemSegWeightConverter], this one does NOT pre-transpose
+ * weights to `[in, out]`. The DSL's [sk.ainet.lang.nn.transformer.linearProject]
+ * always calls `ops.transpose(weight)` at forward time; for Q4/Q8 MemSeg
+ * tensors that's a free metadata-only swap upstream, so pre-transposing
+ * brings no benefit. For dequantized K-quants and FP32 tensors a runtime
+ * transpose still has a real cost — addressing it requires a pre-transposed
+ * marker on `linearProject`, tracked as a follow-up perf optimization.
+ *
+ * Caller manages the [Arena] lifecycle. Tying it to the inference
+ * `ExecutionContext` lifecycle is the typical pattern.
+ */
+public object DecoderGgufMemSegConverter {
+
+    /**
+     * Return a copy of [weights] with Q4_0/Q8_0 tensors wrapped as MemSeg
+     * variants and K-quants dequantized to FP32. No-op if [weights] has no
+     * quantized tensors.
+     */
+    public fun convert(
+        weights: DecoderGgufWeights<FP32, Float>,
+        ctx: ExecutionContext,
+        arena: Arena,
+    ): DecoderGgufWeights<FP32, Float> {
+        if (weights.quantTypes.isEmpty()) return weights
+
+        val newTensors = LinkedHashMap<String, Tensor<FP32, Float>>(weights.tensors.size)
+        for ((name, tensor) in weights.tensors) {
+            val quantType = weights.quantTypes[name]
+            if (quantType == null) {
+                newTensors[name] = tensor
+                continue
+            }
+            newTensors[name] = convertOne(name, tensor, quantType, ctx, arena)
+        }
+
+        // Drop quantTypes from the result — tensors are now either packed
+        // MemSeg (carry their own marker) or dequantized FP32 (no quant
+        // identity). Keeping a stale `quantTypes` map would mislead later
+        // consumers into thinking the tensors are still raw bytes.
+        return weights.copy(tensors = newTensors, quantTypes = emptyMap())
+    }
+
+    private fun convertOne(
+        name: String,
+        tensor: Tensor<FP32, Float>,
+        quantType: GGMLQuantizationType,
+        ctx: ExecutionContext,
+        arena: Arena,
+    ): Tensor<FP32, Float> {
+        val bytes = extractBytes(tensor.data)
+        val shape = tensor.shape
+
+        return when (quantType) {
+            GGMLQuantizationType.Q4_0 -> {
+                val newData = Q4MemorySegmentTensorData.fromRawBytes(shape, bytes, arena)
+                @Suppress("UNCHECKED_CAST")
+                ctx.fromData(newData as TensorData<FP32, Float>, FP32::class)
+            }
+            GGMLQuantizationType.Q8_0 -> {
+                val newData = Q8MemorySegmentTensorData.fromRawBytes(shape, bytes, arena)
+                @Suppress("UNCHECKED_CAST")
+                ctx.fromData(newData as TensorData<FP32, Float>, FP32::class)
+            }
+            GGMLQuantizationType.Q4_K,
+            GGMLQuantizationType.Q5_K,
+            GGMLQuantizationType.Q6_K -> {
+                val floats = DequantOps.dequantFromBytes(bytes, quantType, shape.volume)
+                ctx.fromFloatArray(shape, FP32::class, floats)
+            }
+            else -> {
+                println(
+                    "WARNING: DecoderGgufMemSegConverter: unsupported quant type $quantType for '$name'; " +
+                        "passing through unchanged. Forward pass may fail at matmul."
+                )
+                tensor
+            }
+        }
+    }
+
+    private fun extractBytes(data: TensorData<*, *>): ByteArray {
+        // DecoderGgufWeightLoader with NATIVE_OPTIMIZED stores raw bytes as
+        // an IntArrayTensorData of Int8. Mirror MemSegWeightConverter's path.
+        if (data is IntArrayTensorData<*>) {
+            val buf = data.buffer
+            return ByteArray(buf.size) { buf[it].toByte() }
+        }
+        val size = data.shape.volume
+        return ByteArray(size) {
+            @Suppress("UNCHECKED_CAST")
+            ((data as TensorData<*, Int>)[it]).toByte()
+        }
+    }
+}

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverterTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverterTest.kt
@@ -1,0 +1,193 @@
+package sk.ainet.models.llama
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.gguf.GGMLQuantizationType
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.Q4MemorySegmentMarker
+import sk.ainet.lang.tensor.data.Q8MemorySegmentMarker
+import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Int8
+import java.lang.foreign.Arena
+
+class DecoderGgufMemSegConverterTest {
+
+    private val ctx = DirectCpuExecutionContext()
+    private val dim = 32   // multiple of block size (32)
+    private val ffn = 64
+    private val vocab = 4
+
+    private val metadata = LlamaModelMetadata(
+        architecture = "qwen3",
+        embeddingLength = dim,
+        contextLength = 8,
+        blockCount = 1,
+        headCount = 1,
+        kvHeadCount = 1,
+        feedForwardLength = ffn,
+        ropeDimensionCount = dim,
+        vocabSize = vocab,
+    )
+
+    @Test
+    fun `empty quantTypes returns weights unchanged`() {
+        val weights = DecoderGgufWeights<FP32, Float>(
+            metadata = metadata,
+            tensors = mapOf(
+                "blk.0.attn_norm.weight" to fpTensor(Shape(dim)),
+                "output_norm.weight" to fpTensor(Shape(dim)),
+            ),
+            quantTypes = emptyMap(),
+        )
+
+        Arena.ofConfined().use { arena ->
+            val out = DecoderGgufMemSegConverter.convert(weights, ctx, arena)
+            // Same instance — no-op short-circuit.
+            assertSame(weights, out)
+        }
+    }
+
+    @Test
+    fun `Q4_0 tensor is wrapped as Q4 MemSegment`() {
+        val rawQ4 = rawQ4Tensor(rows = dim, cols = dim)
+        val weights = DecoderGgufWeights<FP32, Float>(
+            metadata = metadata,
+            tensors = mapOf(
+                "blk.0.attn_q.weight" to rawQ4,
+                "blk.0.attn_norm.weight" to fpTensor(Shape(dim)), // FP32 pass-through
+            ),
+            quantTypes = mapOf("blk.0.attn_q.weight" to GGMLQuantizationType.Q4_0),
+        )
+
+        Arena.ofConfined().use { arena ->
+            val out = DecoderGgufMemSegConverter.convert(weights, ctx, arena)
+
+            val q = out.tensors.getValue("blk.0.attn_q.weight")
+            assertTrue(
+                q.data is Q4MemorySegmentMarker,
+                "Q4_0 tensor must be wrapped as Q4MemorySegmentTensorData; got ${q.data::class.simpleName}",
+            )
+
+            val norm = out.tensors.getValue("blk.0.attn_norm.weight")
+            assertSame(
+                weights.tensors.getValue("blk.0.attn_norm.weight"), norm,
+                "FP32 tensor without an entry in quantTypes must pass through unchanged",
+            )
+
+            // quantTypes is dropped after conversion — packed tensors carry
+            // their own marker, dequantized FP32 tensors have no quant identity.
+            assertTrue(out.quantTypes.isEmpty(), "quantTypes should be cleared post-convert")
+        }
+    }
+
+    @Test
+    fun `Q8_0 tensor is wrapped as Q8 MemSegment`() {
+        val rawQ8 = rawQ8Tensor(rows = ffn, cols = dim)
+        val weights = DecoderGgufWeights<FP32, Float>(
+            metadata = metadata,
+            tensors = mapOf("blk.0.ffn_gate.weight" to rawQ8),
+            quantTypes = mapOf("blk.0.ffn_gate.weight" to GGMLQuantizationType.Q8_0),
+        )
+
+        Arena.ofConfined().use { arena ->
+            val out = DecoderGgufMemSegConverter.convert(weights, ctx, arena)
+
+            val gate = out.tensors.getValue("blk.0.ffn_gate.weight")
+            assertTrue(
+                gate.data is Q8MemorySegmentMarker,
+                "Q8_0 tensor must be wrapped as Q8MemorySegmentTensorData; got ${gate.data::class.simpleName}",
+            )
+        }
+    }
+
+    @Test
+    fun `tensor count and key set are preserved`() {
+        val q4 = rawQ4Tensor(dim, dim)
+        val q8 = rawQ8Tensor(ffn, dim)
+        val weights = DecoderGgufWeights<FP32, Float>(
+            metadata = metadata,
+            tensors = linkedMapOf(
+                "blk.0.attn_q.weight" to q4,
+                "blk.0.ffn_gate.weight" to q8,
+                "output_norm.weight" to fpTensor(Shape(dim)),
+            ),
+            quantTypes = mapOf(
+                "blk.0.attn_q.weight" to GGMLQuantizationType.Q4_0,
+                "blk.0.ffn_gate.weight" to GGMLQuantizationType.Q8_0,
+            ),
+        )
+
+        Arena.ofConfined().use { arena ->
+            val out = DecoderGgufMemSegConverter.convert(weights, ctx, arena)
+            assertEquals(weights.tensors.keys, out.tensors.keys)
+            assertEquals(weights.tensors.size, out.tensors.size)
+        }
+    }
+
+    private fun fpTensor(shape: Shape, value: Float = 1f): Tensor<FP32, Float> =
+        ctx.full(shape, FP32::class, value)
+
+    /** Build a raw-byte tensor that simulates a NATIVE_OPTIMIZED Q4_0 load. */
+    private fun rawQ4Tensor(rows: Int, cols: Int): Tensor<FP32, Float> {
+        val nElements = rows * cols
+        val blockSize = 32
+        val bytesPerBlock = 18
+        val nBlocks = nElements / blockSize
+        val nBytes = nBlocks * bytesPerBlock
+
+        val bytes = ByteArray(nBytes)
+        for (block in 0 until nBlocks) {
+            val off = block * bytesPerBlock
+            // f16 scale = 0.5 → encode as half-float
+            val halfBits = floatToHalf(0.5f)
+            bytes[off] = (halfBits and 0xFF).toByte()
+            bytes[off + 1] = ((halfBits shr 8) and 0xFF).toByte()
+            // Nibble codes: 8 (zero offset) on both halves for simplicity
+            for (i in 0 until 16) {
+                bytes[off + 2 + i] = 0x88.toByte()
+            }
+        }
+
+        val tensor = ctx.fromByteArray<Int8, Byte>(Shape(nBytes), Int8::class, bytes)
+        @Suppress("UNCHECKED_CAST")
+        return tensor as Tensor<FP32, Float>
+    }
+
+    /** Build a raw-byte tensor that simulates a NATIVE_OPTIMIZED Q8_0 load. */
+    private fun rawQ8Tensor(rows: Int, cols: Int): Tensor<FP32, Float> {
+        val nElements = rows * cols
+        val blockSize = 32
+        val bytesPerBlock = 34
+        val nBlocks = nElements / blockSize
+        val nBytes = nBlocks * bytesPerBlock
+
+        val bytes = ByteArray(nBytes)
+        for (block in 0 until nBlocks) {
+            val off = block * bytesPerBlock
+            val halfBits = floatToHalf(0.25f)
+            bytes[off] = (halfBits and 0xFF).toByte()
+            bytes[off + 1] = ((halfBits shr 8) and 0xFF).toByte()
+            for (i in 0 until 32) {
+                bytes[off + 2 + i] = 0
+            }
+        }
+
+        val tensor = ctx.fromByteArray<Int8, Byte>(Shape(nBytes), Int8::class, bytes)
+        @Suppress("UNCHECKED_CAST")
+        return tensor as Tensor<FP32, Float>
+    }
+
+    private fun floatToHalf(f: Float): Int {
+        val bits = f.toRawBits()
+        val sign = (bits ushr 16) and 0x8000
+        val exp = ((bits ushr 23) and 0xFF) - 127 + 15
+        val mant = bits and 0x7FFFFF
+        if (exp <= 0) return sign
+        if (exp >= 31) return sign or 0x7C00
+        return sign or (exp shl 10) or (mant ushr 13)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a post-load converter targeting the DSL path's `DecoderGgufWeights<T, V>` format. This is the bind-time piece Phase 1B needs so quantized weights can flow through `OptimizedLLMRuntime` without dequantizing the entire model to FP32.
- Purely additive — 2 new files in `:llm-inference:llama`, no existing code modified. The legacy `MemSegWeightConverter` (operates on `LlamaRuntimeWeights`) stays in place and gets deleted in Phase 4 along with `LlamaRuntime`.

## Why a separate converter
The original Phase 1B plan said "move `MemSegWeightConverter` to `:llm-core` (it's generic)". That premise was wrong: the existing converter operates on `LlamaRuntimeWeights<FP32>` (the hand-coded `LlamaRuntime`'s named-field layer struct: `wq`, `wk`, `wv`, …) and is genuinely tied to that legacy format. The DSL path uses `DecoderGgufWeights<T, V>` — a flat tensor-name → tensor map — which has a different shape. So the DSL needs its own converter; the two coexist until Phase 4 deletes the legacy one.

## Behavior
| Input quant type | Output |
|---|---|
| Q4_0 | Wrapped as `Q4MemorySegmentTensorData` |
| Q8_0 | Wrapped as `Q8MemorySegmentTensorData` |
| Q4_K / Q5_K / Q6_K | Dequantized to FP32 (same trade-off `MemSegWeightConverter` makes; packed K-quant kernels aren't on the DSL hot path) |
| FP32 (no entry in `quantTypes`) | Pass-through unchanged |
| Anything else | Warning logged, pass-through (forward will fail at matmul if hit) |

`quantTypes` is cleared on the result — packed tensors carry their own marker, dequantized tensors have no quant identity, and a stale map would mislead later consumers.

## Why no pre-transpose (unlike the legacy converter)
The DSL's `linearProject(input, weight)` always calls `ops.matmul(input, ops.transpose(weight))`. For Q4/Q8 MemSeg tensors upstream's `transpose` is a shape-only metadata swap (free), so pre-transposing brings no benefit. For dequantized K-quants and FP32 tensors a runtime transpose still has a real cost — addressing it requires adding a pre-transposed marker that `linearProject` checks, which is tracked as a follow-up perf optimization in the sub-plan.

## What ships next on top of this
- **1B.2** — `fromGgufNative(...)` entry point on `QwenNetworkLoader` / `LlamaNetworkLoader` / `VoxtralNetworkLoader` that loads with `NATIVE_OPTIMIZED` and runs the converter before binding into the DSL.
- **1B.4** — DSL-vs-`LlamaRuntime` numerical parity test on the same packed weights.
- After both: Phase 4 (CLI swap, delete `LlamaRuntime`).

## Test plan
- [x] 4 new tests in `DecoderGgufMemSegConverterTest`: empty-quantTypes no-op, Q4_0 wrap (verified via `Q4MemorySegmentMarker`), Q8_0 wrap, key-set preservation.
- [x] No regressions: existing `MemSegWeightConverterTest`, all `:llm-core`, `:llm-inference:llama`, `:llm-inference:qwen`, `:llm-runtime:kllama` tests pass.
- [ ] CI green on PR.

Refs the Phase 1B sub-plan (`~/.claude/plans/snazzy-wibbling-dewdrop-1B.md`) and the closed #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)