### PR TITLE
fix(tokenizer): route Qwen / GPT-2 BPE GGUFs to upstream byte-level BPE

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/GGUFTokenizer.kt
@@ -371,8 +371,13 @@ class GGUFTokenizer private constructor(
          * Create a tokenizer from StreamingGGUFReader fields.
          * StreamingGGUFReader.fields returns direct values (Map<String, Any?>),
          * not ReaderField objects.
+         *
+         * Internal-but-public so [TokenizerFactory.fromGGUF] can hand off
+         * already-parsed fields without re-opening the source. External
+         * callers should use [fromRandomAccessSource] or
+         * [TokenizerFactory.fromGGUF].
          */
-        private fun fromStreamingFields(fields: Map<String, Any?>, debug: Boolean = false): GGUFTokenizer {
+        public fun fromStreamingFields(fields: Map<String, Any?>, debug: Boolean = false): GGUFTokenizer {
             // Extract vocabulary tokens (stored as List<String> in streaming reader)
             val tokensValue = fields["tokenizer.ggml.tokens"]
                 ?: error("GGUF file missing tokenizer.ggml.tokens field")

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerFactory.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerFactory.kt
@@ -2,30 +2,50 @@ package sk.ainet.apps.llm.tokenizer
 
 import sk.ainet.apps.llm.Tokenizer
 import sk.ainet.io.RandomAccessSource
+import sk.ainet.io.gguf.StreamingGGUFReader
 
 /**
  * Unified factory for creating tokenizers from various sources.
  *
- * Usage:
- * ```kotlin
- * // From GGUF file (auto-detects BPE/SentencePiece/WordPiece)
- * val tokenizer = TokenizerFactory.fromGGUF(randomAccessSource)
+ * Per-architecture dispatch: a Qwen / GPT-2 / Mistral-Nemo model needs
+ * byte-level BPE (correctly implemented in upstream
+ * [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer]); a Llama / Gemma /
+ * TinyLlama model uses SentencePiece via the local [GGUFTokenizer].
  *
- * // From HuggingFace tokenizer.json
- * val tokenizer = TokenizerFactory.fromTokenizerJson(jsonString)
- * ```
+ * The split is because the local [GGUFTokenizer]'s `encodeBPE` is the
+ * greedy-by-score SentencePiece algorithm — wrong for byte-level BPE,
+ * which needs `bytes_to_unicode` mapping + GPT-2 pretokenization regex
+ * + merge-rank-based merging. See #52.
  */
 public object TokenizerFactory {
 
     /**
      * Create a tokenizer from GGUF file metadata (streaming, memory-efficient).
-     * Auto-detects tokenizer type from vocabulary and metadata.
+     *
+     * Dispatches on `tokenizer.ggml.model`:
+     * - `gpt2` / `bpe` → upstream [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer]
+     *   (correct byte-level BPE, matches HuggingFace transformers / llama.cpp)
+     * - everything else → local [GGUFTokenizer] (SentencePiece path)
      *
      * @param source Random access source to the GGUF file.
      * @param debug Print debug information during loading.
      */
-    public fun fromGGUF(source: RandomAccessSource, debug: Boolean = false): GGUFTokenizer {
-        return GGUFTokenizer.fromRandomAccessSource(source, debug)
+    public fun fromGGUF(source: RandomAccessSource, debug: Boolean = false): Tokenizer {
+        return StreamingGGUFReader.open(source).use { reader ->
+            val fields = reader.fields
+            val model = (fields["tokenizer.ggml.model"] as? String)?.lowercase()
+            when (model) {
+                "gpt2", "bpe" -> {
+                    if (debug) println("TokenizerFactory: model=$model → upstream QwenByteLevelBpeTokenizer")
+                    val upstream = sk.ainet.io.tokenizer.TokenizerFactory.fromGguf(fields)
+                    UpstreamTokenizerAdapter(upstream)
+                }
+                else -> {
+                    if (debug) println("TokenizerFactory: model=$model → local GGUFTokenizer")
+                    GGUFTokenizer.fromStreamingFields(fields, debug)
+                }
+            }
+        }
     }
 
     /**

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapter.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapter.kt
@@ -1,0 +1,33 @@
+package sk.ainet.apps.llm.tokenizer
+
+import sk.ainet.apps.llm.Tokenizer
+
+/**
+ * Bridges an upstream [sk.ainet.io.tokenizer.Tokenizer] (in
+ * `skainet-io-core`) into this repo's [Tokenizer] interface.
+ *
+ * Upstream's `bosTokenId` / `eosTokenId` are nullable; the local interface
+ * is non-null with int defaults. Upstream has no single-token decode; the
+ * adapter implements it via `decode(intArrayOf(token))`.
+ *
+ * Used by [TokenizerFactory.fromGGUF] to route Qwen / GPT-2 / Mistral-Nemo
+ * GGUFs (`tokenizer.ggml.model == "gpt2"` / `"bpe"`) to the correct
+ * byte-level BPE implementation, instead of the broken local
+ * [GGUFTokenizer]'s greedy-by-score `encodeBPE`. Closes #52.
+ */
+internal class UpstreamTokenizerAdapter(
+    private val delegate: sk.ainet.io.tokenizer.Tokenizer,
+    bosTokenIdFallback: Int = 1,
+    eosTokenIdFallback: Int = 2,
+) : Tokenizer {
+
+    override val vocabSize: Int get() = delegate.vocabSize
+    override val bosTokenId: Int = delegate.bosTokenId ?: bosTokenIdFallback
+    override val eosTokenId: Int = delegate.eosTokenId ?: eosTokenIdFallback
+
+    override fun encode(text: String): IntArray = delegate.encode(text)
+
+    override fun decode(tokens: IntArray): String = delegate.decode(tokens)
+
+    override fun decode(token: Int): String = delegate.decode(intArrayOf(token))
+}

--- a/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapterTest.kt
+++ b/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapterTest.kt
@@ -1,0 +1,88 @@
+package sk.ainet.apps.llm.tokenizer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UpstreamTokenizerAdapterTest {
+
+    /** Stub of the upstream Tokenizer interface for adapter contract tests. */
+    private class StubUpstreamTokenizer(
+        override val vocabSize: Int,
+        override val bosTokenId: Int? = null,
+        override val eosTokenId: Int? = null,
+        private val encodeFn: (String) -> IntArray,
+        private val decodeFn: (IntArray) -> String,
+    ) : sk.ainet.io.tokenizer.Tokenizer {
+        override fun encode(text: String): IntArray = encodeFn(text)
+        override fun decode(ids: IntArray): String = decodeFn(ids)
+    }
+
+    @Test
+    fun `delegates encode and decode`() {
+        val stub = StubUpstreamTokenizer(
+            vocabSize = 100,
+            bosTokenId = 1,
+            eosTokenId = 2,
+            encodeFn = { text -> intArrayOf(text.length, 99) },
+            decodeFn = { ids -> "decoded(${ids.joinToString(",")})" },
+        )
+        val adapter = UpstreamTokenizerAdapter(stub)
+
+        assertEquals(100, adapter.vocabSize)
+        assertEquals(1, adapter.bosTokenId)
+        assertEquals(2, adapter.eosTokenId)
+
+        val encoded = adapter.encode("hello")
+        assertEquals(2, encoded.size)
+        assertEquals(5, encoded[0])
+        assertEquals(99, encoded[1])
+
+        assertEquals("decoded(7,8)", adapter.decode(intArrayOf(7, 8)))
+    }
+
+    @Test
+    fun `single-token decode wraps in IntArray`() {
+        var capturedIds: IntArray? = null
+        val stub = StubUpstreamTokenizer(
+            vocabSize = 10,
+            encodeFn = { intArrayOf() },
+            decodeFn = { ids -> capturedIds = ids; "" },
+        )
+        val adapter = UpstreamTokenizerAdapter(stub)
+
+        adapter.decode(42)
+
+        assertTrue(capturedIds != null && capturedIds!!.size == 1)
+        assertEquals(42, capturedIds!![0])
+    }
+
+    @Test
+    fun `null bos and eos fall back to defaults`() {
+        val stub = StubUpstreamTokenizer(
+            vocabSize = 10,
+            bosTokenId = null,
+            eosTokenId = null,
+            encodeFn = { intArrayOf() },
+            decodeFn = { "" },
+        )
+        // Defaults: bos = 1, eos = 2.
+        val adapter = UpstreamTokenizerAdapter(stub)
+        assertEquals(1, adapter.bosTokenId)
+        assertEquals(2, adapter.eosTokenId)
+    }
+
+    @Test
+    fun `null bos and eos honour custom fallbacks`() {
+        val stub = StubUpstreamTokenizer(
+            vocabSize = 10,
+            bosTokenId = null,
+            eosTokenId = null,
+            encodeFn = { intArrayOf() },
+            decodeFn = { "" },
+        )
+        val adapter = UpstreamTokenizerAdapter(stub, bosTokenIdFallback = 7, eosTokenIdFallback = 13)
+        assertEquals(7, adapter.bosTokenId)
+        assertEquals(13, adapter.eosTokenId)
+    }
+}

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
@@ -5,6 +5,7 @@ import sk.ainet.models.llama.LlamaConfigParser
 import sk.ainet.apps.kllama.LlamaIngestion
 import sk.ainet.apps.kllama.LlamaLoadConfig
 import sk.ainet.apps.llm.Tokenizer
+import sk.ainet.apps.llm.tokenizer.TokenizerFactory
 import sk.ainet.models.llama.LlamaRuntime
 import sk.ainet.apps.kllama.CpuAttentionBackend
 import sk.ainet.apps.kllama.Llama2DotCWeightLoader
@@ -477,7 +478,7 @@ fun main(args: Array<String>) {
             format == ModelFormat.GGUF && tokenizerPath == null -> {
                 println("Loading embedded GGUF tokenizer...")
                 JvmRandomAccessSource.open(modelPath.toString()).use { source ->
-                    GGUFTokenizer.fromRandomAccessSource(source)
+                    TokenizerFactory.fromGGUF(source)
                 }
             }
             else -> {

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/java/KLlamaJava.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/java/KLlamaJava.kt
@@ -4,6 +4,7 @@ package sk.ainet.apps.kllama.java
 
 import kotlinx.coroutines.runBlocking
 import sk.ainet.apps.kllama.*
+import sk.ainet.apps.llm.tokenizer.TokenizerFactory
 import sk.ainet.models.llama.LlamaConfigParser
 import sk.ainet.models.llama.LlamaRuntime
 import sk.ainet.models.llama.LlamaRuntimeWeights
@@ -77,15 +78,15 @@ public object KLlamaJava {
         val backend = CpuAttentionBackend<FP32>(ctx, weights, FP32::class)
         val runtime = LlamaRuntime<FP32>(ctx, weights, backend, FP32::class)
 
-        // Load embedded GGUF tokenizer
+        // Load embedded GGUF tokenizer (auto-dispatches Qwen / GPT-2 BPE → upstream)
         val tokenizer = JvmRandomAccessSource.open(modelPath.toString()).use { source ->
-            GGUFTokenizer.fromRandomAccessSource(source)
+            TokenizerFactory.fromGGUF(source)
         }
 
         return KLlamaSession(
             runtime = runtime,
             tokenizer = tokenizer,
-            eosTokenId = tokenizer.eosId,
+            eosTokenId = tokenizer.eosTokenId,
             systemPrompt = systemPrompt,
             closeAction = Runnable {
                 quantArena.close()


### PR DESCRIPTION
Closes #52.

## Why
The local `GGUFTokenizer.encodeBPE()` is the SentencePiece greedy-by-score algorithm. It's the **wrong algorithm** for byte-level BPE (Qwen / GPT-2 / Mistral-Nemo): missing the `bytes_to_unicode()` mapping, missing merge-rank-based merging, and missing GPT-2 pretokenization regex. Per #52 the symptom is chat-template prompts encoding to broken token sequences, so Qwen3 generates CJK / URL-encoded / HTML-entity nonsense in tool-calling and chat modes.

The fix is **already in upstream SKaiNET 0.23.1** — `sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer` implements the full seven-step HF / llama.cpp pipeline. This PR routes Qwen-family GGUFs there. Pinned SKaiNET version is unchanged.

## What changes
- **New: `UpstreamTokenizerAdapter`** in `:llm-core` (`commonMain`) — bridges upstream's `sk.ainet.io.tokenizer.Tokenizer` (nullable bos/eos, no single-token decode) into this repo's `sk.ainet.apps.llm.Tokenizer` interface (non-null bos/eos, single-token decode).
- **`TokenizerFactory.fromGGUF(source)`** now returns `Tokenizer` (interface) instead of `GGUFTokenizer` (concrete). Inside, peeks `tokenizer.ggml.model` once and dispatches:
  - `gpt2` / `bpe` → upstream `QwenByteLevelBpeTokenizer` via adapter ✅ correct
  - everything else → existing local `GGUFTokenizer` (SentencePiece path, unchanged)
- **`GGUFTokenizer.fromStreamingFields`** — was private, now `public` so the factory can hand off pre-parsed fields without re-opening the source. Doc warns external callers to prefer the factory.
- **Two CLI callers migrated** from `GGUFTokenizer.fromRandomAccessSource(source)` → `TokenizerFactory.fromGGUF(source)`:
  - `:llm-runtime:kllama` `cli/Main.kt`
  - `:llm-runtime:kllama` `java/KLlamaJava.kt` (also: `tokenizer.eosId` → `tokenizer.eosTokenId`, since the variable type is now the interface)
  - `:llm-apps:skainet-cli` already used the factory; unaffected.

## Out of scope
The `fromTokenizerJson` path (SafeTensors tokenizer.json loading) has no Qwen-SafeTensors caller in this repo today — `:llm-runtime:kgemma` uses it for SentencePiece, which works correctly. Extending the upstream dispatch to `fromTokenizerJson` is a small follow-up if/when a Qwen SafeTensors path lands.

## Test plan
- [x] **4 new tests** in `UpstreamTokenizerAdapterTest`: encode / decode delegation, single-token decode, null-bos/eos defaults + custom fallbacks.
- [x] No regressions: `:llm-core:jvmTest`, `:llm-runtime:kllama:jvmTest`, `:llm-runtime:kgemma:jvmTest`, `:llm-apps:skainet-cli:build` all pass.
- [ ] CI green on PR.
- [ ] **Manual smoke** (post-merge, requires real GGUF): run `kllama-cli` on `Qwen2.5-0.5B-Instruct-Q8_0.gguf` with `--demo \"What is 2 + 2?\"`. Expected coherent answer or `<tool_call>` block instead of CJK / URL-encoded garbage from #52.

Refs the closed #46. Phase-4 readiness checklist (issue #114) still has the parity finding open as a separate concern, but #52 is no longer the byte-level-BPE blocker on that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)