### PR TITLE
fix(qwen): apply NEOX (SPLIT_HALF) RoPE pairing for Qwen3 GGUFs

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderTransformerNetwork.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/decoder/DecoderTransformerNetwork.kt
@@ -11,6 +11,7 @@ import sk.ainet.lang.nn.dsl.residual
 import sk.ainet.lang.nn.dsl.rmsNorm
 import sk.ainet.lang.nn.dsl.sequential
 import sk.ainet.lang.nn.dsl.swiGluFFN
+import sk.ainet.lang.nn.transformer.RoPEMode
 import sk.ainet.lang.nn.transformer.VoidDense
 import sk.ainet.lang.types.DType
 
@@ -35,6 +36,14 @@ import sk.ainet.lang.types.DType
  *   Qwen3: true. Llama / Mistral: false.
  * @param qkNormUnitOffset whether the QK-norm uses unit-offset weights
  *   (Gemma-style). Defaults to false.
+ * @param ropeMode pairing convention for RoPE rotation. [RoPEMode.INTERLEAVED]
+ *   (`(buf[2i], buf[2i+1])`, llama.cpp NORM mode 0) is the LLaMA / Mistral /
+ *   Gemma default. [RoPEMode.SPLIT_HALF] (`(buf[i], buf[i+ropeDim/2])`,
+ *   llama.cpp NEOX mode 2) is what Qwen 2/3, Phi, Falcon, StableLM,
+ *   Starcoder2 store in GGUF. Mirrors `RopeType.forArchitecture()` in
+ *   [sk.ainet.apps.llm.RopeUtils] — picking the wrong mode produces
+ *   subtly-wrong logits per token (correct-by-accident at very small
+ *   contexts; compounds across positions).
  * @param maxInferenceLen sequence length used to size the KV cache and RoPE
  *   tables. Capped at min(metadata.contextLength, 4096) by default.
  */
@@ -44,6 +53,7 @@ public inline fun <reified T : DType, V> decoderTransformerNetwork(
     eps: Float = metadata.rmsNormEps,
     qkNorm: Boolean = false,
     qkNormUnitOffset: Boolean = false,
+    ropeMode: RoPEMode = RoPEMode.INTERLEAVED,
     maxInferenceLen: Int = minOf(metadata.contextLength, 4096),
 ): Module<T, V> {
     val dim = metadata.embeddingLength
@@ -72,7 +82,7 @@ public inline fun <reified T : DType, V> decoderTransformerNetwork(
                 qkNormUnitOffset = qkNormUnitOffset,
                 id = "attn",
             ) {
-                rope(headDim, seqLen, base = ropeBase)
+                rope(headDim, seqLen, mode = ropeMode, base = ropeBase)
                 kvCache(seqLen, nKVHeads, headDim)
             }
             stage.residual()

--- a/llm-inference/qwen/src/commonMain/kotlin/sk/ainet/models/qwen/QwenNetworkDef.kt
+++ b/llm-inference/qwen/src/commonMain/kotlin/sk/ainet/models/qwen/QwenNetworkDef.kt
@@ -2,6 +2,7 @@ package sk.ainet.models.qwen
 
 import sk.ainet.lang.nn.Module
 import sk.ainet.lang.nn.dsl.decoder.decoderTransformerNetwork
+import sk.ainet.lang.nn.transformer.RoPEMode
 import sk.ainet.lang.types.DType
 import sk.ainet.models.llama.LlamaModelMetadata
 
@@ -10,11 +11,19 @@ import sk.ainet.models.llama.LlamaModelMetadata
  *
  * Thin caller of the shared [decoderTransformerNetwork] builder with
  * Qwen3-specific knobs:
+ * - **RoPE NEOX pairing** ([RoPEMode.SPLIT_HALF]) — Qwen 2/3 GGUFs are
+ *   stored with `(buf[i], buf[i + ropeDim/2])` pairing per llama.cpp's
+ *   `LLAMA_ROPE_TYPE_NEOX` (mode 2). Picking the LLaMA default of
+ *   [RoPEMode.INTERLEAVED] gives correct-by-accident outputs at very
+ *   small contexts but compounds wrong rotations across positions —
+ *   logits diverged by 5+ on identical FP32 weights vs the legacy
+ *   `LlamaRuntime` (which auto-applies NEOX via
+ *   `RopeType.forArchitecture("qwen3")`). See #114.
  * - RoPE base from `metadata.ropeFreqBase` (typically 1_000_000 — read off
  *   the GGUF; falls back to the metadata default of 10_000 if absent).
  * - RMSNorm eps from `metadata.rmsNormEps` (typically 1e-6 for Qwen3).
  * - **QK-Norm enabled** (`attn_q_norm.weight` / `attn_k_norm.weight` per
- *   layer) — the key Qwen-vs-Llama difference at the network level.
+ *   layer) — Qwen3-specific.
  * - SwiGLU FFN — same as Llama.
  *
  * The metadata type stays `LlamaModelMetadata` because Qwen3 GGUFs use the
