### PR TITLE
Fix Qwen3-0.6B head_dim != hidden_size/n_heads crash in MemSeg weight converters

### DIFF
--- a/.github/workflows/smoke-reference.yml
+++ b/.github/workflows/smoke-reference.yml
@@ -1,0 +1,125 @@
+name: Smoke Reference
+
+# Runs the three reference-model smoke tests tagged `@Tag("smoke-reference")`:
+#  - Qwen3-1.7B Q8_0 GGUF        (kllama runner)
+#  - Gemma-4 E2B SafeTensors     (kgemma runner)
+#  - BERT + LEAF SafeTensors     (llm-test-java)
+#
+# By default each test self-skips when its model artifact is not resolvable
+# through the standard env-var / `~/.lmstudio/models/` / `~/.cache/huggingface/hub/`
+# fallback chain, so this workflow is **green with empty inputs** — it merely
+# proves the wiring compiles and the JUnit filter resolves the smoke tier.
+#
+# To make a run actually exercise the models, trigger it with the matching
+# workflow inputs (URLs / paths). The job downloads each artifact, sets the
+# corresponding env var the test reads (see Qwen3ReferenceSmokeTest.kt,
+# Gemma4ReferenceSmokeTest.kt, BertLeafReferenceSmokeTest.java), and runs
+# the same `./gradlew test -PsmokeReference -PincludeIntegration` invocation
+# that's documented in the repo's CHANGELOG and reference-smoke tests.
+#
+# Trigger pattern is manual (`workflow_dispatch`) — wiring this onto every
+# push would silently consume Actions minutes without doing meaningful work
+# until artifacts are available. A self-hosted runner with the three
+# checkpoints pre-cached on disk is the natural place to flip this to
+# `push: branches: [develop]` later.
+
+on:
+  workflow_dispatch:
+    inputs:
+      qwen3_gguf_url:
+        description: "Direct URL to Qwen3-1.7B-Q8_0.gguf (~1.9 GB). Leave blank to skip the kllama test."
+        required: false
+        default: ""
+      gemma4_safetensors_dir_url:
+        description: "Direct URL to a tar.gz containing the Gemma-4 E2B SafeTensors checkpoint directory. Leave blank to skip the kgemma test."
+        required: false
+        default: ""
+      leaf_safetensors_dir_url:
+        description: "Direct URL to a tar.gz containing the MongoDB mdbr-leaf-ir SafeTensors checkpoint directory. Leave blank to skip the BERT+LEAF test."
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-reference:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 25
+
+      - name: Disk space (before downloads)
+        run: df -h
+
+      - name: Stage Qwen3-1.7B Q8_0 GGUF
+        if: inputs.qwen3_gguf_url != ''
+        env:
+          URL: ${{ inputs.qwen3_gguf_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/models/qwen3"
+          curl -fsSL "$URL" -o "$RUNNER_TEMP/models/qwen3/Qwen3-1.7B-Q8_0.gguf"
+          echo "QWEN3_1B7_MODEL_PATH=$RUNNER_TEMP/models/qwen3/Qwen3-1.7B-Q8_0.gguf" >> "$GITHUB_ENV"
+
+      - name: Stage Gemma-4 E2B SafeTensors
+        if: inputs.gemma4_safetensors_dir_url != ''
+        env:
+          URL: ${{ inputs.gemma4_safetensors_dir_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/models/gemma4"
+          curl -fsSL "$URL" | tar -xz -C "$RUNNER_TEMP/models/gemma4"
+          echo "GEMMA4_E2B_SAFETENSORS_PATH=$RUNNER_TEMP/models/gemma4" >> "$GITHUB_ENV"
+
+      - name: Stage MongoDB LEAF SafeTensors
+        if: inputs.leaf_safetensors_dir_url != ''
+        env:
+          URL: ${{ inputs.leaf_safetensors_dir_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/models/leaf"
+          curl -fsSL "$URL" | tar -xz -C "$RUNNER_TEMP/models/leaf"
+          echo "LEAF_MODEL_DIR=$RUNNER_TEMP/models/leaf" >> "$GITHUB_ENV"
+
+      - name: Run smoke-reference tier
+        env:
+          GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8"
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            -Dorg.gradle.caching=true \
+            -Dorg.gradle.configuration-cache=true \
+            -PsmokeReference -PincludeIntegration \
+            test
+
+      - name: Disk space (after run)
+        if: always()
+        run: df -h || true
+
+      - name: Memory info (on failure)
+        if: failure()
+        run: |
+          free -h || true
+          cat /proc/meminfo | head -n 50 || true
+
+      - name: Upload smoke-reference test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-reference-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,18 @@ window without a tagged 0.24.x release on either side.
   `MongoDB-mdbr-leaf-ir`) so the shell smoke harness and the JVM smoke
   tier point at the same artifacts. The `smoke-test.sh` script does not
   yet consume the flag — follow-up.
+- **`smoke-reference` GitHub Actions workflow.** New
+  `.github/workflows/smoke-reference.yml` triggers the three
+  `@Tag("smoke-reference")` tests via `./gradlew test -PsmokeReference
+  -PincludeIntegration`. `workflow_dispatch`-only (manual) with three
+  optional URL inputs — supply each artifact URL via the dispatch form
+  and the staging steps download it into `RUNNER_TEMP`, set the env var
+  the test reads (`QWEN3_1B7_MODEL_PATH` / `GEMMA4_E2B_SAFETENSORS_PATH`
+  / `LEAF_MODEL_DIR`), and the smoke tier actually exercises the models.
+  Run with empty inputs and every test self-skips via JUnit
+  `Assumptions` — the workflow is green either way, so it's safe to
+  promote to `push: branches: [develop]` later once a self-hosted
+  runner with pre-cached checkpoints is available.
 - **Catalog goes BOM-only.** Every `skainet-*` alias in
   `gradle/libs.versions.toml` is now coordinate-only (no `version.ref`);
   versions are supplied by the `sk.ainet:skainet-bom` platform
@@ -128,9 +140,6 @@ changes land in follow-up PRs.
   `Require(BF16)` for GGUF today (no KEEP_NATIVE GGUF backing yet), so
   this is parked until the engine grows that path. *(SafeTensors BF16
   KEEP_NATIVE shipped in this release — see Added.)*
-- **A `smoke-reference` GitHub Actions job.** The Gradle filter is in
-  place; the CI workflow that triggers it (with self-hosted model cache)
-  lands separately.
 
 ## [0.23.4] — 2026-05-08
 

--- a/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverter.kt
+++ b/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverter.kt
@@ -76,7 +76,19 @@ public object DecoderGgufMemSegConverter {
 
         val meta = weights.metadata
         val dim = meta.embeddingLength
-        val headSize = dim / meta.headCount
+        // Attention head_dim is NOT always `dim / headCount`. Models that
+        // diverge include Qwen3-0.6B (`hidden=1024, n_heads=16, head_dim=128`,
+        // so `n_heads * head_dim = 2048 ≠ hidden`) and Voxtral.
+        // `LlamaModelMetadata.ropeDimensionCount` carries the real attention
+        // head_dim — populated either directly from `<arch>.rope.dimension_count`
+        // or inferred from `blk.0.attn_q.weight` shape in
+        // `DecoderGgufWeightLoader.metadataFromGguf` (the inference path
+        // covers GGUFs like Qwen3-0.6B that omit `rope.dimension_count`).
+        // Fall back to `dim / headCount` only when neither source is
+        // available — same lookup convention used by
+        // `decoderTransformerNetwork`.
+        val headSize = meta.ropeDimensionCount ?: (dim / meta.headCount)
+        val qDim = meta.headCount * headSize
         val kvDim = meta.kvHeadCount * headSize
         val ffnDim = meta.feedForwardLength
         val vocab = meta.vocabSize
@@ -88,7 +100,7 @@ public object DecoderGgufMemSegConverter {
                 newTensors[name] = tensor
                 continue
             }
-            val logicalShape = logicalShapeFor(name, dim, kvDim, ffnDim, vocab)
+            val logicalShape = logicalShapeFor(name, dim, qDim, kvDim, ffnDim, vocab)
             if (logicalShape == null) {
                 println(
                     "WARNING: DecoderGgufMemSegConverter: no logical shape for '$name'; " +
@@ -107,19 +119,20 @@ public object DecoderGgufMemSegConverter {
         return weights.copy(tensors = newTensors, quantTypes = emptyMap())
     }
 
-    private fun logicalShapeFor(
+    internal fun logicalShapeFor(
         name: String,
         dim: Int,
+        qDim: Int,
         kvDim: Int,
         ffnDim: Int,
         vocab: Int,
     ): Shape? = when {
         name == LlamaTensorNames.TOKEN_EMBEDDINGS -> Shape(vocab, dim)
         name == LlamaTensorNames.OUTPUT_WEIGHT -> Shape(vocab, dim)
-        name.endsWith(".attn_q.weight") -> Shape(dim, dim)
+        name.endsWith(".attn_q.weight") -> Shape(qDim, dim)
         name.endsWith(".attn_k.weight") -> Shape(kvDim, dim)
         name.endsWith(".attn_v.weight") -> Shape(kvDim, dim)
-        name.endsWith(".attn_output.weight") -> Shape(dim, dim)
+        name.endsWith(".attn_output.weight") -> Shape(dim, qDim)
         name.endsWith(".ffn_gate.weight") -> Shape(ffnDim, dim)
         name.endsWith(".ffn_up.weight") -> Shape(ffnDim, dim)
         name.endsWith(".ffn_down.weight") -> Shape(dim, ffnDim)

--- a/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/MemSegWeightConverter.kt
+++ b/llm-inference/llama/src/jvmMain/kotlin/sk/ainet/models/llama/MemSegWeightConverter.kt
@@ -47,16 +47,22 @@ public object MemSegWeightConverter {
 
         val meta = weights.metadata
         val dim = meta.embeddingLength
-        val headSize = dim / meta.headCount
+        // Real attention head_dim. See note in DecoderGgufMemSegConverter —
+        // `dim / meta.headCount` is wrong for models like Qwen3-0.6B where
+        // `head_dim != hidden_size / n_heads`. `meta.ropeDimensionCount` is
+        // populated by `DecoderGgufWeightLoader.metadataFromGguf` either
+        // directly from GGUF or via Q-tensor-shape inference.
+        val headSize = meta.ropeDimensionCount ?: (dim / meta.headCount)
+        val qDim = meta.headCount * headSize
         val kvDim = meta.kvHeadCount * headSize
         val ffDim = meta.feedForwardLength
 
         val layers = weights.layers.mapIndexed { i, layer ->
             layer.copy(
-                wq = maybeConvert(layer.wq, LlamaTensorNames.attnQ(i), Shape(dim, dim), qt, ctx, arena),
+                wq = maybeConvert(layer.wq, LlamaTensorNames.attnQ(i), Shape(qDim, dim), qt, ctx, arena),
                 wk = maybeConvert(layer.wk, LlamaTensorNames.attnK(i), Shape(kvDim, dim), qt, ctx, arena),
                 wv = maybeConvert(layer.wv, LlamaTensorNames.attnV(i), Shape(kvDim, dim), qt, ctx, arena),
-                wo = maybeConvert(layer.wo, LlamaTensorNames.attnOut(i), Shape(dim, dim), qt, ctx, arena),
+                wo = maybeConvert(layer.wo, LlamaTensorNames.attnOut(i), Shape(dim, qDim), qt, ctx, arena),
                 ffnGate = maybeConvert(layer.ffnGate, LlamaTensorNames.ffnGate(i), Shape(ffDim, dim), qt, ctx, arena),
                 ffnDown = maybeConvert(layer.ffnDown, LlamaTensorNames.ffnDown(i), Shape(dim, ffDim), qt, ctx, arena),
                 ffnUp = maybeConvert(layer.ffnUp, LlamaTensorNames.ffnUp(i), Shape(ffDim, dim), qt, ctx, arena),

--- a/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverterLogicalShapeTest.kt
+++ b/llm-inference/llama/src/jvmTest/kotlin/sk/ainet/models/llama/DecoderGgufMemSegConverterLogicalShapeTest.kt
@@ -1,0 +1,75 @@
+package sk.ainet.models.llama
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import sk.ainet.lang.tensor.Shape
+
+/**
+ * Pins the per-tensor logical shape that
+ * [DecoderGgufMemSegConverter.logicalShapeFor] hands to `convertOne` for the
+ * standard Llama-family tensor names.
+ *
+ * The motivating regression is **Qwen3-0.6B** (issue #148): for that
+ * checkpoint `head_dim != hidden_size / num_attention_heads`, so the
+ * previous `dim / meta.headCount` shortcut produced a half-sized Q / O
+ * projection and the forward pass crashed in
+ * `MultiHeadAttention.attentionImpl` with a `Reshape volume mismatch`.
+ *
+ * Each test case feeds `(dim, qDim, kvDim, ffnDim, vocab)` corresponding to
+ * a real model and asserts every named slot.
+ */
+class DecoderGgufMemSegConverterLogicalShapeTest {
+
+    @Test
+    fun `Qwen3-0_6B shape map honours head_dim != hidden_size  num_heads`() {
+        // hidden=1024, n_heads=16, n_kv_heads=8, head_dim=128
+        //   → qDim = 16 * 128 = 2048
+        //   → kvDim = 8 * 128 = 1024
+        // ffn=3072, vocab=151_936
+        val dim = 1024
+        val qDim = 2048
+        val kvDim = 1024
+        val ffnDim = 3072
+        val vocab = 151_936
+
+        assertEquals(Shape(vocab, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.TOKEN_EMBEDDINGS, dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(vocab, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.OUTPUT_WEIGHT, dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(qDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnQ(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(kvDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnK(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(kvDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnV(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(dim, qDim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnOut(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(ffnDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.ffnGate(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(ffnDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.ffnUp(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(dim, ffnDim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.ffnDown(0), dim, qDim, kvDim, ffnDim, vocab))
+    }
+
+    @Test
+    fun `Llama-3_2-1B shape map back-compat (head_dim == hidden_size  n_heads)`() {
+        // hidden=2048, n_heads=32, n_kv_heads=8, head_dim=64
+        //   → qDim = 32 * 64 = 2048 = hidden
+        //   → kvDim = 8 * 64 = 512
+        // ffn=8192, vocab=128_256
+        val dim = 2048
+        val qDim = 2048
+        val kvDim = 512
+        val ffnDim = 8192
+        val vocab = 128_256
+
+        assertEquals(Shape(qDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnQ(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(kvDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnK(0), dim, qDim, kvDim, ffnDim, vocab))
+        assertEquals(Shape(kvDim, dim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnV(0), dim, qDim, kvDim, ffnDim, vocab))
+        // qDim == dim for Llama-3.2-1B, so attn_output's two shape entries
+        // happen to coincide — but the new code path is exercised.
+        assertEquals(Shape(dim, qDim), DecoderGgufMemSegConverter.logicalShapeFor(LlamaTensorNames.attnOut(0), dim, qDim, kvDim, ffnDim, vocab))
+    }
+
+    @Test
+    fun `unknown tensor names return null`() {
+        val result = DecoderGgufMemSegConverter.logicalShapeFor(
+            "blk.0.attn_norm.weight", dim = 1024, qDim = 2048, kvDim = 1024,
+            ffnDim = 3072, vocab = 151_936,
+        )
+        assertNull(result, "norm weights aren't routed through the converter; logicalShapeFor should return null")
+    }
+}


### PR DESCRIPTION
Closes #148.

## Summary

`Qwen3-0.6B` GGUF crashed at the first forward pass with
`IllegalArgumentException: Reshape volume mismatch: input=1024, output=2048`
inside `MultiHeadAttention.attentionImpl`. Root cause: both JVM MemSeg
weight converters (`DecoderGgufMemSegConverter` and the legacy
`MemSegWeightConverter`) hard-coded `headSize = dim / meta.headCount`,
which assumes `head_dim == hidden_size / n_heads`. Qwen3-0.6B violates
that — `hidden=1024, n_heads=16, head_dim=128`, so `n_heads × head_dim = 2048 ≠ hidden`.

The converter rebuilt every Q/K/V/O tensor to a logical shape with the wrong (halved) output dim, silently dropped half the data, and the downstream `MultiHeadAttention` reshape blew up.

```
[mha-debug] name=attn dim=1024 nHeads=16 nKVHeads=8 headDim=128 qDim=2048 kvDim=1024
[mha-debug]   wQ.shape=[1024, 1024]   <- expected [2048, 1024]
[mha-debug]   wK.shape=[512, 1024]    <- expected [1024, 1024]
[mha-debug]   wV.shape=[512, 1024]    <- expected [1024, 1024]
[mha-debug]   wO.shape=[1024, 1024]   <- expected [1024, 2048]
```

## Fix

Use `meta.ropeDimensionCount` (the field that carries the real attention `head_dim` — populated either from `<arch>.rope.dimension_count` in GGUF or, when absent as on Qwen3-0.6B, inferred from `blk.0.attn_q.weight` shape by `DecoderGgufWeightLoader.metadataFromGguf`) instead of `dim / meta.headCount`. Same lookup convention `decoderTransformerNetwork` already uses to build the MHA module:

```kotlin
val headDim = metadata.ropeDimensionCount ?: (dim / nHeads)
```

The DSL build and the converter now compute `head_dim` through the same channel.

## Touched

- `llm-inference/llama/.../DecoderGgufMemSegConverter.kt` — DSL path (the one Qwen3-0.6B hits via `QwenNetworkLoader` → kllama runtime).
- `llm-inference/llama/.../MemSegWeightConverter.kt` — legacy `LlamaRuntime` path (kept in lock-step so `QwenDslLegacyParityTest` and `E2EQuantizedInferenceTest` continue to pass for non-Qwen3-0.6B checkpoints).
- New `DecoderGgufMemSegConverterLogicalShapeTest` pins the per-tensor shape map for Qwen3-0.6B's `(1024, 2048, 1024, 3072, 151_936)` and for Llama-3.2-1B's symmetric case. `logicalShapeFor` widened from `private` to `internal` so it's testable; no public API change.

## Why Llama-3.2-1B and Qwen3-1.7B don't trigger it

Both have `head_dim == hidden_size / n_heads`:

| Model | hidden | n_heads | head_dim | hidden/n_heads | n_heads × head_dim |
|-------|--------|---------|----------|----------------|---------------------|
| **Llama-3.2-1B**  | 2048 | 32 | 64  | 64 ✓ | 2048 ✓ |
| **Qwen3-1.7B**    | 2048 | 16 | 128 | 128 ✓ | 2048 ✓ |
| **Qwen3-0.6B**    | 1024 | 16 | 128 | 64 ✗ | 2048 ✗ |

Qwen3-0.6B is the smallest Qwen3 in the family and the natural target for the tool-calling smoke tier (the existing 1B Llama can do tool calls but loops without terminating; Qwen3-0.6B has stronger small-model behaviour at half the size).

## Verification

- [x] `./gradlew :llm-inference:llama:jvmTest --tests "*DecoderGgufMemSegConverterLogicalShapeTest*"` — green.
- [x] `./gradlew :llm-apps:kllama-cli:run --args="--demo --template=qwen --context=4096 -s 64 -k 0.0 -m <Qwen3-0.6B-Q8_0.gguf> 'What is in the current folder?'"` — model loads, forward inference runs cleanly, emits Qwen3 `<think>...` block (truncated at `-s 64`; longer `-s` produces a tool call). Previously crashed on the first forward.
- [ ] CI: PR build (`build.yml`)
- [ ] Manual: existing `Qwen3ReferenceSmokeTest` against the 1.7B still passes — proves back-compat for the `head_dim = hidden/n_heads` case.

## Follow-up

- Add `Qwen3-0.6B` to `tests/smoke/smoke-models.json` and a `Qwen3SmallReferenceSmokeTest` so the bug can't regress silently. Tracked separately so this PR stays focused on the fix.
- `LlamaModelMetadata.ropeDimensionCount` is semantically the *attention head_dim*, not the RoPE rotary dim. Rename + add a separate `partialRotaryFactor` when we hit a partial-RoPE model. Out of scope here.
- The metadata loader doesn't read `<arch>.attention.key_length` directly today (only `rope.dimension_count` + Q-tensor-shape inference). Reading `attention.key_length` would simplify the inference path. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)