### PR TITLE
Honour DTypePolicy in DecoderSafeTensorsLoader: BF16 KEEP_NATIVE path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ window without a tagged 0.24.x release on either side.
   (`HybridTransformerBlock.compile()` will read this in a follow-up). Setting
   a non-`Any` value compiles today and starts taking effect when the
   compile-step plumbing lands — no API change at consumers.
+- **SafeTensors BF16 KEEP_NATIVE** in `DecoderSafeTensorsLoader`. When the
+  consumer attaches a `DTypePolicy` that admits BF16 (`Require(BF16)`,
+  `Prefer(BF16)`, or `OneOf` containing BF16), the loader stops dequanting
+  BF16 tensors and instead wraps the packed 2-bytes-per-element buffer in
+  `Bf16DenseTensorData`. The matmul dispatch in `DefaultCpuOpsJvm` (SKaiNET
+  0.25.0) detects `Bf16TensorData` at runtime and routes to the SIMD BF16
+  kernel — so a BF16 SafeTensors checkpoint now stays near its on-disk
+  footprint in RAM instead of inflating ~2× to FP32. Threaded through
+  `LlamaNetworkLoader` / `QwenNetworkLoader` / `VoxtralNetworkLoader`
+  (each forwards `loader.dtypePolicy` into the
+  `DecoderSafeTensorsLoader<T>(ctx, T::class, metadata, tied, dtypePolicy)`
+  constructor). The default value remains `DTypePolicy.Any` — adaptive
+  FP32 dequant, no behavioural change for existing callers. Validation
+  errors still fire at the `LlamaNetworkLoader.withDtypePolicy(...)`
+  boundary: `LlamaNetworkLoaderDTypePolicyTest` pins each policy arm.
 - **Three reference smoke tests with `@Tag("smoke-reference")`.** The new
   smoke tier exists alongside the existing `@Tag("integration")` filter and
   pins the three architectures we always want to run end-to-end:
@@ -95,12 +110,12 @@ changes land in follow-up PRs.
 - **`HybridTransformerBlock.compile()` honoring the policy on
   `DagBuilder.op(..., dtypePolicy = …)` per the W6 SKaiNET PR.** Blocked
   on the side-map above.
-- **`DecoderSafeTensorsLoader` / `DecoderGgufWeightLoader` actually
-  observing the policy at per-tensor load.** Both currently dequant
-  BF16 → FP32 unconditionally. The next step is to route them through
-  SKaiNET's `SafeTensorsParametersLoader.withPolicy(...)` /
-  `StreamingGgufParametersLoader.withPolicy(...)` so `Require(BF16)`
-  actually keeps native — a contained refactor with a clear contract.
+- **`DecoderGgufWeightLoader` per-tensor policy enforcement.** The GGUF
+  loader still dequants BF16 → FP32 unconditionally — SKaiNET 0.25.0's
+  `StreamingGgufParametersLoader.validatePolicy()` itself rejects
+  `Require(BF16)` for GGUF today (no KEEP_NATIVE GGUF backing yet), so
+  this is parked until the engine grows that path. *(SafeTensors BF16
+  KEEP_NATIVE shipped in this release — see Added.)*
 - **BOM-only versionless aliases in `libs.versions.toml`.** Currently
   every `skainet-*` alias still uses `version.ref = "skainet"` because
   the single-source bump is the lower-risk path during the 0.25.0

--- a/llm-inference/llama/api/jvm/llama.api
+++ b/llm-inference/llama/api/jvm/llama.api
@@ -49,8 +49,8 @@ public final class sk/ainet/models/llama/DecoderGgufWeights {
 }
 
 public final class sk/ainet/models/llama/DecoderSafeTensorsLoader {
-	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/models/llama/LlamaModelMetadata;Z)V
-	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/models/llama/LlamaModelMetadata;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/models/llama/LlamaModelMetadata;ZLsk/ainet/lang/types/DTypePolicy;)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/models/llama/LlamaModelMetadata;ZLsk/ainet/lang/types/DTypePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun load (Lkotlin/jvm/functions/Function0;)Lsk/ainet/models/llama/LlamaRuntimeWeights;
 	public final fun loadToMap (Lkotlin/jvm/functions/Function0;)Lsk/ainet/models/llama/DecoderGgufWeights;
 }