@@ -28,5 +37,6 @@ public inline fun <reified T : DType, V> qwenNetwork(
 ): Module<T, V> = decoderTransformerNetwork<T, V>(
     metadata = metadata,
     qkNorm = qkNorm,
+    ropeMode = RoPEMode.SPLIT_HALF,
     maxInferenceLen = maxInferenceLen,
 )


### PR DESCRIPTION
Refs #114 (one of multiple changes needed there).

## What's wrong
Qwen 2/3 GGUFs are stored with llama.cpp's `LLAMA_ROPE_TYPE_NEOX` (mode 2) — pairing `(buf[i], buf[i + ropeDim/2])`. The legacy `CpuAttentionBackend` correctly auto-applies this via `RopeType.forArchitecture(\"qwen3\") = HALF_SPLIT`. The DSL's `decoderTransformerNetwork` was using the LLaMA default `RoPEMode.INTERLEAVED` (mode 0 — pairs `(buf[2i], buf[2i+1])`), producing **wrong rotations for Qwen3 starting at position 1**.

Position 0 is identity for any rope mode (`sin(0) = 0`), so the bug compounds across token positions but doesn't affect the very first forward.

Same gotcha Gemma's network already documented and worked around — see `GemmaNetworkDef.kt:172-187`. The mode is documented at `RopeUtils.kt:14-22` with the architecture mapping at line 41.

## Changes
- `decoderTransformerNetwork` gains a `ropeMode: RoPEMode = INTERLEAVED` parameter (kept as the LLaMA / Mistral / Gemma default — only Qwen / Phi / Falcon family overrides).
- `qwenNetwork` now passes `ropeMode = RoPEMode.SPLIT_HALF`. KDoc explains with the llama.cpp NEOX reference and the consequence of getting it wrong.

## Scope
This is **one of multiple parity fixes** needed for the DSL Qwen path to produce numerically equivalent output to legacy `LlamaRuntime` (#114). After this PR the residual divergence is from non-RoPE sources (QK-norm eps default mismatch — DSL `RMSNormalization` default `eps=1e-5` vs legacy uses metadata `rmsNormEps=1e-6` for Qwen — and possibly MHA bias defaults / embedding scale). #114 stays open to track those.

The synthetic logit-parity test from the abandoned 1B.4 attempt is **not included** here. Position 0 still diverges (RoPE-irrelevant), so the test can't pass on this PR alone. Phase-4 readiness is better validated via real-GGUF smoke output coherence than synthetic logit parity.

## Test plan
- [x] No regressions: `:llm-core`, `:llm-inference:{llama,qwen,voxtral}`, `:llm-runtime:kllama` test suites pass.
- [x] `decoderTransformerNetwork`'s new param has `INTERLEAVED` default — existing `LlamaNetworkDef` / `VoxtralNetworkDef` callers unaffected.
- [ ] CI green on PR.
- [ ] **Manual smoke** (post-merge): `kllama-cli` with a real Qwen3 GGUF. Compare DSL output coherence against HF / llama.cpp reference for the same prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)