### PR TITLE
MultiHeadAttention: support encoder-decoder cross-attention

### DIFF
--- a/llm-core/build.gradle.kts
+++ b/llm-core/build.gradle.kts
@@ -64,6 +64,10 @@ kotlin {
                 implementation(libs.junit)
                 implementation(libs.skainet.io.gguf)
                 implementation(libs.skainet.io.core)
+                // CPU backend so jvmTest can actually run forward passes
+                // against a real ExecutionContext (otherwise tensor ops are
+                // VoidOps stubs). Mirrors the wiring in `llm-inference/*`.
+                implementation(libs.skainet.backend.cpu)
             }
         }
 

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
@@ -8,6 +8,7 @@ import sk.ainet.lang.nn.topology.ModuleParameters
 import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.operators.bind
 import sk.ainet.lang.types.DType
 import kotlin.math.sqrt
 import kotlin.reflect.KClass
@@ -21,6 +22,13 @@ import kotlin.reflect.KClass
  * - Optional RoPE (rotary position embeddings)
  * - Optional KV Cache (autoregressive decoding)
  * - Causal or bidirectional masking
+ * - Encoder-decoder cross-attention via the [forward] entry that takes a
+ *   second `encoderMemory` tensor. In cross-attention mode Q is projected
+ *   from the decoder hidden state, K and V from the encoder memory; RoPE
+ *   and the KV cache are bypassed; the causal mask is forced off. Cross-K/V
+ *   caching is a runtime concern — pass the raw memory tensor each step
+ *   (one extra matmul vs. cached projections; acceptable for the typical
+ *   ASR / NMT shapes).
  *
  * Weight parameters are exposed as ModuleParameters and loaded via WeightMapper.
  * This module does NOT use Linear submodules because LLM projections often omit bias.
@@ -168,7 +176,46 @@ public class MultiHeadAttention<T : DType, V>(
             if (kvCache != null) add(kvCache as Module<T, V>)
         }
 
