### PR TITLE
fix(tokenizer): consume upstream tokenizers, retire forked impl (#52)

### DIFF
--- a/llm-apps/skainet-cli/src/main/kotlin/sk/ainet/apps/skainet/cli/Main.kt
+++ b/llm-apps/skainet-cli/src/main/kotlin/sk/ainet/apps/skainet/cli/Main.kt
@@ -240,11 +240,12 @@ fun main(args: Array<String>) {
             )
         }
 
-        // Load tokenizer from GGUF
+        // Load tokenizer from already-parsed GGUF metadata. Routes to the
+        // upstream sk.ainet.io.tokenizer impl (correct byte-level BPE for
+        // Qwen/GPT-2 — see issue #52). The legacy fromGGUF(source) path
+        // uses the local forked impl with broken byte-BPE.
         println("Loading embedded GGUF tokenizer...")
-        val tokenizer: Tokenizer = JvmRandomAccessSource.open(modelPath.toString()).use { source ->
-            TokenizerFactory.fromGGUF(source)
-        }
+        val tokenizer: Tokenizer = TokenizerFactory.fromGgufFields(modelInfo.fields)
 
         // Build model metadata for chat template auto-detection
         val metadata = ModelMetadata(

--- a/llm-core/build.gradle.kts
+++ b/llm-core/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
             implementation(libs.skainet.io.core)
             implementation(libs.skainet.io.gguf)
             implementation(libs.kotlinx.io.core)
+            implementation(libs.kotlinx.serialization.json)
         }
 
         commonTest.dependencies {

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/SentencePieceSpecialTokens.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/SentencePieceSpecialTokens.kt
@@ -1,0 +1,278 @@
+package sk.ainet.apps.llm.tokenizer
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import sk.ainet.apps.llm.Tokenizer
+import sk.ainet.io.tokenizer.SentencePieceTokenizer
+
+/**
+ * Downstream model-specific decorator that adds atomic special-token
+ * splitting on top of upstream [SentencePieceTokenizer].
+ *
+ * Why this lives here, not upstream
+ * ---------------------------------
+ * Upstream `sk.ainet.io.tokenizer.SentencePieceTokenizer.encode()` does pure
+ * SentencePiece — it never treats any vocab entry as atomic / non-splittable.
+ * That works for vanilla LLaMA but breaks chat-template models like Gemma 4
+ * whose `<bos>`, `<|turn>`, `<turn|>` and similar markers must encode as a
+ * single id rather than fragmenting into per-character byte-fallback pieces.
+ *
+ * Until upstream extracts a shared `SpecialTokenSplitter` decorator
+ * (proposed follow-up — see issue tracker), this class fills the gap as a
+ * downstream model-specific tokenizer handler. It also patches two other
+ * upstream gaps for the HuggingFace `tokenizer.json` path:
+ *
+ *  - Resolves `bosTokenId` / `eosTokenId` from the `added_tokens` array
+ *    (upstream's HF factory reads neither).
+ *  - Allows overriding `addSpacePrefix` (upstream's HF factory hard-codes
+ *    `true`, but Gemma 4 needs `false` to match HuggingFace reference IDs).
+ *
+ * Algorithm
+ * ---------
+ *  - **encode(text)**: walk left-to-right; at each position try the
+ *    longest registered special-token string. On a match, emit its id and
+ *    skip past it. Otherwise extend the current non-special segment until
+ *    the next special boundary (or end-of-text), then `base.encode(segment)`.
+ *  - **decode(ids)**: scan ids; collect contiguous non-special ids into
+ *    a buffer, flushing via `base.decode(buffer)` when we hit a special
+ *    id, then emit the special's string form. The byte-level UTF-8
+ *    spanning that SentencePiece does inside `decode(IntArray)` is
+ *    preserved within each non-special run, because special-token
+ *    boundaries always sit on UTF-8 boundaries (specials are literal
+ *    strings).
+ */
+public class SentencePieceSpecialTokens(
+    private val base: SentencePieceTokenizer,
+    private val specialTokens: Map<String, Int>,
+    bosTokenId: Int? = null,
+    eosTokenId: Int? = null,
+) : Tokenizer {
+
+    private val specialIdToString: Map<Int, String> =
+        specialTokens.entries.associate { (k, v) -> v to k }
+
+    /** Longest-first ordering so e.g. `<|im_start|>` wins over `<|im`. */
+    private val specialsByLengthDesc: List<String> =
+        specialTokens.keys.sortedByDescending { it.length }
+
+    override val vocabSize: Int = base.vocabSize
+    override val bosTokenId: Int = (bosTokenId ?: base.bosTokenId) ?: -1
+    override val eosTokenId: Int = (eosTokenId ?: base.eosTokenId) ?: -1
+
+    override fun encode(text: String): IntArray {
+        val out = ArrayList<Int>(text.length)
+        var i = 0
+        while (i < text.length) {
+            val matched = matchSpecialAt(text, i)
+            if (matched != null) {
+                out.add(specialTokens.getValue(matched))
+                i += matched.length
+                continue
+            }
+            val nextSpecial = nextSpecialStart(text, i)
+            val segment = text.substring(i, nextSpecial)
+            for (id in base.encode(segment)) out.add(id)
+            i = nextSpecial
+        }
+        return IntArray(out.size) { out[it] }
+    }
+
+    override fun decode(tokens: IntArray): String {
+        if (tokens.isEmpty()) return ""
+        val sb = StringBuilder()
+        val buffer = ArrayList<Int>()
+        for (id in tokens) {
+            val special = specialIdToString[id]
+            if (special != null) {
+                if (buffer.isNotEmpty()) {
+                    sb.append(base.decode(buffer.toIntArray()))
+                    buffer.clear()
+                }
+                sb.append(special)
+            } else {
+                buffer.add(id)
+            }
+        }
+        if (buffer.isNotEmpty()) {
+            sb.append(base.decode(buffer.toIntArray()))
+        }
+        return sb.toString()
+    }
+
+    override fun decode(token: Int): String {
+        val special = specialIdToString[token]
+        if (special != null) return special
+        return base.decode(intArrayOf(token))
+    }
+
+    private fun matchSpecialAt(text: String, from: Int): String? {
+        for (tok in specialsByLengthDesc) {
+            if (tok.isNotEmpty() && text.regionMatches(from, tok, 0, tok.length)) return tok
+        }
+        return null
+    }
+
+    private fun nextSpecialStart(text: String, from: Int): Int {
+        var earliest = text.length
+        for (tok in specialTokens.keys) {
+            if (tok.isEmpty()) continue
+            val idx = text.indexOf(tok, startIndex = from + 1)
+            if (idx in 0 until earliest) earliest = idx
+        }
+        return earliest
+    }
+
+    public companion object {
+        private const val TOKEN_TYPE_CONTROL = 3
+        private const val TOKEN_TYPE_USER_DEFINED = 4
+
+        private val JSON: Json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+        /**
+         * Wrap an upstream SentencePiece tokenizer constructed from GGUF
+         * metadata, layering atomic special-token splitting on top.
+         *
+         * Special tokens are identified by `tokenizer.ggml.token_type`
+         * entries with code `TOKEN_TYPE_CONTROL` (3) or
+         * `TOKEN_TYPE_USER_DEFINED` (4). Both are treated as atomic — the
+         * local fork's behavior, preserved here so chat-template markers
+         * like `<bos>` (CONTROL) and `<|tool_call>` (often USER_DEFINED)
+         * encode as a single id.
+         */
+        public fun fromGgufFields(fields: Map<String, Any?>): Tokenizer {
+            val base = SentencePieceTokenizer.fromGgufFields(fields)
+
+            @Suppress("UNCHECKED_CAST")
+            val tokens = (fields["tokenizer.ggml.tokens"] as? List<*>)
+                ?.filterIsInstance<String>().orEmpty()
+            val tokenTypes = (fields["tokenizer.ggml.token_type"] as? List<*>)
+                ?.mapNotNull { (it as? Number)?.toInt() }.orEmpty()
+
+            val specials = HashMap<String, Int>()
+            val limit = minOf(tokens.size, tokenTypes.size)
+            for (i in 0 until limit) {
+                val type = tokenTypes[i]
+                if (type == TOKEN_TYPE_CONTROL || type == TOKEN_TYPE_USER_DEFINED) {
+                    val tok = tokens[i]
+                    if (tok.isNotEmpty()) specials[tok] = i
+                }
+            }
+
+            // If GGUF didn't carry token_type at all (some older files), the
+            // SentencePiece encoder still works — just no atomic splitting.
+            return SentencePieceSpecialTokens(base, specials)
+        }
+
+        /**
+         * Wrap an upstream SentencePiece tokenizer constructed from a
+         * HuggingFace `tokenizer.json` string, layering atomic special-
+         * token splitting and patching upstream's HF-path gaps.
+         *
+         * Reads:
+         *  - `added_tokens[]` for the special-token registry, BOS, and EOS.
+         *    Entries with `"special": true` (or missing the field) are
+         *    treated as special.
+         *  - Optional `tokenizer_config.json` (passed as [configJson]) for
+         *    `add_space_prefix` — Gemma 4 sets this to `false`, which
+         *    upstream's HF factory does not honor.
+         */
+        public fun fromTokenizerJson(json: String, configJson: String? = null): Tokenizer {
+            val root = JSON.parseToJsonElement(json).jsonObject
+            val configRoot = configJson?.let { JSON.parseToJsonElement(it).jsonObject }
+
+            val addSpacePrefix = configRoot?.get("add_space_prefix")?.jsonPrimitive?.boolean
+                ?: detectAddSpacePrefixFromNormalizer(root)
+                ?: true
+
+            val base = buildBaseFromTokenizerJson(root, addSpacePrefix)
+
+            val (specials, bosId, eosId) = extractSpecialsFromAddedTokens(root)
+            return SentencePieceSpecialTokens(
+                base = base,
+                specialTokens = specials,
+                bosTokenId = bosId,
+                eosTokenId = eosId,
+            )
+        }
+
+        /**
+         * Build an upstream SentencePieceTokenizer with a custom
+         * [addSpacePrefix]. Upstream's `SentencePieceTokenizer.fromTokenizerJson`
+         * hard-codes `addSpacePrefix=true`; Gemma 4 needs `false`. This
+         * mirrors the upstream parsing of `model.vocab` (an array of
+         * `[token, score]` pairs) and `model.unk_id`, then rebuilds the
+         * tokenizer with the desired flag.
+         */
+        private fun buildBaseFromTokenizerJson(root: JsonObject, addSpacePrefix: Boolean): SentencePieceTokenizer {
+            val model = root["model"]?.jsonObject ?: error("tokenizer.json missing 'model'")
+            val vocabArr = model["vocab"]?.jsonArray ?: error("tokenizer.json missing 'model.vocab'")
+            val tokens = ArrayList<String>(vocabArr.size)
+            val scores = ArrayList<Float>(vocabArr.size)
+            for (entry in vocabArr) {
+                val pair = entry.jsonArray
+                tokens.add(pair[0].jsonPrimitive.content)
+                val raw = pair[1].jsonPrimitive
+                scores.add(raw.content.toFloatOrNull() ?: 0f)
+            }
+            val unknownId = model["unk_id"]?.jsonPrimitive?.int
+            return SentencePieceTokenizer(
+                tokens = tokens,
+                scores = scores,
+                unknownTokenId = unknownId,
+                addSpacePrefix = addSpacePrefix,
+            )
+        }
+
+        /**
+         * Walk `tokenizer.json#normalizer` looking for a `Prepend` step
+         * with content `▁` — that's HF's encoding of `add_dummy_prefix=true`.
+         * Returns null if the normalizer doesn't say either way.
+         */
+        private fun detectAddSpacePrefixFromNormalizer(root: JsonObject): Boolean? {
+            val normalizer = root["normalizer"] as? JsonObject ?: return null
+            // Sequence of normalizers
+            val seq = normalizer["normalizers"]?.jsonArray
+            val candidates = seq ?: listOf(normalizer)
+            for (n in candidates) {
+                val obj = n as? JsonObject ?: continue
+                val type = obj["type"]?.jsonPrimitive?.content ?: continue
+                if (type == "Prepend") {
+                    val prepend = obj["prepend"]?.jsonPrimitive?.content
+                    if (prepend == "▁") return true
+                }
+            }
+            return false
+        }
+
+        private data class AddedTokens(
+            val specials: Map<String, Int>,
+            val bosId: Int?,
+            val eosId: Int?,
+        )
+
+        private fun extractSpecialsFromAddedTokens(root: JsonObject): AddedTokens {
+            val added = root["added_tokens"]?.jsonArray
+            if (added == null) return AddedTokens(emptyMap(), null, null)
+            val specials = HashMap<String, Int>(added.size)
+            var bosId: Int? = null
+            var eosId: Int? = null
+            for (entry in added) {
+                val obj = entry.jsonObject
+                val content = obj["content"]?.jsonPrimitive?.content ?: continue
+                val id = obj["id"]?.jsonPrimitive?.int ?: continue
+                val isSpecial = obj["special"]?.jsonPrimitive?.boolean ?: true
+                if (isSpecial) specials[content] = id
+                when (content) {
+                    "<bos>", "<|begin_of_text|>", "<s>" -> bosId = bosId ?: id
+                    "<eos>", "<|end_of_text|>", "</s>" -> eosId = eosId ?: id
+                }
+            }
+            return AddedTokens(specials, bosId, eosId)
+        }
+    }
+}

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerFactory.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerFactory.kt
@@ -7,17 +7,40 @@ import sk.ainet.io.gguf.StreamingGGUFReader
 /**
  * Unified factory for creating tokenizers from various sources.
  *
- * Per-architecture dispatch: a Qwen / GPT-2 / Mistral-Nemo model needs
- * byte-level BPE (correctly implemented in upstream
- * [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer]); a Llama / Gemma /
- * TinyLlama model uses SentencePiece via the local [GGUFTokenizer].
+ * Per-architecture dispatch routes Qwen / GPT-2 / Mistral-Nemo (byte-level
+ * BPE) to upstream [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer] —
+ * the local [GGUFTokenizer]'s `encodeBPE` is the greedy-by-score
+ * SentencePiece algorithm, wrong for byte-level BPE which needs
+ * `bytes_to_unicode` mapping + GPT-2 pretokenization regex +
+ * merge-rank-based merging. See #52.
  *
- * The split is because the local [GGUFTokenizer]'s `encodeBPE` is the
- * greedy-by-score SentencePiece algorithm — wrong for byte-level BPE,
- * which needs `bytes_to_unicode` mapping + GPT-2 pretokenization regex
- * + merge-rank-based merging. See #52.
+ * Three entry points:
+ *
+ * - [fromGgufFields] — preferred when GGUF metadata has already been
+ *   parsed (e.g. via `UnifiedModelLoader.peek`); always routes through
+ *   the upstream `sk.ainet.io.tokenizer.TokenizerFactory`.
+ * - [fromGGUF] — convenience for a raw GGUF [RandomAccessSource]. Reads
+ *   metadata once and dispatches gpt2/bpe → upstream byte-BPE; else →
+ *   local SentencePiece path.
+ * - [fromTokenizerJson] / [fromHuggingFace] — HuggingFace `tokenizer.json`.
  */
 public object TokenizerFactory {
+
+    /**
+     * Create a tokenizer from a pre-parsed GGUF metadata field map.
+     *
+     * Delegates to upstream `sk.ainet.io.tokenizer.TokenizerFactory.fromGguf`,
+     * which has the correct byte-level BPE for Qwen/GPT-2 (issue #52). The
+     * result is wrapped in an adapter so callers continue to see the local
+     * [Tokenizer] interface (with `decode(Int)` and non-null bos/eos).
+     *
+     * @param fields The GGUF metadata map, e.g. `GGUFModelInfo.fields` from
+     *   `UnifiedModelLoader.peek`.
+     */
+    public fun fromGgufFields(fields: Map<String, Any?>): Tokenizer {
+        val upstream = sk.ainet.io.tokenizer.TokenizerFactory.fromGguf(fields)
+        return UpstreamTokenizerAdapter(upstream)
+    }
 
     /**
      * Create a tokenizer from GGUF file metadata (streaming, memory-efficient).
@@ -26,6 +49,9 @@ public object TokenizerFactory {
      * - `gpt2` / `bpe` → upstream [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer]
      *   (correct byte-level BPE, matches HuggingFace transformers / llama.cpp)
      * - everything else → local [GGUFTokenizer] (SentencePiece path)
+     *
+     * Prefer [fromGgufFields] when metadata is already in hand — avoids
+     * re-reading the source.
      *
      * @param source Random access source to the GGUF file.
      * @param debug Print debug information during loading.
@@ -69,3 +95,4 @@ public object TokenizerFactory {
         return createHuggingFaceBPETokenizerFromJson(tokenizerJson, tokenizerConfigJson)
     }
 }
+

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerFactory.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerFactory.kt
@@ -5,94 +5,94 @@ import sk.ainet.io.RandomAccessSource
 import sk.ainet.io.gguf.StreamingGGUFReader
 
 /**
- * Unified factory for creating tokenizers from various sources.
+ * Unified factory for creating tokenizers from various sources. Delegates
+ * the byte-level BPE (Qwen/GPT-2) and SentencePiece (LLaMA/Gemma) algorithms
+ * to upstream `sk.ainet.io.tokenizer.*` and layers the
+ * [SentencePieceSpecialTokens] decorator on top of SP-family results so
+ * chat-template markers (`<bos>`, `<|turn>`, etc.) encode atomically.
  *
- * Per-architecture dispatch routes Qwen / GPT-2 / Mistral-Nemo (byte-level
- * BPE) to upstream [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer] —
- * the local [GGUFTokenizer]'s `encodeBPE` is the greedy-by-score
- * SentencePiece algorithm, wrong for byte-level BPE which needs
- * `bytes_to_unicode` mapping + GPT-2 pretokenization regex +
- * merge-rank-based merging. See #52.
+ * Usage:
+ * ```kotlin
+ * // From an already-parsed GGUF metadata map (cheapest — no extra file open):
+ * val info = UnifiedModelLoader.peek { sourceProvider() }
+ * val tokenizer = TokenizerFactory.fromGgufFields(info.fields)
  *
- * Three entry points:
+ * // From a GGUF RandomAccessSource (parses metadata via StreamingGGUFReader):
+ * val tokenizer = TokenizerFactory.fromGgufSource(source)
  *
- * - [fromGgufFields] — preferred when GGUF metadata has already been
- *   parsed (e.g. via `UnifiedModelLoader.peek`); always routes through
- *   the upstream `sk.ainet.io.tokenizer.TokenizerFactory`.
- * - [fromGGUF] — convenience for a raw GGUF [RandomAccessSource]. Reads
- *   metadata once and dispatches gpt2/bpe → upstream byte-BPE; else →
- *   local SentencePiece path.
- * - [fromTokenizerJson] / [fromHuggingFace] — HuggingFace `tokenizer.json`.
+ * // From a HuggingFace tokenizer.json string (+ optional tokenizer_config.json):
+ * val tokenizer = TokenizerFactory.fromTokenizerJsonString(json, configJson)
+ * ```
  */
 public object TokenizerFactory {
 
     /**
      * Create a tokenizer from a pre-parsed GGUF metadata field map.
      *
-     * Delegates to upstream `sk.ainet.io.tokenizer.TokenizerFactory.fromGguf`,
-     * which has the correct byte-level BPE for Qwen/GPT-2 (issue #52). The
-     * result is wrapped in an adapter so callers continue to see the local
-     * [Tokenizer] interface (with `decode(Int)` and non-null bos/eos).
+     * Routes byte-level BPE through upstream directly; routes SentencePiece
+     * through [SentencePieceSpecialTokens] so chat-template control / user-
+     * defined tokens encode atomically (Gemma 4, etc.).
      *
      * @param fields The GGUF metadata map, e.g. `GGUFModelInfo.fields` from
      *   `UnifiedModelLoader.peek`.
      */
     public fun fromGgufFields(fields: Map<String, Any?>): Tokenizer {
-        val upstream = sk.ainet.io.tokenizer.TokenizerFactory.fromGguf(fields)
-        return UpstreamTokenizerAdapter(upstream)
-    }
-
-    /**
-     * Create a tokenizer from GGUF file metadata (streaming, memory-efficient).
-     *
-     * Dispatches on `tokenizer.ggml.model`:
-     * - `gpt2` / `bpe` → upstream [sk.ainet.io.tokenizer.QwenByteLevelBpeTokenizer]
-     *   (correct byte-level BPE, matches HuggingFace transformers / llama.cpp)
-     * - everything else → local [GGUFTokenizer] (SentencePiece path)
-     *
-     * Prefer [fromGgufFields] when metadata is already in hand — avoids
-     * re-reading the source.
-     *
-     * @param source Random access source to the GGUF file.
-     * @param debug Print debug information during loading.
-     */
-    public fun fromGGUF(source: RandomAccessSource, debug: Boolean = false): Tokenizer {
-        return StreamingGGUFReader.open(source).use { reader ->
-            val fields = reader.fields
-            val model = (fields["tokenizer.ggml.model"] as? String)?.lowercase()
-            when (model) {
-                "gpt2", "bpe" -> {
-                    if (debug) println("TokenizerFactory: model=$model → upstream QwenByteLevelBpeTokenizer")
-                    val upstream = sk.ainet.io.tokenizer.TokenizerFactory.fromGguf(fields)
-                    UpstreamTokenizerAdapter(upstream)
-                }
-                else -> {
-                    if (debug) println("TokenizerFactory: model=$model → local GGUFTokenizer")
-                    GGUFTokenizer.fromStreamingFields(fields, debug)
-                }
+        val model = (fields["tokenizer.ggml.model"] as? String)?.lowercase()
+        return when (model) {
+            "llama", "sentencepiece" -> SentencePieceSpecialTokens.fromGgufFields(fields)
+            else -> {
+                val upstream = sk.ainet.io.tokenizer.TokenizerFactory.fromGguf(fields)
+                UpstreamTokenizerAdapter(upstream)
             }
         }
     }
 
     /**
-     * Create a tokenizer from a HuggingFace `tokenizer.json` string.
-     * Parses vocab and BPE merges from the JSON.
-     *
-     * @param json The tokenizer.json content.
-     * @param debug Print debug information during loading.
+     * Convenience: open a [StreamingGGUFReader] over [source], parse metadata,
+     * and build a tokenizer via [fromGgufFields]. The reader is closed before
+     * returning. Use this when you only have the source handle and don't need
+     * the rest of the GGUF metadata.
      */
-    public fun fromTokenizerJson(json: String, debug: Boolean = false): GGUFTokenizer {
-        return GGUFTokenizer.fromTokenizerJson(json, debug)
+    public fun fromGgufSource(source: RandomAccessSource): Tokenizer {
+        return StreamingGGUFReader.open(source).use { reader ->
+            fromGgufFields(reader.fields)
+        }
     }
 
     /**
-     * Create a HuggingFace BPE tokenizer from `tokenizer.json` + optional config.
+     * Create a tokenizer from a HuggingFace `tokenizer.json` string (+ optional
+     * `tokenizer_config.json`).
      *
-     * @param tokenizerJson Content of `tokenizer.json`.
-     * @param tokenizerConfigJson Optional content of `tokenizer_config.json`.
+     * Routes BPE through upstream directly; routes Unigram / SentencePiece
+     * through [SentencePieceSpecialTokens] so the `added_tokens` registry
+     * (including bos/eos resolution) and `add_space_prefix` detection are
+     * applied — both are upstream gaps that affect Gemma 4 SafeTensors.
      */
-    public fun fromHuggingFace(tokenizerJson: String, tokenizerConfigJson: String? = null): Tokenizer {
-        return createHuggingFaceBPETokenizerFromJson(tokenizerJson, tokenizerConfigJson)
+    public fun fromTokenizerJsonString(json: String, configJson: String? = null): Tokenizer {
+        // Detect model.type with a minimal substring scan so we don't have to
+        // round-trip through kotlinx.serialization twice (once here, once in
+        // the dispatched factory).
+        val modelType = detectModelType(json)
+        return when (modelType) {
+            "Unigram" -> SentencePieceSpecialTokens.fromTokenizerJson(json, configJson)
+            else -> {
+                val upstream = sk.ainet.io.tokenizer.TokenizerFactory.fromTokenizerJson(json)
+                UpstreamTokenizerAdapter(upstream)
+            }
+        }
+    }
+
+    private fun detectModelType(json: String): String? {
+        val modelIdx = json.indexOf("\"model\"")
+        if (modelIdx < 0) return null
+        val typeIdx = json.indexOf("\"type\"", modelIdx)
+        if (typeIdx < 0) return null
+        val colonIdx = json.indexOf(':', typeIdx)
+        if (colonIdx < 0) return null
+        val openQuote = json.indexOf('"', colonIdx)
+        if (openQuote < 0) return null
+        val closeQuote = json.indexOf('"', openQuote + 1)
+        if (closeQuote < 0) return null
+        return json.substring(openQuote + 1, closeQuote)
     }
 }
-

--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapter.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapter.kt
@@ -7,23 +7,27 @@ import sk.ainet.apps.llm.Tokenizer
  * `skainet-io-core`) into this repo's [Tokenizer] interface.
  *
  * Upstream's `bosTokenId` / `eosTokenId` are nullable; the local interface
- * is non-null with int defaults. Upstream has no single-token decode; the
- * adapter implements it via `decode(intArrayOf(token))`.
+ * is non-null. Upstream has no single-token decode; the adapter implements
+ * it via `decode(intArrayOf(token))`.
  *
- * Used by [TokenizerFactory.fromGGUF] to route Qwen / GPT-2 / Mistral-Nemo
- * GGUFs (`tokenizer.ggml.model == "gpt2"` / `"bpe"`) to the correct
- * byte-level BPE implementation, instead of the broken local
- * [GGUFTokenizer]'s greedy-by-score `encodeBPE`. Closes #52.
+ * Used by [TokenizerFactory] to route Qwen / GPT-2 / Mistral-Nemo GGUFs
+ * (and tokenizer.json files) to the correct upstream byte-level BPE,
+ * instead of the broken local greedy-by-score `encodeBPE`. Closes #52.
+ *
+ * Models without BOS / EOS report `-1` so the absence is detectable —
+ * none of the GGUF chat models in this repo currently lack them, and
+ * silent fallback to a "reasonable" id would mask real bugs.
+ *
+ * Becomes redundant once the local `Tokenizer` interface is replaced by
+ * a typealias to upstream — at which point this whole class is deleted.
  */
 internal class UpstreamTokenizerAdapter(
     private val delegate: sk.ainet.io.tokenizer.Tokenizer,
-    bosTokenIdFallback: Int = 1,
-    eosTokenIdFallback: Int = 2,
 ) : Tokenizer {
 
     override val vocabSize: Int get() = delegate.vocabSize
-    override val bosTokenId: Int = delegate.bosTokenId ?: bosTokenIdFallback
-    override val eosTokenId: Int = delegate.eosTokenId ?: eosTokenIdFallback
+    override val bosTokenId: Int = delegate.bosTokenId ?: -1
+    override val eosTokenId: Int = delegate.eosTokenId ?: -1
 
     override fun encode(text: String): IntArray = delegate.encode(text)
 

--- a/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapterTest.kt
+++ b/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/UpstreamTokenizerAdapterTest.kt
@@ -58,7 +58,7 @@ class UpstreamTokenizerAdapterTest {
     }
 
     @Test
-    fun `null bos and eos fall back to defaults`() {
+    fun `null bos and eos report -1 to surface absence`() {
         val stub = StubUpstreamTokenizer(
             vocabSize = 10,
             bosTokenId = null,
@@ -66,23 +66,8 @@ class UpstreamTokenizerAdapterTest {
             encodeFn = { intArrayOf() },
             decodeFn = { "" },
         )
-        // Defaults: bos = 1, eos = 2.
         val adapter = UpstreamTokenizerAdapter(stub)
-        assertEquals(1, adapter.bosTokenId)
-        assertEquals(2, adapter.eosTokenId)
-    }
-
-    @Test
-    fun `null bos and eos honour custom fallbacks`() {
-        val stub = StubUpstreamTokenizer(
-            vocabSize = 10,
-            bosTokenId = null,
-            eosTokenId = null,
-            encodeFn = { intArrayOf() },
-            decodeFn = { "" },
-        )
-        val adapter = UpstreamTokenizerAdapter(stub, bosTokenIdFallback = 7, eosTokenIdFallback = 13)
-        assertEquals(7, adapter.bosTokenId)
-        assertEquals(13, adapter.eosTokenId)
+        assertEquals(-1, adapter.bosTokenId)
+        assertEquals(-1, adapter.eosTokenId)
     }
 }

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
@@ -511,7 +511,7 @@ fun main(args: Array<String>) {
             format == ModelFormat.GGUF && tokenizerPath == null -> {
                 println("Loading embedded GGUF tokenizer...")
                 JvmRandomAccessSource.open(modelPath.toString()).use { source ->
-                    TokenizerFactory.fromGGUF(source)
+                    TokenizerFactory.fromGgufSource(source)
                 }
             }
             else -> {

--- a/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/java/KLlamaJava.kt
+++ b/llm-runtime/kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/java/KLlamaJava.kt
@@ -89,7 +89,7 @@ public object KLlamaJava {
 
         // Embedded GGUF tokenizer (auto-dispatches Qwen / GPT-2 BPE → upstream)
         val tokenizer = JvmRandomAccessSource.open(modelPath.toString()).use { source ->
-            TokenizerFactory.fromGGUF(source)
+            TokenizerFactory.fromGgufSource(source)
         }
 
         return KLlamaSession(


### PR DESCRIPTION
Closes #52.

## Summary

The local \`llm-core\` fork of byte-level BPE in \`GGUFTokenizer.encodeBPE()\` is broken (no byte→unicode map, score-ranked merges instead of merge-rank, no special-token atomic splitting). For Qwen3 this surfaces as \`Ċ\` artifacts in place of \`\\n\` and stray \`!\`-wrapped JSON in tool-call emissions, breaking the agent loop. Upstream PR SKaiNET#465 fixed this in \`skainet-io-core\` (consumed here as \`sk.ainet.core:skainet-io-core:0.23.1\`, already on the classpath).

This PR retires the fork and consumes upstream — the architectural shape the user asked for: tokenizer infrastructure lives upstream as foundational IO, downstream holds only model-specific handlers (chat templates, tool-call parsers, the SentencePiece special-token decorator).

## Changes

1. **\`TokenizerFactory.fromGgufFields(modelInfo.fields)\`** — new entry point that delegates to upstream \`sk.ainet.io.tokenizer.TokenizerFactory.fromGguf\` and wraps the result in an \`UpstreamTokenizerAdapter\` that bridges the local interface (\`decode(Int)\`, non-null bos/eos) to upstream's nullable design.
2. **\`SentencePieceSpecialTokens\` decorator** (model-specific handler) — wraps upstream \`SentencePieceTokenizer\` to add atomic special-token splitting for chat-template markers (\`<bos>\`, \`<|turn>\`, \`<turn|>\`). Required because upstream \`SentencePieceTokenizer.encode()\` does pure SP — the gap that motivated this decorator. Also patches upstream's HF-JSON path gaps: reads \`add_space_prefix\` from the normalizer block and resolves bos/eos from \`added_tokens\`. Becomes redundant once upstream PR SKaiNET#595 lands and we bump skainet — deletion is a follow-up downstream PR.
3. **\`fromGgufSource\` / \`fromTokenizerJsonString\`** — convenience factory methods for callers that have a \`RandomAccessSource\` or raw JSON string instead of an already-parsed metadata map.
4. **\`skainet-cli/Main.kt\`** — switched to \`fromGgufFields(modelInfo.fields)\`, reusing the field map already obtained from \`UnifiedModelLoader.peek\`.
5. **Legacy \`TokenizerFactory\` methods removed** (\`fromGGUF\`, \`fromTokenizerJson\`, \`fromHuggingFace\`) — no in-tree caller used them after the cascade migration.

## Verification

| Test | Before | After |
| --- | --- | --- |
| Qwen3-1.7B greedy generation | coherent text but with \`Ċ\` artifacts | clean output |
| Qwen3-1.7B tool demo | broken: \`<think>Ċ</think>ĊĊ<tool_call>!{...}!</tool_call>\`, agent loop terminates | full round-trip: model emits clean JSON → calculator returns 391.0 → model produces final answer "391" |
| \`:llm-core:jvmTest\` | green | green |
| Full \`compileKotlinJvm\` | green | green |

## Architectural notes

This PR establishes the consume-upstream pattern but does **not** complete the full cascade. Still ahead (separate follow-up commits/PRs):

- Migrate the remaining \`GGUFTokenizer.foo(...)\` callers (\`kllama-cli\` jvm/native/wasmJs, \`KLlamaJava\`, \`kgemma-cli\`, \`Gemma4ChatModel\`, \`JvmBenchmarkEngine\`, \`NativeBenchmarkEngine\`) off the legacy class methods and onto \`TokenizerFactory.fromGgufSource\` / \`fromTokenizerJsonString\`.
- Replace the local \`Tokenizer\` interface with a \`typealias\` to \`sk.ainet.io.tokenizer.Tokenizer\` (avoids re-creating the divergence trap; binary-compat preserved by the typealias). Adjust other live impls (\`TokenizerImpl\`, \`TekkenTokenizerAdapter\`, \`bert/HuggingFaceTokenizer\`, \`SkaiNetChatModel\` default) for nullable bos/eos.
- Delete the forked \`GGUFTokenizer.kt\` and strategy classes.
- Retarget \`Gemma4TokenizerParityTest\` to \`TokenizerFactory.fromTokenizerJsonString\`.

Splitting the cascade into a follow-up PR keeps this one's bisect surface minimal — the user-visible bug fix lands now, the impl deletion lands once it's been validated against the parity test fixture.

## Test plan

- [x] \`./gradlew :llm-apps:skainet-cli:run --args="-m Qwen3-1.7B-Q8_0.gguf -s 32 -k 0.0 'The capital of France is'"\` → coherent answer
- [x] Same with \`--demo --template=chatml "What is 17 * 23?"\` → clean tool call, full round-trip
- [x] \`./gradlew :llm-core:jvmTest\` green
- [x] \`./gradlew compileKotlinJvm\` green across all modules
- [ ] CI to verify Android, native, wasmJs targets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)