--- a/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/DecoderSafeTensorsLoader.kt
+++ b/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/DecoderSafeTensorsLoader.kt
@@ -12,7 +12,11 @@ import sk.ainet.io.safetensors.StreamingSafeTensorsReader
 import sk.ainet.io.safetensors.StreamingSafeTensorInfo
 import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.Bf16DenseTensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.types.BF16
 import sk.ainet.lang.types.DType
+import sk.ainet.lang.types.DTypePolicy
 import sk.ainet.lang.types.FP32
 import kotlin.math.pow
 import kotlin.reflect.KClass
@@ -24,16 +28,38 @@ import kotlin.reflect.KClass
  * Handles:
  * - HuggingFace → GGUF tensor name mapping
  * - Q4 + .qb companion tensor dequantization to FP32
- * - BF16/F16 dequantization to FP32
+ * - BF16/F16 dequantization to FP32 (default)
+ * - BF16 KEEP_NATIVE when [dtypePolicy] admits BF16 (SKaiNET 0.25.0):
+ *   constructs a [Bf16DenseTensorData]-backed tensor so the BF16 matmul
+ *   kernel routes via `DefaultCpuOpsJvm` without a 2× memory blow-up.
  * - Shape normalization ([1, dim] norms → [dim])
  * - Tied word embeddings (output.weight = token_embd.weight)