-    override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> {
+    override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> =
+        attentionImpl(qInput = input, kvInput = input, isCrossAttention = false, ctx = ctx)
+
+    /**
+     * Forward entry that supports cross-attention. When [encoderMemory] is `null`
+     * this is equivalent to `forward(input, ctx)` (self-attention). When non-null,
+     * Q is projected from [input] and K, V are projected from [encoderMemory];
+     * RoPE and the KV cache are skipped and the causal mask is forced off.
+     *
+     * Cross-attention requires `kvCache == null` and `slidingWindow == null` —
+     * both are rejected with a clear error message.
+     */
+    public fun forward(
+        input: Tensor<T, V>,
+        encoderMemory: Tensor<T, V>?,
+        ctx: ExecutionContext,
+    ): Tensor<T, V> {
+        if (encoderMemory == null) {
+            return forward(input, ctx)
+        }
+        require(kvCache == null) {
+            "MultiHeadAttention: cross-attention (non-null encoderMemory) does not support kvCache. " +
+                "Cross-attention K/V should be cached at the runtime layer."
+        }
+        require(slidingWindow == null) {
+            "MultiHeadAttention: cross-attention is incompatible with slidingWindow."
+        }
+        val boundInput = input.bind(ctx)
+        val boundMemory = encoderMemory.bind(ctx)
+        return sk.ainet.lang.nn.hooks.withForwardHooks(ctx, this, boundInput) {
+            attentionImpl(qInput = boundInput, kvInput = boundMemory, isCrossAttention = true, ctx = ctx)
+        }
+    }
+
+    private fun attentionImpl(
+        qInput: Tensor<T, V>,
+        kvInput: Tensor<T, V>,
+        isCrossAttention: Boolean,
+        ctx: ExecutionContext,
+    ): Tensor<T, V> {
         val ops = ctx.ops
         val scale = attentionScale ?: (1.0f / sqrt(headDim.toFloat()))
 
@@ -188,11 +235,11 @@ public class MultiHeadAttention<T : DType, V>(
         val wO = params[oWIdx].value
 
         // Project Q, K, V: input @ W^T (+ bias if enabled).
-        // linearProject handles both the stock [out, in] layout and the
-        // [in, out] pre-transposed layout produced by MemSeg conversion.
-        var q = linearProject(ops, input, wQ)
-        var k = linearProject(ops, input, wK)
-        var v = linearProject(ops, input, wV)
+        // Q always comes from qInput; in self-attn kvInput === qInput,
+        // in cross-attn kvInput is the encoder memory (different seqLen).
+        var q = linearProject(ops, qInput, wQ)
+        var k = linearProject(ops, kvInput, wK)
+        var v = linearProject(ops, kvInput, wV)
         if (mhaDump) {
             mhaDumpStat("[blk.0.mha post-Q-proj      ]", q)
             mhaDumpStat("[blk.0.mha post-K-proj      ]", k)
@@ -224,10 +271,11 @@ public class MultiHeadAttention<T : DType, V>(
         // The correct transformation needs an explicit dim-0/dim-1 swap.
         // SKaiNET's `ops.transpose` only swaps the LAST two dims, so we
         // can't reuse it here; we materialise the permute via a copy.
-        val seqLen = if (input.rank >= 2) input.shape[input.rank - 2] else 1
-        q = swapSeqHeadDims(ops.reshape(q, Shape(seqLen, nHeads, headDim)), ctx)
-        k = swapSeqHeadDims(ops.reshape(k, Shape(seqLen, nKVHeads, headDim)), ctx)
-        var vReshaped = swapSeqHeadDims(ops.reshape(v, Shape(seqLen, nKVHeads, headDim)), ctx)
+        val qSeqLen = if (qInput.rank >= 2) qInput.shape[qInput.rank - 2] else 1
+        val kvSeqLen = if (kvInput.rank >= 2) kvInput.shape[kvInput.rank - 2] else 1
+        q = swapSeqHeadDims(ops.reshape(q, Shape(qSeqLen, nHeads, headDim)), ctx)
+        k = swapSeqHeadDims(ops.reshape(k, Shape(kvSeqLen, nKVHeads, headDim)), ctx)
+        var vReshaped = swapSeqHeadDims(ops.reshape(v, Shape(kvSeqLen, nKVHeads, headDim)), ctx)
 
         // Optional QK-Norm
         if (qNorm != null && kNorm != null) {
@@ -251,9 +299,12 @@ public class MultiHeadAttention<T : DType, V>(
             if (mhaDump) mhaDumpStat("[blk.0.mha post-V-norm      ]", vReshaped)
         }
 
-        // Optional RoPE
+        // Optional RoPE — skip in cross-attention. Cross-attn keys come from
+        // encoder memory that's already positioned (its RoPE was applied
+        // during encoder self-attention); rotating them again with the
+        // decoder's position would corrupt the alignment.
         val ropeModule = rope
-        if (ropeModule != null) {
+        if (ropeModule != null && !isCrossAttention) {
             val position = kvCache?.position ?: 0
             if (mhaDump) println("[blk.0.mha pos=$position]")
             q = ropeModule.forward(q, position, ctx)
@@ -264,8 +315,11 @@ public class MultiHeadAttention<T : DType, V>(
             }
         }
 
-        // Optional KV Cache update
-        val (fullK, fullV) = if (kvCache != null) {
+        // Optional KV Cache update — only self-attention. Cross-attention
+        // K/V cannot share a cache with self-attention (different shapes,
+        // different ownership). Caching is the runtime's responsibility
+        // for cross-attention and is rejected at the entry above.
+        val (fullK, fullV) = if (kvCache != null && !isCrossAttention) {
             kvCache!!.update(k, vReshaped, ctx)
         } else {
             k to vReshaped
@@ -287,9 +341,17 @@ public class MultiHeadAttention<T : DType, V>(
         // When sliding-window attention is active, we build a combined
         // causal+window mask ourselves and disable SDPA's built-in causal
         // path (which would otherwise re-mask the same positions).
+        // Sliding-window + cross-attention is rejected at the entry; in the
+        // cross-attn branch slidingWindow is guaranteed null, so this lambda
+        // is never invoked.
         val seqKV = kBatched.shape[2]
-        val slidingMask = slidingWindow?.let { buildSlidingCausalMask(seqLen, seqKV, it, ctx, qBatched.dtype) }
-        val useCausalPath = causal && slidingMask == null
+        val slidingMask = slidingWindow?.let {
+            require(!isCrossAttention) { "slidingWindow + cross-attention is not supported" }
+            buildSlidingCausalMask(qSeqLen, seqKV, it, ctx, qBatched.dtype)
+        }
+        // Cross-attention never applies a causal mask — there's no temporal
+        // ordering between decoder query positions and encoder memory frames.
+        val useCausalPath = !isCrossAttention && causal && slidingMask == null
 
         // Scaled dot-product attention
         val attnOut = ops.scaledDotProductAttention(
@@ -313,7 +375,9 @@ public class MultiHeadAttention<T : DType, V>(
         // matches the prior naked reshape for the autoregressive case.
         val squeezed = ops.squeeze(attnOut, 0)
         val swappedBack = swapSeqHeadDims(squeezed, ctx)
-        val merged = ops.reshape(swappedBack, Shape(seqLen, qDim))
+        // Output sequence length follows Q, not K/V — relevant for cross-attn
+        // where kvSeqLen and qSeqLen differ.
+        val merged = ops.reshape(swappedBack, Shape(qSeqLen, qDim))
 
         // Output projection: merged @ wO^T (+ bias if enabled)
         var output = linearProject(ops, merged, wO)

--- a/llm-core/src/jvmTest/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttentionForwardTest.kt
+++ b/llm-core/src/jvmTest/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttentionForwardTest.kt
@@ -1,0 +1,162 @@
+package sk.ainet.lang.nn.transformer
+
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.FP32
+
+/**
+ * Forward-pass tests for [MultiHeadAttention] focused on the encoder-decoder
+ * cross-attention path added alongside this test file
+ * (`forward(input, encoderMemory, ctx)`).
+ *
+ * Pins three contracts:
+ *  - self-attention output is bit-identical whether reached via the inherited
+ *    `forward(input, ctx)` (today's API) or the new 3-arg entry with
+ *    `encoderMemory = null` (the compatibility path);
+ *  - cross-attention accepts asymmetric Q vs K/V sequence lengths;
+ *  - cross-attention ignores `causal` (no temporal ordering between decoder
+ *    queries and encoder memory frames);
+ *  - cross-attention rejects a non-null kvCache (caching is a runtime
+ *    concern for cross-attn).
+ */
+class MultiHeadAttentionForwardTest {
+
+    private val ctx = DirectCpuExecutionContext()
+
+    // Small but non-degenerate shapes: 4-dim model with 2 heads → headDim=2.
+    private val dim = 4
+    private val nHeads = 2
+    private val headDim = dim / nHeads
+
+    private fun buildMha(
+        causal: Boolean = false,
+        kvCache: KVCache<FP32, Float>? = null,
+    ): MultiHeadAttention<FP32, Float> {
+        val mha = MultiHeadAttention<FP32, Float>(
+            dim = dim,
+            nHeads = nHeads,
+            nKVHeads = nHeads,
+            causal = causal,
+            bias = false,
+            qkNorm = false,
+            kvCache = kvCache,
+            name = "test_mha",
+        )
+        // Replace the void placeholder weights with deterministic real ones.
+        // Layout: [out, in]. Different per-projection so we can tell them apart.
+        mha.params[0].value = wMatrix(dim, dim, seed = 1)  // q_proj
+        mha.params[1].value = wMatrix(dim, dim, seed = 2)  // k_proj
+        mha.params[2].value = wMatrix(dim, dim, seed = 3)  // v_proj
+        mha.params[3].value = wMatrix(dim, dim, seed = 4)  // o_proj
+        return mha
+    }
+
+    /** Deterministic `[out, in]` weight matrix with values in a small range. */
+    private fun wMatrix(out: Int, inDim: Int, seed: Int): Tensor<FP32, Float> {
+        // Pseudo-random but reproducible. sin(seed + idx) keeps values in [-1, 1].
+        val values = FloatArray(out * inDim) { idx ->
+            (kotlin.math.sin((seed * 1000 + idx).toFloat()) * 0.3f)
+        }
+        return ctx.fromFloatArray(Shape(out, inDim), FP32::class, values)
+    }
+
+    private fun inputTensor(seqLen: Int, seed: Int): Tensor<FP32, Float> {
+        val values = FloatArray(seqLen * dim) { idx ->
+            (kotlin.math.cos((seed * 1000 + idx).toFloat()) * 0.5f)
+        }
+        return ctx.fromFloatArray(Shape(seqLen, dim), FP32::class, values)
+    }
+
+    @Test
+    fun selfAttentionUnchangedWhenEncoderMemoryIsNull() {
+        val mha = buildMha(causal = false)
+        val input = inputTensor(seqLen = 3, seed = 7)
+
+        // Path 1: inherited 2-arg forward (today's API).
+        val viaOldEntry = mha.forward(input, ctx).data.copyToFloatArray()
+
+        // Path 2: new 3-arg forward with encoderMemory = null (compat path).
+        val viaNewEntry = mha.forward(input, null, ctx).data.copyToFloatArray()
+
+        assertContentEquals(
+            viaOldEntry, viaNewEntry,
+            "passing encoderMemory = null must be bit-identical to the inherited self-attention path",
+        )
+    }
+
+    @Test
+    fun crossAttentionProducesOutputShapedLikeQuery() {
+        val mha = buildMha(causal = false)
+        val query = inputTensor(seqLen = 2, seed = 11)
+        val memory = inputTensor(seqLen = 5, seed = 23)
+
+        val out = mha.forward(query, memory, ctx)
+
+        // Output sequence length follows Q, not K/V — that's the cross-attn contract.
+        assertEquals(2, out.shape[0], "output seqLen must equal query seqLen")
+        assertEquals(dim, out.shape[1], "output dim must equal model dim")
+    }
+
+    @Test
+    fun crossAttentionDoesNotApplyCausalMask() {
+        // Build MHA with causal=true. In self-attention that masks the future;
+        // in cross-attention the new branch forces causal off.
+        val mhaCausal = buildMha(causal = true)
+        val mhaNonCausal = buildMha(causal = false)
+
+        // Use the SAME query and SAME memory for both. Cross-attn output must
+        // agree regardless of the `causal` flag — proves the mask is bypassed.
+        val query = inputTensor(seqLen = 3, seed = 41)
+        val memory = inputTensor(seqLen = 4, seed = 53)
+
+        val outCausal = mhaCausal.forward(query, memory, ctx).data.copyToFloatArray()
+        val outNonCausal = mhaNonCausal.forward(query, memory, ctx).data.copyToFloatArray()
+
+        // Same projection weights → same output (modulo float jitter) when the
+        // mask isn't applied. The two MHAs have identical seeded weights, so
+        // exact equality is the right assertion.
+        assertContentEquals(
+            outCausal, outNonCausal,
+            "cross-attn output must not depend on the `causal` constructor flag",
+        )
+    }
+
+    @Test
+    fun crossAttentionRejectsKvCache() {
+        val cache = AppendKVCache<FP32, Float>(maxSeqLen = 8, nKVHeads = nHeads, headDim = headDim)
+        val mha = buildMha(causal = true, kvCache = cache)
+        val query = inputTensor(seqLen = 1, seed = 61)
+        val memory = inputTensor(seqLen = 3, seed = 67)
+
+        val err = assertFailsWith<IllegalArgumentException> {
+            mha.forward(query, memory, ctx)
+        }
+        assertTrue(
+            err.message?.contains("kvCache", ignoreCase = true) == true,
+            "error message should mention kvCache; got: ${err.message}",
+        )
+    }
+
+    @Test
+    fun moduleTreeUnchanged() {
+        val mha = buildMha(causal = false)
+        // No RoPE, no QK-norm, no KV cache → modules list must be empty (the
+        // pre-refactor snapshot for this configuration). Adding a submodule
+        // here would surface accidental extra state.
+        assertEquals(emptyList(), mha.modules, "modules list must be empty for vanilla self-attn config")
+        // Params: q/k/v/o weights only, no biases.
+        val paramNames = mha.params.map { it.name }
+        assertContentEquals(
+            listOf("test_mha.q_proj.weight", "test_mha.k_proj.weight", "test_mha.v_proj.weight", "test_mha.o_proj.weight"),
+            paramNames,
+            "param names + order must match the pre-refactor snapshot",
+        )
+    }
+}


### PR DESCRIPTION
Resolves #138.

## What

Adds an optional second-tensor entry to MHA's forward:

```kotlin
public fun forward(
    input: Tensor<T, V>,
    encoderMemory: Tensor<T, V>?,
    ctx: ExecutionContext,
): Tensor<T, V>
```

When `encoderMemory` is null (or unset, via the inherited 2-arg `forward(input, ctx)`), behaviour is bit-identical to today's self-attention path — internal refactor moves the body into a private `attentionImpl(qInput, kvInput, isCrossAttention, ctx)` and the existing `onForward` delegates with `kvInput = input, isCrossAttention = false`.

When `encoderMemory` is non-null:
- Q is projected from `input`, K/V from `encoderMemory`
- RoPE is skipped on both Q and K (encoder memory is already positioned by the encoder's self-attention RoPE; re-rotating with the decoder's position would corrupt alignment)
- Causal mask is forced off (no temporal ordering between decoder queries and encoder memory frames)
- `kvCache` must be null — cross-attn K/V caching is a runtime concern, not MHA's; rejected at entry with a clear error
- `slidingWindow` must be null — windowing implies causal+self-attn

## Why

First consumer is the Moonshine ASR port. Without this, every encoder-decoder model (Whisper, BART, T5, …) has to reinvent cross-attention locally. Confirmed via a sweep of every existing consumer (Llama, Qwen, Gemma, Apertus, Voxtral) — all are decoder-only or projection-conditioned; no current consumer cross-attends.

## Tests

New `MultiHeadAttentionForwardTest` (5 tests on `DirectCpuExecutionContext`):

| test | pins |
|---|---|
| `selfAttentionUnchangedWhenEncoderMemoryIsNull` | output is bit-identical between the inherited 2-arg `forward` and the new 3-arg entry with `null` |
| `crossAttentionProducesOutputShapedLikeQuery` | asymmetric seqLen — output follows Q, not K/V |
| `crossAttentionDoesNotApplyCausalMask` | `causal=true` and `causal=false` give the same cross-attn output |
| `crossAttentionRejectsKvCache` | non-null `kvCache` → `IllegalArgumentException` |
| `moduleTreeUnchanged` | `params` / `modules` lists match the pre-refactor snapshot |

Plus `:llm-core:jvmTest`, `:llm-inference:llama:jvmTest`, `:llm-inference:apertus:jvmTest` all green.

`llm-core`'s `jvmTest` now pulls in `libs.skainet.backend.cpu` (the same wiring gemma/apertus already use) so forward-pass tests can run against a real `ExecutionContext`.

## Out of scope (deliberately deferred)

- Batch-dim handling for `B>1` inputs to MHA (latent bug; no consumer exercises it today — Llama's `batchForwardFull` bypasses MHA entirely).
- Configurable `o_proj` parameter name (consumers needing `dense` etc. use position-indexed weight assignment or a name-mapper today).
- Splitting MHA into composable pieces (`project-Q` / `project-KV` / `attend` / `output-proj`). Tempting but inflates blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)