### PR TITLE
feat(qwen): DSL native-quantized GGUF entry point + Q8 smoke test

### DIFF
--- a/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverter.kt
+++ b/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverter.kt
@@ -1,8 +1,10 @@
 package sk.ainet.models.llama
 
 import sk.ainet.context.ExecutionContext
+import sk.ainet.io.RandomAccessSource
 import sk.ainet.io.gguf.GGMLQuantizationType
 import sk.ainet.io.gguf.dequant.DequantOps
+import sk.ainet.io.model.QuantPolicy
 import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.tensor.data.IntArrayTensorData
 import sk.ainet.lang.tensor.data.Q4MemorySegmentTensorData
@@ -123,4 +125,29 @@ public object DecoderGgufMemSegConverter {
             ((data as TensorData<*, Int>)[it]).toByte()
         }
     }
+}
+
+/**
+ * Convenience wrapper for the DSL inference path: stream a GGUF file with
+ * `NATIVE_OPTIMIZED` quant policy, then run [DecoderGgufMemSegConverter] so
+ * Q4_0 / Q8_0 tensors are wrapped as `MemorySegment`-backed packed data
+ * before binding into a DSL network. Per-architecture loaders compose this
+ * with their own `acceptedArchitectures` set and pass the result to
+ * `xNetworkLoader.fromWeights(...)`.
+ *
+ * Caller manages the [arena] lifecycle.
+ */
+public suspend fun loadDecoderGgufWeightsNative(
+    randomAccessProvider: () -> RandomAccessSource,
+    acceptedArchitectures: Set<String>,
+    ctx: ExecutionContext,
+    arena: Arena,
+): DecoderGgufWeights<FP32, Float> {
+    val loader = DecoderGgufWeightLoader(
+        randomAccessProvider = randomAccessProvider,
+        quantPolicy = QuantPolicy.NATIVE_OPTIMIZED,
+        acceptedArchitectures = acceptedArchitectures,
+    )
+    val raw = loader.loadToMapStreaming<FP32, Float>(ctx)
+    return DecoderGgufMemSegConverter.convert(raw, ctx, arena)
 }

--- a/llm-inference/qwen/src/jvmMain/kotlin/sk/ainet/models/qwen/QwenNetworkLoaderJvm.kt
+++ b/llm-inference/qwen/src/jvmMain/kotlin/sk/ainet/models/qwen/QwenNetworkLoaderJvm.kt
@@ -1,0 +1,38 @@
+package sk.ainet.models.qwen
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.RandomAccessSource
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.llama.loadDecoderGgufWeightsNative
+import java.lang.foreign.Arena
+
+/**
+ * Streaming GGUF load for the DSL Qwen3 path with native-quantized weights.
+ *
+ * Produces a [Module] whose Q4_0 / Q8_0 weights remain `MemorySegment`-
+ * packed end-to-end, so the upstream `DefaultCpuOpsJvm.matmul` quant
+ * dispatch fires at forward time without dequantising to FP32. K-quants
+ * (Q4_K / Q5_K / Q6_K) are dequantised to FP32 — packed K-quant kernels
+ * are not on the DSL hot path yet.
+ *
+ * Caller manages the [arena] lifecycle. Tying it to the inference
+ * `ExecutionContext` lifecycle is the typical pattern.
+ *
+ * Companion to [QwenNetworkLoader.fromGguf], which always dequantises to
+ * FP32 and is the multiplatform-friendly default. This entry point is
+ * JVM-only — `MemorySegment` and `Arena` are JDK-21+ APIs.
+ */
+public suspend fun QwenNetworkLoader.Companion.fromGgufNative(
+    randomAccessProvider: () -> RandomAccessSource,
+    ctx: ExecutionContext,
+    arena: Arena,
+): Module<FP32, Float> {
+    val weights = loadDecoderGgufWeightsNative(
+        randomAccessProvider = randomAccessProvider,
+        acceptedArchitectures = QWEN_ARCHITECTURES,
+        ctx = ctx,
+        arena = arena,
+    )
+    return QwenNetworkLoader.fromWeights(weights)
+}