+ *
+ * @param dtypePolicy declarative dtype constraint. Default [DTypePolicy.Any]
+ *   = adaptive dequant. `Require(BF16)` / `Prefer(BF16)` / `OneOf` containing
+ *   BF16 = KEEP_NATIVE path. Mirrors the SKaiNET 0.25.0
+ *   `SafeTensorsParametersLoader.mapPolicyToBf16` semantics.
  */
 public class DecoderSafeTensorsLoader<T : DType>(
     private val ctx: ExecutionContext,
     private val dtype: KClass<T>,
     private val metadata: LlamaModelMetadata,
-    private val tiedEmbeddings: Boolean = false
+    private val tiedEmbeddings: Boolean = false,
+    private val dtypePolicy: DTypePolicy = DTypePolicy.Any,
 ) {
+
+    /**
+     * Returns `true` iff [dtypePolicy] wants BF16 weights kept in their
+     * packed 2-bytes-per-element form rather than dequantised to FP32.
+     * Matches the engine-side `SafeTensorsParametersLoader.mapPolicyToBf16`
+     * cases that resolve to `Bf16LoadPolicy.KEEP_NATIVE`.
+     */
+    private val keepBf16Native: Boolean = when (val p = dtypePolicy) {
+        DTypePolicy.Any -> false
+        is DTypePolicy.Require -> p.target == BF16
+        is DTypePolicy.Prefer -> p.target == BF16
+        is DTypePolicy.OneOf -> BF16 in p.allowed
+    }
 
     /**
      * Load weights from SafeTensors file into a flat tensor map with GGUF-canonical names.
@@ -66,10 +92,28 @@ public class DecoderSafeTensorsLoader<T : DType>(
                     }
                     DataType.BFLOAT16 -> {
                         val bytes = reader.loadTensorData(info)
-                        val floats = dequantBF16(bytes)
                         val targetShape = normalizeNormShape(info.shape)
-                        @Suppress("UNCHECKED_CAST")
-                        ctx.fromFloatArray<T, Float>(targetShape, dtype, floats) as Tensor<T, Float>
+                        if (keepBf16Native) {
+                            // KEEP_NATIVE: wrap the packed 2-bytes-per-element
+                            // BF16 buffer as `Bf16DenseTensorData`. The matmul
+                            // dispatch in `DefaultCpuOpsJvm` (SKaiNET 0.25.0)
+                            // detects `Bf16TensorData` at runtime and routes
+                            // to the SIMD BF16 kernel — avoiding the 2× memory
+                            // inflation of the FP32 dequant path.
+                            //
+                            // The declared dtype generic stays `T` (typically
+                            // FP32) because consumers don't care about the
+                            // physical encoding — the get/set surface still
+                            // returns Float. Mirrors the
+                            // `GemmaMemSegConverter` pattern for Q4/Q8.
+                            val data = Bf16DenseTensorData.fromRawBytes(targetShape, bytes)
+                            @Suppress("UNCHECKED_CAST")
+                            ctx.fromData(data as TensorData<T, Float>, dtype) as Tensor<T, Float>
+                        } else {
+                            val floats = dequantBF16(bytes)
+                            @Suppress("UNCHECKED_CAST")
+                            ctx.fromFloatArray<T, Float>(targetShape, dtype, floats) as Tensor<T, Float>
+                        }
                     }
                     DataType.FLOAT16 -> {
                         val bytes = reader.loadTensorData(info)

--- a/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/LlamaNetworkLoader.kt
+++ b/llm-inference/llama/src/commonMain/kotlin/sk/ainet/models/llama/LlamaNetworkLoader.kt
@@ -146,7 +146,7 @@ public class LlamaNetworkLoader @PublishedApi internal constructor(
                 loader.loadToMapStreaming<T, V>(ctx)
             }
             is WeightsProvider.SafeTensors -> {
-                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
+                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings, dtypePolicy)
                 @Suppress("UNCHECKED_CAST")
                 loader.loadToMap(wp.randomAccessProvider) as DecoderGgufWeights<T, V>
             }

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaNetworkLoaderDTypePolicyTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/LlamaNetworkLoaderDTypePolicyTest.kt
@@ -1,0 +1,123 @@
+package sk.ainet.models.llama
+
+import kotlinx.io.Source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import sk.ainet.io.RandomAccessSource
+import sk.ainet.lang.types.BF16
+import sk.ainet.lang.types.DTypePolicy
+import sk.ainet.lang.types.FP16
+import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Int8
+
+/**
+ * Pins the `DTypePolicy` validation contract on `LlamaNetworkLoader`:
+ *
+ *   - the default value is [DTypePolicy.Any];
+ *   - `withDtypePolicy(Require(FP32))` always succeeds (it's the loader's
+ *     native output dtype);
+ *   - `withDtypePolicy(Require(BF16))` succeeds **only** for SafeTensors-
+ *     backed loaders — the GGUF path mirrors the engine's eager rejection
+ *     in `StreamingGgufParametersLoader.validatePolicy()` because the
+ *     transformer-repo GGUF chain still dequants BF16 to FP32;
+ *   - `withDtypePolicy(Require(FP16))` / `Require(Int8)` etc. always
+ *     reject — the loader doesn't fabricate dtypes the source files
+ *     don't carry.
+ *   - `Prefer` / `OneOf` arms never raise (they're soft constraints).
+ *
+ * No model files are read — these tests only construct loader instances
+ * to exercise the validation boundary added in PR #144 (`*NetworkLoader.
+ * withDtypePolicy`).
+ */
+class LlamaNetworkLoaderDTypePolicyTest {
+
+    private val noopSourceProvider: () -> Source = { error("source not used in validation tests") }
+    private val noopRandomAccessProvider: () -> RandomAccessSource = { error("source not used in validation tests") }
+
+    private val anyMetadata = LlamaModelMetadata(
+        architecture = "llama",
+        embeddingLength = 4,
+        contextLength = 8,
+        blockCount = 1,
+        headCount = 1,
+        kvHeadCount = 1,
+        feedForwardLength = 4,
+        ropeDimensionCount = 4,
+        vocabSize = 4,
+        ropeFreqBase = 10_000f,
+        rmsNormEps = 1e-5f,
+    )
+
+    @Test
+    fun `default policy is Any`() {
+        val loader = LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+        assertSame(DTypePolicy.Any, loader.dtypePolicy)
+    }
+
+    @Test
+    fun `Require(FP32) is accepted on both GGUF and SafeTensors paths`() {
+        val gguf = LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+            .withDtypePolicy(DTypePolicy.Require(FP32))
+        assertEquals(DTypePolicy.Require(FP32), gguf.dtypePolicy)
+
+        val safetensors = LlamaNetworkLoader.fromSafeTensors(
+            metadata = anyMetadata, randomAccessProvider = noopRandomAccessProvider,
+        ).withDtypePolicy(DTypePolicy.Require(FP32))
+        assertEquals(DTypePolicy.Require(FP32), safetensors.dtypePolicy)
+    }
+
+    @Test
+    fun `Require(BF16) is accepted on SafeTensors but rejected on GGUF`() {
+        val safetensors = LlamaNetworkLoader.fromSafeTensors(
+            metadata = anyMetadata, randomAccessProvider = noopRandomAccessProvider,
+        ).withDtypePolicy(DTypePolicy.Require(BF16))
+        assertEquals(DTypePolicy.Require(BF16), safetensors.dtypePolicy)
+
+        assertFailsWith<IllegalArgumentException> {
+            LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+                .withDtypePolicy(DTypePolicy.Require(BF16))
+        }
+    }
+
+    @Test
+    fun `Require(FP16) is rejected on both paths`() {
+        assertFailsWith<IllegalArgumentException> {
+            LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+                .withDtypePolicy(DTypePolicy.Require(FP16))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LlamaNetworkLoader.fromSafeTensors(
+                metadata = anyMetadata, randomAccessProvider = noopRandomAccessProvider,
+            ).withDtypePolicy(DTypePolicy.Require(FP16))
+        }
+    }
+
+    @Test
+    fun `Require(Int8) is rejected on both paths`() {
+        assertFailsWith<IllegalArgumentException> {
+            LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+                .withDtypePolicy(DTypePolicy.Require(Int8))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LlamaNetworkLoader.fromSafeTensors(
+                metadata = anyMetadata, randomAccessProvider = noopRandomAccessProvider,
+            ).withDtypePolicy(DTypePolicy.Require(Int8))
+        }
+    }
+
+    @Test
+    fun `Prefer and OneOf are always accepted regardless of target`() {
+        // Prefer is a soft constraint — never raises.
+        LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+            .withDtypePolicy(DTypePolicy.Prefer(BF16))
+        LlamaNetworkLoader.fromGguf(sourceProvider = noopSourceProvider)
+            .withDtypePolicy(DTypePolicy.Prefer(FP16))
+
+        // OneOf is a restricted set; non-empty is the only invariant.
+        LlamaNetworkLoader.fromSafeTensors(
+            metadata = anyMetadata, randomAccessProvider = noopRandomAccessProvider,
+        ).withDtypePolicy(DTypePolicy.OneOf(setOf(FP32, BF16)))
+    }
+}

--- a/llm-inference/qwen/src/commonMain/kotlin/sk/ainet/models/qwen/QwenNetworkLoader.kt
+++ b/llm-inference/qwen/src/commonMain/kotlin/sk/ainet/models/qwen/QwenNetworkLoader.kt
@@ -148,7 +148,7 @@ public class QwenNetworkLoader @PublishedApi internal constructor(
                 loader.loadToMapStreaming<T, V>(ctx)
             }
             is WeightsProvider.SafeTensors -> {
-                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
+                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings, dtypePolicy)
                 @Suppress("UNCHECKED_CAST")
                 loader.loadToMap(wp.randomAccessProvider) as DecoderGgufWeights<T, V>
             }

