### PR TITLE
fix: BPEStrategy.postprocess reverses the full GPT-2 byte_to_unicode table

### DIFF
--- a/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/BPEStrategy.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/apps/llm/tokenizer/BPEStrategy.kt
@@ -4,17 +4,30 @@ import sk.ainet.apps.llm.TokenizerStrategy
 import sk.ainet.apps.llm.TokenizerType
 
 /**
- * Tokenizer strategy for GPT-2/GPT-3 style BPE models.
- * Uses Ġ (U+0120 LATIN CAPITAL LETTER G WITH DOT ABOVE) as the space marker.
+ * Tokenizer strategy for GPT-2 / GPT-3 / Qwen style **byte-level** BPE.
  *
- * GPT-2 BPE tokenizers encode spaces as part of the following token,
- * using Ġ to represent a space before the token.
+ * Byte-level BPE encodes every input byte as a printable Unicode glyph
+ * before the BPE merge passes. Spaces map to `Ġ` (U+0120), newlines to
+ * `Ċ` (U+010A), tabs to `ĉ` (U+0109), etc.; the full table is the
+ * `byte_to_unicode` mapping from OpenAI's GPT-2 reference
+ * implementation. [postprocess] reverses that mapping so the consumer
+ * sees real bytes back instead of the encoded glyphs (i.e. `Ċ` → `\n`,
+ * `Ġ` → ` `).
+ *
+ * ## Why this matters
+ *
+ * Without the full inverse table consumers got the raw encoded glyphs
+ * leaking into output text — most visibly `Ċ` instead of newlines, but
+ * also `ĉ` for tabs and any multi-byte UTF-8 character split into its
+ * constituent encoded-byte glyphs. The previous implementation only
+ * handled the space marker, which was enough to make Latin sentences
+ * look right but broke every byte that needed escaping.
  */
 public object BPEStrategy : TokenizerStrategy {
     override val type: TokenizerType = TokenizerType.BPE
 
-    /** GPT-2 BPE space marker: Ġ (U+0120) */
-    override val spaceMarker: String = "\u0120"
+    /** GPT-2 BPE space marker: Ġ (U+0120). */
+    override val spaceMarker: String = "Ġ"
 
     override fun preprocess(text: String): String {
         // GPT-2 style: space becomes Ġ prefix on following token
@@ -22,10 +35,52 @@ public object BPEStrategy : TokenizerStrategy {
         return text.replace(" ", spaceMarker)
     }
 
+    /**
+     * Reverse the byte-to-unicode mapping. Each character in [token]
+     * decodes to a single byte; the resulting byte sequence is then
+     * interpreted as UTF-8.
+     *
+     * Falls back to a verbatim pass (with only the space marker
+     * reversed) if [token] contains a character outside the
+     * byte-to-unicode alphabet — defensive guard for non-byte-level
+     * inputs (e.g. SentencePiece tokens accidentally routed here).
+     */
     override fun postprocess(token: String): String {
-        return when (token) {
-            spaceMarker -> " "
-            else -> token.replace(spaceMarker, " ")
+        if (token.isEmpty()) return token
+        val bytes = ByteArray(token.length)
+        var i = 0
+        for (ch in token) {
+            val b = UNICODE_TO_BYTE[ch] ?: return token.replace(spaceMarker, " ")
+            bytes[i++] = b
         }
+        return bytes.decodeToString()
+    }
+
+    // ---- byte_to_unicode / unicode_to_byte tables ----
+    //
+    // From the GPT-2 reference (`bytes_to_unicode()` in
+    // `openai/gpt-2/src/encoder.py`, mirrored verbatim in HuggingFace
+    // `tokenizers` and tiktoken). The 188 "printable" bytes are
+    // identity-mapped; the remaining 68 bytes (0..32, 127..160, 173)
+    // are remapped into the U+0100..U+0143 range so every encoded
+    // byte renders as a single visible non-whitespace glyph.
+
+    private val BYTE_TO_UNICODE: Map<Byte, Char> = buildByteToUnicode()
+    private val UNICODE_TO_BYTE: Map<Char, Byte> =
+        BYTE_TO_UNICODE.entries.associate { (b, c) -> c to b }
+
+    private fun buildByteToUnicode(): Map<Byte, Char> {
+        val printableRanges = listOf(33..126, 161..172, 174..255)
+        val printable = HashSet<Int>().apply { printableRanges.forEach { addAll(it) } }
+        val map = HashMap<Byte, Char>(256)
+        for (range in printableRanges) for (b in range) map[b.toByte()] = b.toChar()
+        var n = 0
+        for (b in 0..255) {
+            if (b !in printable) {
+                map[b.toByte()] = (256 + n).toChar()
+                n++
+            }
+        }
+        return map
     }
 }

--- a/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerStrategyTest.kt
+++ b/llm-core/src/commonTest/kotlin/sk/ainet/apps/llm/tokenizer/TokenizerStrategyTest.kt
@@ -102,6 +102,69 @@ class TokenizerStrategyTest {
         assertEquals("hello", result)
     }
 
+    // ==================== BPEStrategy byte-level decode ====================
+
+    @Test
+    fun `BPEStrategy postprocess decodes newline glyph Ċ back to newline byte`() {
+        // GPT-2 byte_to_unicode maps byte 0x0A (newline) to U+010A (Ċ).
+        // The reverse-mapping in postprocess should restore the newline.
+        val result = BPEStrategy.postprocess("Ċ")
+        assertEquals("\n", result)
+    }
+
+    @Test
+    fun `BPEStrategy postprocess decodes tab glyph ĉ back to tab byte`() {
+        // GPT-2 byte_to_unicode maps byte 0x09 (tab) to U+0109 (ĉ).
+        val result = BPEStrategy.postprocess("ĉ")
+        assertEquals("\t", result)
+    }
+
+    @Test
+    fun `BPEStrategy postprocess decodes mixed byte-level token preserving newlines and spaces`() {
+        // The Qwen3 / GPT-2 byte-level encoding of "Hello\nworld" with a
+        // leading space → "ĠHelloĊworld". postprocess should produce the
+        // original byte sequence.
+        val result = BPEStrategy.postprocess("ĠHelloĊworld")
+        assertEquals(" Hello\nworld", result)
+    }
+
+    @Test
+    fun `BPEStrategy postprocess reconstructs multi-byte UTF-8 split across bytes`() {
+        // Emoji 🚀 is UTF-8 0xF0 0x9F 0x9A 0x80. GPT-2 byte_to_unicode maps:
+        //   0xF0 (240, printable) → 0xF0 = 'ð'
+        //   0x9F (159, not printable) → 0x121 + (offset for 159)
+        //   0x9A (154, not printable) → 0x121 + (offset for 154)
+        //   0x80 (128, not printable) → 0x121 + (offset for 128)
+        // Postprocess should reverse each char to its byte and decode the
+        // resulting 4-byte sequence as UTF-8, yielding the emoji.
+        val encoded = byteArrayOf(0xF0.toByte(), 0x9F.toByte(), 0x9A.toByte(), 0x80.toByte())
+            .map { byte ->
+                val u = byte.toInt() and 0xFF
+                when {
+                    u in 33..126 || u in 161..172 || u in 174..255 -> u.toChar()
+                    else -> {
+                        // Compute the U+0100+offset glyph the encoder would have produced.
+                        val missingBefore = (0 until u).count { b ->
+                            !(b in 33..126 || b in 161..172 || b in 174..255)
+                        }
+                        (256 + missingBefore).toChar()
+                    }
+                }
+            }
+            .joinToString("")
+        val result = BPEStrategy.postprocess(encoded)
+        assertEquals("🚀", result)  // 🚀 surrogate pair
+    }
+
+    @Test
+    fun `BPEStrategy postprocess falls back to identity-with-space-marker on non-byte-level input`() {
+        // SentencePiece-style ▁ (U+2581) is outside the byte_to_unicode
+        // alphabet; postprocess should not garble it, just pass through
+        // (with the space marker still reversed if present).
+        assertEquals("▁foo", BPEStrategy.postprocess("▁foo"))
+        assertEquals(" foo▁bar", BPEStrategy.postprocess("Ġfoo▁bar"))
+    }
+
     // ==================== WordPiece Strategy Tests ====================
 
     @Test


### PR DESCRIPTION
## Summary

GPT-2 / Qwen3 byte-level BPE encodes every input byte as a printable Unicode glyph before merge passes: spaces → `Ġ` (U+0120), newlines → `Ċ` (U+010A), tabs → `ĉ` (U+0109), and any non-printable or multi-byte UTF-8 sequence into glyphs in U+0100..U+0143. Previously `BPEStrategy.postprocess` only reverse-mapped the space marker, so newlines / tabs / multi-byte glyphs leaked into decoded output verbatim.

Most visibly: every Qwen3 assistant response containing a newline came back with literal `Ċ` instead of `\n`:

```
Assistant: <think>Ċ<think>Ċ<think>ĊOkay, the user is asking...
                  ^      ^       ^
                  └── should be actual newlines
```

This fix builds the full byte_to_unicode reverse table (OpenAI's `bytes_to_unicode()` from `gpt-2/src/encoder.py`, mirrored verbatim by HuggingFace `tokenizers` and tiktoken):

- 188 "printable" bytes (33..126, 161..172, 174..255) identity-map to their Unicode code point.
- The remaining 68 bytes (0..32, 127..160, 173) map to U+0100..U+0143 in iteration order, with byte 0x20 (space) landing on U+0120 (`Ġ`).

`postprocess` now decodes each char of a token back to its single byte via the inverse table, then interprets the resulting byte sequence as UTF-8. Multi-byte chars (CJK, emoji) round-trip correctly because they're encoded as multiple consecutive byte-level glyphs.

Falls back to a verbatim pass (with only the space marker reversed) if the token contains a char outside the byte_to_unicode alphabet — defensive guard for non-byte-level inputs (e.g. SentencePiece tokens accidentally routed here through misconfiguration).

Also nudges `BPEStrategy.spaceMarker` to use the literal `Ġ` glyph instead of `"Ġ"` for legibility — same string, more readable.

## Test plan

- [x] Five new cases in `TokenizerStrategyTest`:
  - [x] `Ċ → \n` (the smoking-gun case)
  - [x] `ĉ → \t`
  - [x] mixed: `ĠHelloĊworld → " Hello\nworld"`
  - [x] `🚀` round-trip via its 4-byte UTF-8 sequence
  - [x] SentencePiece-style `▁` pass-through fallback
- [x] Verified end-to-end against Qwen3-0.6B (both GGUF Q8_0 on JVM and mlx-community 4-bit on MLX): assistant output now has real newlines instead of `Ċ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)