--- a/llm-inference/qwen/src/jvmTest/kotlin/sk/ainet/models/qwen/QwenDslQuantizedTest.kt
+++ b/llm-inference/qwen/src/jvmTest/kotlin/sk/ainet/models/qwen/QwenDslQuantizedTest.kt
@@ -1,0 +1,202 @@
+package sk.ainet.models.qwen
+
+import java.lang.foreign.Arena
+import java.lang.foreign.ValueLayout
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.Q8MemorySegmentTensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.llama.DecoderGgufWeights
+import sk.ainet.models.llama.LlamaModelMetadata
+import sk.ainet.models.llama.LlamaTensorNames
+
+/**
+ * Empirical probe: can the DSL Qwen path (`qwenNetwork()` +
+ * `OptimizedLLMRuntime` DIRECT mode) forward a Q8_0-quantized weight tree
+ * without dequantising? Mirrors [`GemmaDslQuantizedTest`] for Qwen3 —
+ * including `qkNorm = true` so QK-norm submodules also flow through.
+ *
+ * Build two parallel weight maps with identical logical values, one FP32
+ * baseline and one with the 7 matmul projections (Q/K/V/O + gate/up/down)
+ * swapped to `Q8MemorySegmentTensorData`. Logit divergence must stay below
+ * `1e-3` — any larger gap means the upstream Q8 dispatch isn't composing
+ * with the DSL forward as expected.
+ *
+ * Synthetic weights use small integer values + scale = 1, so Q8 round-to-
+ * int8 is exact and the only source of variance is the matmul kernel
+ * itself.
+ */
+class QwenDslQuantizedTest {
+
+    private val ctx = DirectCpuExecutionContext()
+
+    // Q8_0 kernels assume `inputDim % 32 == 0`. dim=32, ffnDim=64 satisfy
+    // this for all projections (Q/K/V output and FFN gate/up/down).
+    private val dim = 32
+    private val nHeads = 2
+    private val kvHeads = 2
+    private val headDim = dim / nHeads
+    private val ffnDim = 64
+    private val vocabSize = 64
+    private val seqLen = 16
+
+    private val metadata = LlamaModelMetadata(
+        architecture = "qwen3",
+        embeddingLength = dim,
+        contextLength = seqLen,
+        blockCount = 1,
+        headCount = nHeads,
+        kvHeadCount = kvHeads,
+        feedForwardLength = ffnDim,
+        ropeDimensionCount = headDim,
+        vocabSize = vocabSize,
+        ropeFreqBase = 1_000_000f,
+        rmsNormEps = 1e-6f,
+    )
+
+    @Test
+    fun `Q8 MemSeg projections flow through DSL Qwen and match FP32 within tolerance`() {
+        Arena.ofConfined().use { arena ->
+            val (fp32Weights, q8Weights) = buildWeightPair(arena)
+
+            val fp32Model = QwenNetworkLoader.fromWeights(fp32Weights)
+            val q8Model = QwenNetworkLoader.fromWeights(q8Weights)
+
+            val fp32Runtime = OptimizedLLMRuntime(fp32Model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
+            val q8Runtime = OptimizedLLMRuntime(q8Model, ctx, OptimizedLLMMode.DIRECT, FP32::class)
+
+            val tokens = intArrayOf(1, 5, 3)
+            var maxDiff = 0f
+            for ((step, tokenId) in tokens.withIndex()) {
+                val a = fp32Runtime.forward(tokenId).data.copyToFloatArray()
+                val b = q8Runtime.forward(tokenId).data.copyToFloatArray()
+                for (i in a.indices) {
+                    val d = abs(a[i] - b[i])
+                    maxDiff = max(maxDiff, d)
+                    assertTrue(
+                        d < 1e-3f,
+                        "step=$step logit[$i] diverged: fp32=${a[i]} q8=${b[i]} diff=$d",
+                    )
+                }
+            }
+            println("Qwen DSL Q8 probe PASSED. Max |Δlogit| across ${tokens.size} tokens: $maxDiff")
+        }
+    }
+
+    /**
+     * Build two `DecoderGgufWeights` sharing identical logical values.
+     * The Q8 variant swaps the 7 matmul projections to packed MemSeg
+     * tensors; norms, embeddings, output head, and QK-norm scales stay
+     * FP32 (those aren't matmul targets, or aren't 32-block-multiple).
+     */
+    private fun buildWeightPair(
+        arena: Arena,
+    ): Pair<DecoderGgufWeights<FP32, Float>, DecoderGgufWeights<FP32, Float>> {
+        // Small integer values keep Q8 round-to-int exact.
+        val tokenEmb = FloatArray(vocabSize * dim) { ((it % 5) - 2).toFloat() }
+        val outputW = FloatArray(vocabSize * dim) { ((it % 5) - 2).toFloat() }
+        val ones = FloatArray(dim) { 1f }
+        val onesHead = FloatArray(headDim) { 1f }
+
+        val q = FloatArray(nHeads * headDim * dim) { (((it * 3) % 7) - 3).toFloat() }
+        val k = FloatArray(kvHeads * headDim * dim) { (((it * 5) % 7) - 3).toFloat() }
+        val v = FloatArray(kvHeads * headDim * dim) { (((it * 7) % 7) - 3).toFloat() }
+        val o = FloatArray(dim * nHeads * headDim) { (((it * 11) % 7) - 3).toFloat() }
+        val gate = FloatArray(ffnDim * dim) { (((it * 3) % 5) - 2).toFloat() }
+        val up = FloatArray(ffnDim * dim) { (((it * 5) % 5) - 2).toFloat() }
+        val down = FloatArray(dim * ffnDim) { (((it * 7) % 5) - 2).toFloat() }
+
+        val fp32Map = linkedMapOf<String, Tensor<FP32, Float>>(
+            LlamaTensorNames.TOKEN_EMBEDDINGS to fp32Tensor(Shape(vocabSize, dim), tokenEmb),
+            LlamaTensorNames.OUTPUT_NORM to fp32Tensor(Shape(dim), ones),
+            LlamaTensorNames.OUTPUT_WEIGHT to fp32Tensor(Shape(vocabSize, dim), outputW),
+            LlamaTensorNames.attnNorm(0) to fp32Tensor(Shape(dim), ones),
+            LlamaTensorNames.attnQ(0) to fp32Tensor(Shape(nHeads * headDim, dim), q),
+            LlamaTensorNames.attnK(0) to fp32Tensor(Shape(kvHeads * headDim, dim), k),
+            LlamaTensorNames.attnV(0) to fp32Tensor(Shape(kvHeads * headDim, dim), v),
+            LlamaTensorNames.attnOut(0) to fp32Tensor(Shape(dim, nHeads * headDim), o),
+            // QK-norm scales — staying FP32 (per-head RMSNorm, not a matmul target).
+            // Triggers the loader's auto-detect into a qkNorm=true network.
+            LlamaTensorNames.attnQNorm(0) to fp32Tensor(Shape(headDim), onesHead),
+            LlamaTensorNames.attnKNorm(0) to fp32Tensor(Shape(headDim), onesHead),
+            LlamaTensorNames.ffnNorm(0) to fp32Tensor(Shape(dim), ones),
+            LlamaTensorNames.ffnGate(0) to fp32Tensor(Shape(ffnDim, dim), gate),
+            LlamaTensorNames.ffnUp(0) to fp32Tensor(Shape(ffnDim, dim), up),
+            LlamaTensorNames.ffnDown(0) to fp32Tensor(Shape(dim, ffnDim), down),
+        )
+        val fp32 = DecoderGgufWeights(metadata, fp32Map)
+
+        val q8Map = linkedMapOf<String, Tensor<FP32, Float>>(
+            LlamaTensorNames.TOKEN_EMBEDDINGS to fp32Tensor(Shape(vocabSize, dim), tokenEmb),
+            LlamaTensorNames.OUTPUT_NORM to fp32Tensor(Shape(dim), ones),
+            LlamaTensorNames.OUTPUT_WEIGHT to fp32Tensor(Shape(vocabSize, dim), outputW),
+            LlamaTensorNames.attnNorm(0) to fp32Tensor(Shape(dim), ones),
+            LlamaTensorNames.attnQ(0) to q8Tensor(nHeads * headDim, dim, q, arena),
+            LlamaTensorNames.attnK(0) to q8Tensor(kvHeads * headDim, dim, k, arena),
+            LlamaTensorNames.attnV(0) to q8Tensor(kvHeads * headDim, dim, v, arena),
+            LlamaTensorNames.attnOut(0) to q8Tensor(dim, nHeads * headDim, o, arena),
+            LlamaTensorNames.attnQNorm(0) to fp32Tensor(Shape(headDim), onesHead),
+            LlamaTensorNames.attnKNorm(0) to fp32Tensor(Shape(headDim), onesHead),
+            LlamaTensorNames.ffnNorm(0) to fp32Tensor(Shape(dim), ones),
+            LlamaTensorNames.ffnGate(0) to q8Tensor(ffnDim, dim, gate, arena),
+            LlamaTensorNames.ffnUp(0) to q8Tensor(ffnDim, dim, up, arena),
+            LlamaTensorNames.ffnDown(0) to q8Tensor(dim, ffnDim, down, arena),
+        )
+        val q8 = DecoderGgufWeights(metadata, q8Map)
+
+        return fp32 to q8
+    }
+
+    private fun fp32Tensor(shape: Shape, values: FloatArray): Tensor<FP32, Float> =
+        ctx.fromFloatArray(shape, FP32::class, values)
+
+    /** Pack a small-integer FloatArray into Q8_0 with scale = 1.0 per block. */
+    private fun packQ8_0_unitScale(values: FloatArray): ByteArray {
+        require(values.size % 32 == 0) {
+            "packQ8_0_unitScale: values.size (${values.size}) must be a multiple of 32"
+        }
+        val nBlocks = values.size / 32
+        val bytes = ByteArray(nBlocks * 34)
+        // f16 1.0 little-endian: 0x3C00 → bytes [0x00, 0x3C].
+        for (b in 0 until nBlocks) {
+            val off = b * 34
+            bytes[off] = 0x00
+            bytes[off + 1] = 0x3C
+            for (i in 0 until 32) {
+                val intVal = values[b * 32 + i].toInt()
+                require(intVal in -128..127) {
+                    "packQ8_0_unitScale: value $intVal out of int8 range"
+                }
+                bytes[off + 2 + i] = intVal.toByte()
+            }
+        }
+        return bytes
+    }
+
+    private fun q8Tensor(
+        rows: Int,
+        cols: Int,
+        values: FloatArray,
+        arena: Arena,
+    ): Tensor<FP32, Float> {
+        require(values.size == rows * cols) {
+            "values.size=${values.size} != rows*cols=${rows * cols}"
+        }
+        val bytes = packQ8_0_unitScale(values)
+        val segment = arena.allocate(bytes.size.toLong())
+        for ((i, b) in bytes.withIndex()) {
+            segment.set(ValueLayout.JAVA_BYTE, i.toLong(), b)
+        }
+        val data = Q8MemorySegmentTensorData(Shape(rows, cols), segment)
+        @Suppress("UNCHECKED_CAST")
+        return ctx.fromData(data as TensorData<FP32, Float>, FP32::class)
+    }
+}


### PR DESCRIPTION
## Summary
Closes the bind-time gap so the DSL Qwen path can consume packed Q4_0 / Q8_0 GGUF weights without dequantising to FP32 (which today forces ~32 GB resident on Qwen3-8B-Q4_K_M).

Three additions, no existing code modified:
- **`loadDecoderGgufWeightsNative`** in `:llm-inference:llama/jvmMain` — top-level helper that streams a GGUF with `NATIVE_OPTIMIZED` quant policy and runs `DecoderGgufMemSegConverter` (#112) so Q4_0 / Q8_0 tensors emerge as `MemorySegment`-packed data ready to bind into a DSL network.
- **`QwenNetworkLoader.fromGgufNative`** in `:llm-inference:qwen/jvmMain` (new source set) — companion-extension that wraps the helper through `QwenNetworkLoader.fromWeights` with `QWEN_ARCHITECTURES`, returning `Module<FP32, Float>` in one call. JVM-only — `Arena` and `MemorySegment` are JDK-21+ APIs. The multiplatform-friendly `fromGguf` (defaults to dequantize) is unchanged.
- **`QwenDslQuantizedTest`** — empirical probe mirroring `GemmaDslQuantizedTest`. Builds parallel FP32 and Q8 weight maps with identical logical values (small integers, scale=1 → exact Q8 round-to-int), runs both through `OptimizedLLMRuntime` DIRECT, asserts logits diverge by < 1e-3. Includes `attn_q_norm` / `attn_k_norm` scales so `QwenNetworkLoader.fromWeights`'s auto-detect builds a real `qkNorm=true` Qwen network — exercising Q8 packed Q/K/V/O + FFN gate/up/down all flowing through the DSL forward.

## What this validates
The upstream `DefaultCpuOpsJvm.matmul` auto-dispatch on `Q4/Q8MemorySegmentMarker` composes correctly with the DSL Qwen path end-to-end. The heavy kernel work Phase 1B was originally scoped for is mostly already done upstream; the missing piece was the bind-time conversion, now wired in.

## Out of scope (deferred)
- **Llama / Voxtral `fromGgufNative` variants** — Llama is on the legacy `LlamaRuntime` path until Phase 4; Voxtral is the TTS backbone and not yet a CLI consumer. Both can land in a small follow-up.
- **DSL-vs-`LlamaRuntime` numerical parity test on packed weights** (sub-plan 1B.4) — separate PR.
- **K-quant (Q4_K / Q5_K / Q6_K) packed kernels** — converter dequantises K-quants to FP32; packed K-quant kernels exist upstream but aren't on the DSL hot path. Memory-perf optimization for later.

## Test plan
- [x] `QwenDslQuantizedTest` — 1 test, max |Δlogit| well under 1e-3.
- [x] No regressions: full `:llm-inference:llama:jvmTest`, `:llm-inference:qwen:jvmTest`, `:llm-runtime:kllama:jvmTest` pass.
- [ ] CI green on PR.

Refs the Phase 1B sub-plan, builds on #109/#110/#111/#112, and the closed #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)