--- a/llm-inference/voxtral/src/commonMain/kotlin/sk/ainet/models/voxtral/VoxtralNetworkLoader.kt
+++ b/llm-inference/voxtral/src/commonMain/kotlin/sk/ainet/models/voxtral/VoxtralNetworkLoader.kt
@@ -170,7 +170,7 @@ public class VoxtralNetworkLoader @PublishedApi internal constructor(
                 loader.loadToMapStreaming<T, V>(ctx)
             }
             is WeightsProvider.SafeTensors -> {
-                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings)
+                val loader = DecoderSafeTensorsLoader<T>(ctx, T::class, wp.metadata, wp.tiedEmbeddings, dtypePolicy)
                 @Suppress("UNCHECKED_CAST")
                 loader.loadToMap(wp.randomAccessProvider) as DecoderGgufWeights<T, V>
             }


### PR DESCRIPTION
**Stacked on #144** — base is `feat/skainet-0.25.0-bump`. When #144 merges I'll re-target this PR to `develop` (GitHub does that automatically on the same branch tip).

## Summary

#144 added the `DTypePolicy` surface on every `*NetworkLoader` as forward-compat scaffolding — the policy was accepted at the boundary but not yet observed at per-tensor load. **This PR makes the SafeTensors half real.**

When the consumer attaches a policy that admits BF16 — `Require(BF16)`, `Prefer(BF16)`, or `OneOf` containing `BF16` — `DecoderSafeTensorsLoader` stops dequanting BF16 tensors and instead wraps the packed 2-bytes-per-element buffer in **`Bf16DenseTensorData`** (new in SKaiNET 0.25.0). The matmul dispatch in `DefaultCpuOpsJvm` detects `Bf16TensorData` at runtime and routes to the SIMD BF16 kernel — so a BF16 SafeTensors checkpoint now stays **near its on-disk footprint in RAM** instead of inflating ~2× to FP32.

```kotlin
// before — always dequants:
LlamaNetworkLoader.fromSafeTensors(metadata, raSource)
    .load<FP32, Float>(ctx)            // BF16 → FP32, 2× memory

// after — opt-in keep-native:
LlamaNetworkLoader.fromSafeTensors(metadata, raSource)
    .withDtypePolicy(DTypePolicy.Require(BF16))
    .load<FP32, Float>(ctx)            // BF16 stays BF16, SIMD kernel routes
```

## Threading

`LlamaNetworkLoader` / `QwenNetworkLoader` / `VoxtralNetworkLoader` each forward `loader.dtypePolicy` into the new fifth constructor argument of `DecoderSafeTensorsLoader`. Default `DTypePolicy.Any` keeps the adaptive FP32 dequant behaviour, so existing callers see no change.

## Out of scope

- **GGUF loaders intentionally unchanged.** SKaiNET 0.25.0's `StreamingGgufParametersLoader.validatePolicy()` still rejects `Require(BF16)` for GGUF (no KEEP_NATIVE GGUF backing yet), and the transformer-repo's `DecoderGgufWeightLoader` inherits that constraint. Documented in the CHANGELOG's Deferred section.
- **Apertus / Bert.** Apertus uses `ApertusSingleSafeTensorsLoader` (separate class with its own dequant path) and Bert uses `BertNetworkLoader.fromTensorMap` (pre-loaded weights). Each can adopt the same pattern in a follow-up — they're not on the critical path for BF16 reference smoke.

## Tests

- **`LlamaNetworkLoaderDTypePolicyTest`** (new, jvmTest) pins the validation contract on each policy arm + provider combination:
  - `Require(BF16)`: accepted on SafeTensors, rejected on GGUF
  - `Require(FP16)` / `Require(Int8)`: rejected everywhere
  - `Require(FP32)`: always accepted
  - `Prefer(*)` / `OneOf(*)`: always accepted
- `llama` `.api` baseline regenerated for the new `DecoderSafeTensorsLoader` constructor signature; `apiCheck` green.
- `./gradlew allTests` green.

## Test plan

- [x] `./gradlew :llm-inference:llama:jvmTest --tests "*LlamaNetworkLoaderDTypePolicyTest*"` — green
- [x] `./gradlew :llm-inference:llama:apiCheck :llm-inference:qwen:apiCheck :llm-inference:voxtral:apiCheck` — green
- [x] `./gradlew allTests` — green (~10 min)
- [ ] CI: PR build (`build.yml`)
- [ ] Manual: load a BF16 SafeTensors model with `.withDtypePolicy(DTypePolicy.Require(BF16))` and verify resident memory stays near disk footprint via `jcmd <pid> VM.native_memory summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)