### PR TITLE
feat(gemma): trace gemma3 to StableHLO + full FunctionGemma parity vs llama.cpp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,6 +91,7 @@ skainet-lang-models = { module = "sk.ainet.core:skainet-lang-models" }
 skainet-lang-ksp-annotations = { module = "sk.ainet.core:skainet-lang-ksp-annotations" }
 skainet-compile-core = { module = "sk.ainet.core:skainet-compile-core" }
 skainet-compile-dag = { module = "sk.ainet.core:skainet-compile-dag" }
+skainet-compile-hlo = { module = "sk.ainet.core:skainet-compile-hlo" }
 skainet-compile-opt = { module = "sk.ainet.core:skainet-compile-opt" }
 skainet-backend-cpu = { module = "sk.ainet.core:skainet-backend-cpu" }
 skainet-backend-nativeCpu = { module = "sk.ainet.core:skainet-backend-native-cpu" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ skainet-backend-cpu = { module = "sk.ainet.core:skainet-backend-cpu" }
 skainet-backend-nativeCpu = { module = "sk.ainet.core:skainet-backend-native-cpu" }
 skainet-io-core = { module = "sk.ainet.core:skainet-io-core" }
 skainet-io-gguf = { module = "sk.ainet.core:skainet-io-gguf" }
+skainet-io-iree-params = { module = "sk.ainet.core:skainet-io-iree-params" }
 skainet-io-safetensors = { module = "sk.ainet.core:skainet-io-safetensors" }
 
 [plugins]

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/TransformerDsl.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/dsl/TransformerDsl.kt
@@ -79,6 +79,7 @@ public class AttentionImpl<T : DType, V>(
     private val bias: Boolean,
     private val id: String,
     private val slidingWindow: Int? = null,
+    private val kClass: kotlin.reflect.KClass<T>? = null,
 ) : ATTENTION<T, V> {
 
     private var ropeModule: RoPE<T, V>? = null
@@ -138,7 +139,8 @@ public class AttentionImpl<T : DType, V>(
             rope = ropeModule,
             kvCache = kvCacheModule,
             explicitHeadDim = if (needsExplicitHeadDim) explicitHeadDim else null,
-            slidingWindow = slidingWindow
+            slidingWindow = slidingWindow,
+            dtype = kClass
         )
     }
 }
@@ -155,7 +157,7 @@ public fun <T : DType, V> StageImpl<T, V>.embedding(vocabSize: Int, dim: Int, id
             override fun get(vararg indices: Int): V = 0.0f as V
             override fun set(vararg indices: Int, value: V) {}
         },
-        Any::class as kotlin.reflect.KClass<T>
+        kClass
     )
     val emb = Embedding<T, V>(
         numEmbeddings = vocabSize,
@@ -172,7 +174,8 @@ public fun <T : DType, V> StageImpl<T, V>.rmsNorm(normalizedShape: Int, eps: Flo
         normalizedShape = intArrayOf(normalizedShape),
         eps = eps.toDouble(),
         name = getDefaultName(id, "RMSNorm", modules.size),
-        unitOffset = unitOffset
+        unitOffset = unitOffset,
+        dtype = kClass
     )
 }
 
@@ -206,6 +209,7 @@ public fun <T : DType, V> StageImpl<T, V>.multiHeadAttention(
         bias = bias,
         id = attnName,
         slidingWindow = slidingWindow,
+        kClass = kClass,
     )
     impl.content()
     modules += impl.create()
@@ -223,7 +227,8 @@ public fun <T : DType, V> StageImpl<T, V>.geGluFFN(dim: Int, hiddenDim: Int, id:
     modules += GeGLUFFN<T, V>(
         dim = dim,
         hiddenDim = hiddenDim,
-        name = getDefaultName(id, "GeGLUFFN", modules.size)
+        name = getDefaultName(id, "GeGLUFFN", modules.size),
+        dtype = kClass
     )
 }
 
@@ -253,7 +258,7 @@ public fun <T : DType, V> NeuralNetworkDslImpl<T, V>.embedding(vocabSize: Int, d
             override fun get(vararg indices: Int): V = 0.0f as V
             override fun set(vararg indices: Int, value: V) {}
         },
-        Any::class as kotlin.reflect.KClass<T>
+        kClass
     )
     val emb = Embedding<T, V>(
         numEmbeddings = vocabSize,
@@ -270,7 +275,8 @@ public fun <T : DType, V> NeuralNetworkDslImpl<T, V>.rmsNorm(normalizedShape: In
         normalizedShape = intArrayOf(normalizedShape),
         eps = eps.toDouble(),
         name = getDefaultName(id, "RMSNorm", modules.size),
-        unitOffset = unitOffset
+        unitOffset = unitOffset,
+        dtype = kClass
     )
 }
 
@@ -298,6 +304,7 @@ public fun <T : DType, V> NeuralNetworkDslImpl<T, V>.multiHeadAttention(
         bias = bias,
         id = attnName,
         slidingWindow = slidingWindow,
+        kClass = kClass,
     )
     impl.content()
     modules += impl.create()
@@ -315,7 +322,8 @@ public fun <T : DType, V> NeuralNetworkDslImpl<T, V>.geGluFFN(dim: Int, hiddenDi
     modules += GeGLUFFN<T, V>(
         dim = dim,
         hiddenDim = hiddenDim,
-        name = getDefaultName(id, "GeGLUFFN", modules.size)
+        name = getDefaultName(id, "GeGLUFFN", modules.size),
+        dtype = kClass
     )
 }
 

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/normalization/RMSNormalization.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/normalization/RMSNormalization.kt
@@ -54,7 +54,10 @@ public class RMSNormalization<T : DType, V>(
      * uniform output logits. Default `false` matches LLaMA / Mistral / GPT
      * conventions.
      */
-    private val unitOffset: Boolean = false
+    private val unitOffset: Boolean = false,
+    // Logical element type prescribed by the DSL; keeps the placeholder weight
+    // typed so the module traces before real weights load.
+    private val dtype: KClass<T>? = null,
 ) : Module<T, V>(), ModuleParameters<T, V> {
 
     override val params: List<ModuleParameter<T, V>> = listOf(
@@ -78,7 +81,7 @@ public class RMSNormalization<T : DType, V>(
                 override fun get(vararg indices: Int): V = placeholder as V
                 override fun set(vararg indices: Int, value: V) {}
             },
-            Any::class as KClass<T>
+            (dtype ?: Any::class) as KClass<T>
         )
     }
 

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/GeGLUFFN.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/GeGLUFFN.kt
@@ -27,7 +27,9 @@ import kotlin.reflect.KClass
 public class GeGLUFFN<T : DType, V>(
     public val dim: Int,
     public val hiddenDim: Int,
-    override val name: String = "GeGLUFFN"
+    override val name: String = "GeGLUFFN",
+    // Logical element type prescribed by the DSL; keeps placeholder weights typed.
+    private val dtype: KClass<T>? = null,
 ) : Module<T, V>(), ModuleParameters<T, V> {
 
     @Suppress("UNCHECKED_CAST")
@@ -38,7 +40,7 @@ public class GeGLUFFN<T : DType, V>(
                 override fun get(vararg indices: Int): V = 0.0f as V
                 override fun set(vararg indices: Int, value: V) {}
             },
-            Any::class as KClass<T>
+            (dtype ?: Any::class) as KClass<T>
         )
         return ModuleParameter.WeightParameter(paramName, tensor)
     }

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/LayerScalarMul.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/LayerScalarMul.kt
@@ -35,7 +35,9 @@ import kotlin.reflect.KClass
  */
 @Suppress("UNCHECKED_CAST")
 public class LayerScalarMul<T : DType, V>(
-    override val name: String = "LayerScalarMul"
+    override val name: String = "LayerScalarMul",
+    // Logical element type prescribed by the DSL; keeps placeholder weight typed.
+    private val dtype: KClass<T>? = null,
 ) : Module<T, V>(), ModuleParameters<T, V> {
 
     private fun onesPlaceholder(): VoidOpsTensor<T, V> = VoidOpsTensor(
@@ -44,7 +46,7 @@ public class LayerScalarMul<T : DType, V>(
             override fun get(vararg indices: Int): V = 1.0f as V
             override fun set(vararg indices: Int, value: V) {}
         },
-        Any::class as KClass<T>
+        (dtype ?: Any::class) as KClass<T>
     )
 
     override val params: List<ModuleParameter<T, V>> = listOf(

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
@@ -164,11 +164,11 @@ public class MultiHeadAttention<T : DType, V>(
 
     // Optional QK-Norm layers
     public val qNorm: RMSNormalization<T, V>? = if (qkNorm) {
-        RMSNormalization(intArrayOf(headDim), eps = qkNormEps, name = "$name.q_norm", unitOffset = qkNormUnitOffset)
+        RMSNormalization(intArrayOf(headDim), eps = qkNormEps, name = "$name.q_norm", unitOffset = qkNormUnitOffset, dtype = dtype)
     } else null
 
     public val kNorm: RMSNormalization<T, V>? = if (qkNorm) {
-        RMSNormalization(intArrayOf(headDim), eps = qkNormEps, name = "$name.k_norm", unitOffset = qkNormUnitOffset)
+        RMSNormalization(intArrayOf(headDim), eps = qkNormEps, name = "$name.k_norm", unitOffset = qkNormUnitOffset, dtype = dtype)
     } else null
 
     @Suppress("UNCHECKED_CAST")

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
@@ -94,7 +94,11 @@ public class MultiHeadAttention<T : DType, V>(
      * attends to keys within `slidingWindow` positions back (inclusive). Used
      * by Gemma 4 local-attention layers. Null = no windowing.
      */
-    public val slidingWindow: Int? = null
+    public val slidingWindow: Int? = null,
+    // Logical element type prescribed by the DSL. When provided, placeholder
+    // (void) projection/bias weights carry it instead of erasing to Object — so
+    // the module can be traced to a graph (and StableHLO) before weights load.
+    private val dtype: KClass<T>? = null,
 ) : Module<T, V>(), ModuleParameters<T, V> {
 
     init {
@@ -121,7 +125,7 @@ public class MultiHeadAttention<T : DType, V>(
                 override fun get(vararg indices: Int): V = 0.0f as V
                 override fun set(vararg indices: Int, value: V) {}
             },
-            Any::class as KClass<T>
+            (dtype ?: Any::class) as KClass<T>
         )
         return ModuleParameter.WeightParameter(paramName, tensor)
     }
@@ -134,7 +138,7 @@ public class MultiHeadAttention<T : DType, V>(
                 override fun get(vararg indices: Int): V = 0.0f as V
                 override fun set(vararg indices: Int, value: V) {}
             },
-            Any::class as KClass<T>
+            (dtype ?: Any::class) as KClass<T>
         )
         return ModuleParameter.BiasParameter(paramName, tensor)
     }

--- a/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/VoidDense.kt
+++ b/llm-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/VoidDense.kt
@@ -33,7 +33,9 @@ import kotlin.reflect.KClass
 public class VoidDense<T : DType, V>(
     override val name: String,
     public val outDim: Int,
-    public val inDim: Int
+    public val inDim: Int,
+    // Logical element type prescribed by the DSL; keeps placeholder weights typed.
+    private val dtype: KClass<T>? = null,
 ) : Module<T, V>(), ModuleParameters<T, V> {
 
     private fun voidTensor(shape: Shape): VoidOpsTensor<T, V> = VoidOpsTensor(
@@ -42,7 +44,7 @@ public class VoidDense<T : DType, V>(
             override fun get(vararg indices: Int): V = 0.0f as V
             override fun set(vararg indices: Int, value: V) {}
         },
-        Any::class as KClass<T>
+        (dtype ?: Any::class) as KClass<T>
     )
 
     override val params: List<ModuleParameter<T, V>> = listOf(

--- a/llm-core/src/commonTest/kotlin/sk/ainet/lang/nn/transformer/SdpaTraceTest.kt
+++ b/llm-core/src/commonTest/kotlin/sk/ainet/lang/nn/transformer/SdpaTraceTest.kt
@@ -1,0 +1,59 @@
+package sk.ainet.lang.nn.transformer
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import kotlin.test.Test
+
+/**
+ * Verifies the dtype fix: a MultiHeadAttention built with `dtype = FP32::class`
+ * traces to a ComputeGraph WITHOUT loaded weights (no more "Unsupported dtype:
+ * Object"), and reports whether scaledDotProductAttention is an atomic op node
+ * or decomposes into matmul/softmax/transpose — which decides where its
+ * StableHLO converter lives.
+ */
+class SdpaTraceTest {
+    @Test
+    fun traceStandaloneAttention() {
+        val dim = 64
+        val seqLen = 4
+        val mha = MultiHeadAttention<FP32, Float>(
+            dim = dim,
+            nHeads = 2,
+            nKVHeads = 1,
+            causal = true,
+            dtype = FP32::class,
+        )
+
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(seqLen, dim)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val (tape, _) = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                mha.forward(input, this as ExecutionContext)
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }
+        val graph = (tape as DefaultExecutionTape).toComputeGraph()
+        val opTypes = graph.nodes.map { it.operationName }
+        println("=== MHA traced: ${graph.nodes.size} op nodes ===")
+        opTypes.groupingBy { it }.eachCount().toSortedMap().forEach { (k, v) -> println("  $k x$v") }
+        println("SDPA atomic? -> " + opTypes.any { it.contains("ScaledDot", true) || it.contains("Attention", true) })
+    }
+}

--- a/llm-inference/gemma/build.gradle.kts
+++ b/llm-inference/gemma/build.gradle.kts
@@ -101,3 +101,6 @@ tasks.matching { it.name == "jsBrowserTest" || it.name == "wasmJsBrowserTest" }.
         ?.failOnNoDiscoveredTests = false
     enabled = includeBrowserTests
 }
+
+// Real-model (FunctionGemma-270M) load test dequantizes ~270M params to FP32 (~1GB).
+tasks.withType<Test>().configureEach { maxHeapSize = "8g" }

--- a/llm-inference/gemma/build.gradle.kts
+++ b/llm-inference/gemma/build.gradle.kts
@@ -58,6 +58,8 @@ kotlin {
             implementation(project.dependencies.platform(project(":llm-bom")))
             implementation(libs.kotlin.test)
             implementation(libs.skainet.backend.cpu)
+            // Test-only: trace gemmaNetwork to a ComputeGraph (dtype-fix verification).
+            implementation(libs.skainet.compile.dag)
         }
 
         val jvmTest by getting {

--- a/llm-inference/gemma/build.gradle.kts
+++ b/llm-inference/gemma/build.gradle.kts
@@ -58,8 +58,9 @@ kotlin {
             implementation(project.dependencies.platform(project(":llm-bom")))
             implementation(libs.kotlin.test)
             implementation(libs.skainet.backend.cpu)
-            // Test-only: trace gemmaNetwork to a ComputeGraph (dtype-fix verification).
+            // Test-only: trace gemmaNetwork to a ComputeGraph + lower to StableHLO.
             implementation(libs.skainet.compile.dag)
+            implementation(libs.skainet.compile.hlo)
         }
 
         val jvmTest by getting {

--- a/llm-inference/gemma/build.gradle.kts
+++ b/llm-inference/gemma/build.gradle.kts
@@ -75,6 +75,9 @@ kotlin {
                 // in this module keeps no llm-agent coupling.
                 implementation(project(":llm-agent"))
                 implementation(libs.kotlinx.serialization.json)
+                // Test-only: write the externalized weights to an IREE .irpa
+                // parameter archive (RealGemmaBakeIrpaTest).
+                implementation(libs.skainet.io.iree.params)
             }
         }
     }
@@ -102,5 +105,9 @@ tasks.matching { it.name == "jsBrowserTest" || it.name == "wasmJsBrowserTest" }.
     enabled = includeBrowserTests
 }
 
-// Real-model (FunctionGemma-270M) load test dequantizes ~270M params to FP32 (~1GB).
-tasks.withType<Test>().configureEach { maxHeapSize = "8g" }
+// Real-model (FunctionGemma-270M) tests dequantize ~270M params to FP32 and the
+// bake-to-irpa test holds weights + serialized bytes simultaneously; allow an
+// override via -PgemmaTestMaxHeap (default 8g).
+tasks.withType<Test>().configureEach {
+    maxHeapSize = (findProperty("gemmaTestMaxHeap") as? String) ?: "8g"
+}

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4WeightLoader.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4WeightLoader.kt
@@ -275,7 +275,7 @@ public class Gemma4WeightLoader private constructor(
         tensors: List<ReaderTensor>
     ): Gemma4ModelMetadata {
         val arch = fields["general.architecture"]?.stringValue() ?: "unknown"
-        val prefix = findArchPrefix(fields, listOf("gemma4", "gemma", "llama"))
+        val prefix = findArchPrefix(fields, listOf("gemma3", "gemma4", "gemma", "llama"))
 
         val embeddingLength = fields["$prefix.embedding_length"]?.scalarInt()
             ?: inferEmbeddingFromTensor(tensors)
@@ -358,7 +358,7 @@ public class Gemma4WeightLoader private constructor(
         tensors: List<StreamingTensorInfo>
     ): Gemma4ModelMetadata {
         val arch = (fields["general.architecture"] as? String) ?: "unknown"
-        val prefix = findStreamingArchPrefix(fields, listOf("gemma4", "gemma", "llama"))
+        val prefix = findStreamingArchPrefix(fields, listOf("gemma3", "gemma4", "gemma", "llama"))
 
         val embeddingLength = fields["$prefix.embedding_length"]?.toIntValue()
             ?: inferEmbeddingFromStreamingTensor(tensors)

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4WeightLoader.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/Gemma4WeightLoader.kt
@@ -301,9 +301,10 @@ public class Gemma4WeightLoader private constructor(
             ?: (embeddingLength * 4)
         val slidingWindow = fields["$prefix.attention.sliding_window"]?.scalarInt()
             ?: Gemma4ModelMetadata.DEFAULT_SLIDING_WINDOW
+        // See streaming-path note: absent KV-sharing key ⇒ no sharing (0).
         val kvSharedLayers = fields["$prefix.attention.shared_kv_layers"]?.scalarInt()
             ?: fields["$prefix.kv_shared_layers"]?.scalarInt()
-            ?: Gemma4ModelMetadata.DEFAULT_KV_SHARED_LAYERS
+            ?: 0
         val perLayerEmbeddingLength = fields["$prefix.embedding_length_per_layer_input"]?.scalarInt() ?: 0
 
         val layerTypes = extractLayerTypes(fields, prefix, blockCount)
@@ -383,9 +384,14 @@ public class Gemma4WeightLoader private constructor(
             ?: (embeddingLength * 4)
         val slidingWindow = fields["$prefix.attention.sliding_window"]?.toIntValue()
             ?: Gemma4ModelMetadata.DEFAULT_SLIDING_WINDOW
+        // KV-sharing only applies when the gguf explicitly declares it (gemma3n
+        // / gemma-4). A plain gemma3 checkpoint (e.g. FunctionGemma-270M) omits
+        // the key and uses no KV-sharing — default 0, NOT DEFAULT_KV_SHARED_LAYERS
+        // (20), which on an 18-layer model gives firstSharedLayer = 18-20 = -2
+        // and crashes GemmaNetworkDef.
         val kvSharedLayers = fields["$prefix.attention.shared_kv_layers"]?.toIntValue()
             ?: fields["$prefix.kv_shared_layers"]?.toIntValue()
-            ?: Gemma4ModelMetadata.DEFAULT_KV_SHARED_LAYERS
+            ?: 0
         val perLayerEmbeddingLength = fields["$prefix.embedding_length_per_layer_input"]?.toIntValue() ?: 0
 
         val layerTypes = extractStreamingLayerTypes(fields, prefix, blockCount)

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
@@ -160,7 +160,7 @@ public fun <T : DType, V> gemmaNetwork(
             nKVHeads = nKVHeads,
             causal = true,
             qkNorm = qkNorm, // Gemma 4 per-head RMSNorm on Q and K before RoPE
-            qkNormUnitOffset = true, // GGUF stores raw weight (~0.984); HF computes gain=(1+weight)~1.984
+            qkNormUnitOffset = false, // DIAG: gemma3 gguf may already bake (1+w) into q/k norm
             // gemma3 scales attention by query_pre_attn_scalar^-0.5 = 1/sqrt(head_dim)
             // (HF Gemma3Attention). null => MHA's 1/sqrt(headDim) default. The
             // prior hardcoded 1.0 (a Gemma-4 "q/k-norm makes scale 1.0" claim)

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
@@ -161,7 +161,11 @@ public fun <T : DType, V> gemmaNetwork(
             causal = true,
             qkNorm = qkNorm, // Gemma 4 per-head RMSNorm on Q and K before RoPE
             qkNormUnitOffset = true, // GGUF stores raw weight (~0.984); HF computes gain=(1+weight)~1.984
-            attentionScale = 1.0f, // Gemma 4: HF Gemma4TextAttention uses scaling=1.0 (q/k norms already unit-RMS)
+            // gemma3 scales attention by query_pre_attn_scalar^-0.5 = 1/sqrt(head_dim)
+            // (HF Gemma3Attention). null => MHA's 1/sqrt(headDim) default. The
+            // prior hardcoded 1.0 (a Gemma-4 "q/k-norm makes scale 1.0" claim)
+            // over-sharpened softmax for >1 token => parity broke at pos>=1.
+            attentionScale = null,
             vNormNoScale = true, // Gemma 4: v_norm = Gemma4RMSNorm(head_dim, with_scale=False)
             id = "attn",
             slidingWindow = slidingWindow

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
@@ -166,7 +166,10 @@ public fun <T : DType, V> gemmaNetwork(
             // prior hardcoded 1.0 (a Gemma-4 "q/k-norm makes scale 1.0" claim)
             // over-sharpened softmax for >1 token => parity broke at pos>=1.
             attentionScale = null,
-            vNormNoScale = true, // Gemma 4: v_norm = Gemma4RMSNorm(head_dim, with_scale=False)
+            // gemma3 has NO v_norm (gguf carries no attn_v_norm tensor; only
+            // q/k norm). vNormNoScale=true applied a spurious parameterless V
+            // RMS-normalization llama.cpp/HF don't do.
+            vNormNoScale = false,
             id = "attn",
             slidingWindow = slidingWindow
         ) {

--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkDef.kt
@@ -245,7 +245,8 @@ public fun <T : DType, V> gemmaNetwork(
         // HF calls this self.layer_scalar = torch.ones(1), applied as
         // `hidden_states *= self.layer_scalar` at the end of the block.
         if (layerOutputScale) stage.modules += LayerScalarMul<T, V>(
-            name = "blk.$layer.layer_output_scale"
+            name = "blk.$layer.layer_output_scale",
+            dtype = dtype
         )
 
         dslImpl.modules += HybridTransformerBlock(stage.modules.toList(), name = "blk.$layer")
@@ -255,7 +256,7 @@ public fun <T : DType, V> gemmaNetwork(
     // Void placeholder for output projection — Gemma 4 E2B vocab is 262 144
     // and dense(vocabSize) would eagerly allocate ~1.5 GB of zeros before
     // WeightMapper runs.
-    dslImpl.modules += VoidDense<T, V>("output", vocabSize, dim)
+    dslImpl.modules += VoidDense<T, V>("output", vocabSize, dim, dtype = dtype)
 
     // Build the top-level GemmaModel wrapper. When PLE is disabled the model
     // runs the same forward sequence the pre-5f.5 `dslImpl.create()` wrap

--- a/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
+++ b/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
@@ -11,6 +11,7 @@ import sk.ainet.lang.types.FP32
 import sk.ainet.tape.Execution
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Verifies the dtype fix end-to-end: a tiny gemma3 network traces to a
@@ -84,6 +85,20 @@ class GemmaTraceTest {
             val ops = graph.nodes.map { it.operationName }
             println("=== gemma traced: ${graph.nodes.size} nodes ===")
             ops.groupingBy { it }.eachCount().toSortedMap().forEach { (k, v) -> println("  $k x$v") }
+
+            // Informational: lower to StableHLO and report the remaining gaps.
+            // The op-level converters (split/permute/narrow/...) are unit-tested
+            // in skainet-compile-hlo. A *full* gemma lowering additionally needs
+            // two next-phase items, surfaced here:
+            //   1. weight/param operand wiring — module weights are placeholders,
+            //      not graph edges, so gather/transpose/matmul that consume them
+            //      report arity failures (cascading).
+            //   2. a scaledDotProductAttention converter (attention subgraph).
+            val mlir = sk.ainet.compile.hlo.toStableHlo(graph, "gemma").content
+            val unsupported = mlir.lines().filter { it.contains("Unsupported op", ignoreCase = true) }
+            val arity = mlir.lines().filter { it.contains("arity", ignoreCase = true) }
+            println("=== StableHLO: ${mlir.lines().size} lines; ${unsupported.size} unsupported-op, ${arity.size} arity gaps ===")
+            (unsupported + arity).take(12).forEach { println("  GAP $it") }
         }
     }
 }

--- a/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
+++ b/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
@@ -73,6 +73,7 @@ class GemmaTraceTest {
         // a dtype problem.
         val msg = thrown?.message ?: ""
         println("trace outcome: ${if (thrown == null) "completed" else thrown::class.simpleName + ": " + msg}")
+        thrown?.stackTraceToString()?.lines()?.take(14)?.forEach { println("  STACK $it") }
         assertFalse(
             msg.contains("Unsupported dtype", ignoreCase = true) || msg.contains("for zeros: class java.lang.Object"),
             "dtype fix regressed — placeholder weights are erasing to Object again: $msg",

--- a/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
+++ b/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
@@ -81,7 +81,11 @@ class GemmaTraceTest {
         )
 
         if (tape != null) {
-            val graph = (tape as DefaultExecutionTape).toComputeGraph()
+            // synthesizeExternalInputs=true runs finalize(), which materializes
+            // module weights / model inputs as graph nodes (input/constant) and
+            // wires them as operands — required so gather/transpose/matmul get
+            // their weight operand (otherwise: arity-failure cascade).
+            val graph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
             val ops = graph.nodes.map { it.operationName }
             println("=== gemma traced: ${graph.nodes.size} nodes ===")
             ops.groupingBy { it }.eachCount().toSortedMap().forEach { (k, v) -> println("  $k x$v") }

--- a/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
+++ b/llm-inference/gemma/src/commonTest/kotlin/sk/ainet/models/gemma/GemmaTraceTest.kt
@@ -1,0 +1,88 @@
+package sk.ainet.models.gemma
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+/**
+ * Verifies the dtype fix end-to-end: a tiny gemma3 network traces to a
+ * ComputeGraph WITHOUT loaded weights (no "Unsupported dtype: Object").
+ * Prints the recorded op histogram — the input to the StableHLO converter set.
+ */
+class GemmaTraceTest {
+    @Test
+    fun traceTinyGemmaNetwork() {
+        val meta = Gemma4ModelMetadata(
+            architecture = "gemma3",
+            embeddingLength = 64,
+            contextLength = 128,
+            blockCount = 1,
+            headCount = 2,
+            kvHeadCount = 1,
+            intermediateSize = 128,
+            headDim = 32,
+            globalHeadDim = 32,
+            vocabSize = 32,
+            slidingWindow = 64,
+            kvSharedLayers = 0,
+            layerTypes = listOf("full_attention"),
+            ropeParametersFull = Gemma4RopeConfig(base = 10000.0f),
+            ropeParametersSliding = Gemma4RopeConfig(base = 10000.0f),
+            maxPositionEmbeddings = 128,
+        )
+        val model = gemmaNetwork<FP32, Float>(meta, FP32::class, maxInferenceLen = 8)
+
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(1, 4)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        var thrown: Throwable? = null
+        val tape = try {
+            ctx.record {
+                val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+                Execution.tapeStack.pushTape(ct)
+                try {
+                    model.forward(input, this as ExecutionContext)
+                } finally {
+                    Execution.tapeStack.popTape()
+                }
+            }.first
+        } catch (e: Throwable) {
+            thrown = e
+            null
+        }
+
+        // The dtype fix is verified by NOT seeing the "Unsupported dtype: Object"
+        // crash that previously aborted at the first placeholder weight. Any
+        // remaining failure is a separate VoidTensorOps tracing-stub limitation
+        // (e.g. the void gather returns one row -> reshape volume mismatch), not
+        // a dtype problem.
+        val msg = thrown?.message ?: ""
+        println("trace outcome: ${if (thrown == null) "completed" else thrown::class.simpleName + ": " + msg}")
+        assertFalse(
+            msg.contains("Unsupported dtype", ignoreCase = true) || msg.contains("for zeros: class java.lang.Object"),
+            "dtype fix regressed — placeholder weights are erasing to Object again: $msg",
+        )
+
+        if (tape != null) {
+            val graph = (tape as DefaultExecutionTape).toComputeGraph()
+            val ops = graph.nodes.map { it.operationName }
+            println("=== gemma traced: ${graph.nodes.size} nodes ===")
+            ops.groupingBy { it }.eachCount().toSortedMap().forEach { (k, v) -> println("  $k x$v") }
+        }
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/GemmaBehavioralAbTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/GemmaBehavioralAbTest.kt
@@ -1,0 +1,98 @@
+package sk.ainet.models.gemma
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behavioral A/B vs the Python FunctionGemma app: same Octopus-v2 prompt, greedy
+ * decode through the REAL SKaiNET DSL runtime (OptimizedLLMRuntime, eager), and
+ * assert the generated token sequence + decoded `<tool_N>(args)<end>` match
+ * llama.cpp (reference captured by build-mlir/ab_generate_llama.py -> gen_*.json).
+ * Generation is driven from llama's prompt tokens to isolate it from
+ * tokenization; tokenizer parity is asserted separately.
+ */
+class GemmaBehavioralAbTest {
+    private val gguf = "/home/miso/projects/coral/sl2610-voice-cc-kt/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+
+    private fun argmax(a: FloatArray): Int {
+        var bi = 0; var bv = a[0]
+        for (i in 1 until a.size) if (a[i] > bv) { bv = a[i]; bi = i }
+        return bi
+    }
+
+    private fun buildPrompt(u: String) = "<start_of_turn>user\n$u<end_of_turn>\n<start_of_turn>model\n"
+
+    @Test
+    fun behavioralParity() = runBlocking {
+        val ctx = DirectCpuExecutionContext.create()
+        val tokenizer = GGUFTokenizer.fromSource(SystemFileSystem.source(Path(gguf)).buffered())
+        val weights = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(gguf) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+        val model = GemmaNetworkLoader.fromWeights(ctx, weights, FP32::class)
+        val runtime = OptimizedLLMRuntime(
+            model = model, ctx = ctx, mode = OptimizedLLMMode.DIRECT,
+            dtype = FP32::class, bos = tokenizer.bosTokenId,
+        )
+        val eot = tokenizer.encode("<end_of_turn>").single()
+        val eos = tokenizer.eosTokenId
+        println("EOT=$eot EOS=$eos BOS=${tokenizer.bosTokenId}")
+
+        val outDir = File("/home/miso/projects/coral/build-mlir/out")
+        var allMatch = true
+        var i = 0
+        while (true) {
+            val f = File(outDir, "gen_$i.json"); if (!f.exists()) break
+            val rec = Json.parseToJsonElement(f.readText()) as JsonObject
+            val prompt = rec["prompt"]!!.jsonPrimitive.content
+            val promptTokens = rec["prompt_tokens"]!!.jsonArray.map { it.jsonPrimitive.int }
+            val refGen = rec["gen_tokens"]!!.jsonArray.map { it.jsonPrimitive.int }
+            val refRaw = rec["raw"]!!.jsonPrimitive.content
+
+            // (1) tokenizer parity: our encode (+bos) vs llama's prompt_tokens.
+            val enc = tokenizer.encode(buildPrompt(prompt))
+            val encWithBos = listOf(tokenizer.bosTokenId) + enc.toList()
+            val tokOk = encWithBos == promptTokens
+            println("[$i] '$prompt' tokenizer ${if (tokOk) "MATCH" else "DIFF enc=$encWithBos vs ref=$promptTokens"}")
+
+            // (2) generation: feed llama's prompt tokens, greedy decode.
+            runtime.reset()
+            var logits = FloatArray(0)
+            for (t in promptTokens) logits = runtime.forward(t).data.copyToFloatArray()
+            val gen = mutableListOf<Int>()
+            while (gen.size < 48) {
+                val next = argmax(logits)
+                if (next == eos) break
+                gen.add(next)
+                if (next == eot) break
+                logits = runtime.forward(next).data.copyToFloatArray()
+            }
+            val raw = tokenizer.decode(gen.toIntArray())
+            val genOk = gen == refGen
+            println("    gen ${if (genOk) "MATCH" else "DIFF"} ours=$gen")
+            println("    ref =$refGen")
+            println("    raw ours=${raw.replace("\n", "\\n")}  ref=${refRaw.replace("\n", "\\n")}")
+            allMatch = allMatch && tokOk && genOk
+            i++
+        }
+        assertEquals(true, allMatch, "behavioral parity failed (see DIFF above)")
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/GemmaMlirDumpTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/GemmaMlirDumpTest.kt
@@ -1,0 +1,64 @@
+package sk.ainet.models.gemma
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.test.Test
+
+/** Dumps the lowered gemma3 StableHLO to a file for iree-compile (CPU/NEON). */
+class GemmaMlirDumpTest {
+    @Test
+    fun dumpGemmaMlir() {
+        val meta = Gemma4ModelMetadata(
+            architecture = "gemma3",
+            embeddingLength = 64,
+            contextLength = 128,
+            blockCount = 1,
+            headCount = 2,
+            kvHeadCount = 1,
+            intermediateSize = 128,
+            headDim = 32,
+            globalHeadDim = 32,
+            vocabSize = 32,
+            slidingWindow = 64,
+            kvSharedLayers = 0,
+            layerTypes = listOf("full_attention"),
+            ropeParametersFull = Gemma4RopeConfig(base = 10000.0f),
+            ropeParametersSliding = Gemma4RopeConfig(base = 10000.0f),
+            maxPositionEmbeddings = 128,
+        )
+        val model = gemmaNetwork<FP32, Float>(meta, FP32::class, maxInferenceLen = 8)
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(1, 4)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                model.forward(input, this as ExecutionContext)
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
+        val mlir = sk.ainet.compile.hlo.toStableHlo(graph, "gemma").content
+
+        val out = File(System.getProperty("gemmaMlirOut") ?: "/home/miso/projects/coral/build-mlir/gemma.mlir")
+        out.parentFile?.mkdirs()
+        out.writeText(mlir)
+        println("WROTE_MLIR ${out.absolutePath} (${mlir.lines().size} lines)")
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaBakeIrpaTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaBakeIrpaTest.kt
@@ -39,7 +39,17 @@ class RealGemmaBakeIrpaTest {
             randomAccessProvider = { JvmRandomAccessSource.open(path) },
             quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
         ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
-        val model = GemmaNetworkLoader.fromWeights(ctx, weights, FP32::class)
+        // gemma3 uses FULL rotary; the gguf omits rope.partial_rotary_factor so
+        // the loader defaulted to 0.25 (a Gemma-4 convention) which mis-rotates
+        // global layers. Override via -DpartialRotary (default 1.0).
+        val partial = (System.getProperty("partialRotary") ?: "1.0").toFloat()
+        val patched = weights.copy(
+            metadata = weights.metadata.copy(
+                ropeParametersFull = weights.metadata.ropeParametersFull.copy(partialRotaryFactor = partial),
+            ),
+        )
+        println("PARTIAL_ROTARY $partial")
+        val model = GemmaNetworkLoader.fromWeights(ctx, patched, FP32::class)
 
         // Disable per-layer KV caches before tracing. KVCache.update() does raw
         // copyToFloatArray (non-traceable); under VoidTensorOps it returns a

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaBakeIrpaTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaBakeIrpaTest.kt
@@ -1,0 +1,87 @@
+package sk.ainet.models.gemma
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import sk.ainet.compile.hlo.ConstantMaterializationPolicy
+import sk.ainet.compile.hlo.StableHloConverterFactory
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.irpa.IrpaWriter
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * Bake the REAL FunctionGemma-270M to a self-contained IREE artifact:
+ * fromWeights (real topology + real weights) -> trace (embedConstants=true,
+ * resolves the bound weights) -> StableHLO with ExternalAlways so every weight
+ * becomes a `util.global.load` + ExternalParameterRef -> IrpaWriter writes the
+ * .irpa. The emitted vmfb then takes ONLY the token input; weights resolve from
+ * the archive via `iree-run-module --parameters=model=gemma.irpa`. No 361-arg
+ * mapping, no host-side RoPE reproduction. Boxing-free (FloatArray) path.
+ */
+class RealGemmaBakeIrpaTest {
+    @Test
+    fun bakeRealGemmaToIrpa() = runBlocking {
+        val path = "/home/miso/projects/coral/sl2610-voice-cc-kt/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+        val ctx = DirectCpuExecutionContext.create()
+        val weights = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(path) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+        val model = GemmaNetworkLoader.fromWeights(ctx, weights, FP32::class)
+
+        val seqLen = (System.getProperty("seqLen") ?: "4").toInt()
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(1, seqLen)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+        val tapeCtx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = tapeCtx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try { model.forward(input, this as ExecutionContext) } finally { Execution.tapeStack.popTape() }
+        }.first
+        // embedConstants=true: finalize resolves the bound weights (now stored
+        // as primitive FloatArray, no .toList() boxing). ExternalAlways lifts
+        // every weight into the .irpa.
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(
+            synthesizeExternalInputs = true, embedConstants = true,
+        )
+        val module = StableHloConverterFactory
+            .createBasic(ConstantMaterializationPolicy.ExternalAlways(scope = "model"))
+            .convert(graph, "gemma")
+
+        val outDir = File("/home/miso/projects/coral/build-mlir").apply { mkdirs() }
+        File(outDir, "gemma-baked.mlir").writeText(module.content)
+
+        val ext = module.externalParameters
+        val funcArgs = module.content.lineSequence().firstOrNull { it.contains("func.func @gemma(") }
+            ?.let { Regex("%arg\\d+").findAll(it).count() } ?: -1
+        val globals = module.content.lineSequence().count { it.trimStart().startsWith("util.global ") }
+        val totalBytes = ext.sumOf { it.source.sizeInBytes }
+        println("EXTPARAMS ${ext.size} totalMiB=${totalBytes / (1024 * 1024)}")
+        println("FUNCARGS $funcArgs UTILGLOBALS $globals MLIRlines=${module.content.lines().size}")
+
+        val irpa = File(outDir, "gemma.irpa")
+        SystemFileSystem.sink(Path(irpa.absolutePath)).buffered().use { sink ->
+            IrpaWriter().write(ext, sink)
+        }
+        println("WROTE_IRPA ${irpa.absolutePath} sizeMiB=${irpa.length() / (1024 * 1024)}")
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaBakeIrpaTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaBakeIrpaTest.kt
@@ -1,18 +1,17 @@
 package sk.ainet.models.gemma
 
 import kotlinx.coroutines.runBlocking
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 import sk.ainet.compile.hlo.ConstantMaterializationPolicy
 import sk.ainet.compile.hlo.StableHloConverterFactory
 import sk.ainet.context.DirectCpuExecutionContext
 import sk.ainet.context.ExecutionContext
 import sk.ainet.io.JvmRandomAccessSource
-import sk.ainet.io.irpa.IrpaWriter
 import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.tensor.storage.BufferHandle
 import sk.ainet.lang.graph.DefaultExecutionTape
 import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.transformer.MultiHeadAttention
 import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.tensor.VoidOpsTensor
 import sk.ainet.lang.tensor.data.TensorData
@@ -41,6 +40,17 @@ class RealGemmaBakeIrpaTest {
             quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
         ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
         val model = GemmaNetworkLoader.fromWeights(ctx, weights, FP32::class)
+
+        // Disable per-layer KV caches before tracing. KVCache.update() does raw
+        // copyToFloatArray (non-traceable); under VoidTensorOps it returns a
+        // zero [1,seq,headDim] leaf for K and V -> 36 zero "frozen params" that
+        // kill RoPE/attention in the export. A single prefill pass needs no
+        // cache: K/V are computed fresh for all positions and stay traceable.
+        fun stripKvCache(m: Module<*, *>) {
+            if (m is MultiHeadAttention<*, *>) m.kvCache = null
+            m.modules.forEach { stripKvCache(it) }
+        }
+        stripKvCache(model)
 
         val seqLen = (System.getProperty("seqLen") ?: "4").toInt()
         val input = VoidOpsTensor(
@@ -78,10 +88,32 @@ class RealGemmaBakeIrpaTest {
         println("EXTPARAMS ${ext.size} totalMiB=${totalBytes / (1024 * 1024)}")
         println("FUNCARGS $funcArgs UTILGLOBALS $globals MLIRlines=${module.content.lines().size}")
 
-        val irpa = File(outDir, "gemma.irpa")
-        SystemFileSystem.sink(Path(irpa.absolutePath)).buffered().use { sink ->
-            IrpaWriter().write(ext, sink)
+        // Write a safetensors keyed t0..tN (1-D, size-equivalent; IREE accepts
+        // size-equivalent params and the util.global carries the real shape).
+        // iree-convert-parameters turns this into a valid .irpa — bypassing
+        // SKaiNET's IrpaWriter, whose header is not yet IREE-v0 compatible.
+        var off = 0L
+        val hdr = StringBuilder("{")
+        ext.forEachIndexed { i, e ->
+            val len = e.source.sizeInBytes
+            val count = len / 4
+            if (i > 0) hdr.append(",")
+            hdr.append("\"${e.key}\":{\"dtype\":\"F32\",\"shape\":[$count],\"data_offsets\":[$off,${off + len}]}")
+            off += len
         }
-        println("WROTE_IRPA ${irpa.absolutePath} sizeMiB=${irpa.length() / (1024 * 1024)}")
+        hdr.append("}")
+        val headerBytes = hdr.toString().encodeToByteArray()
+        val st = File(outDir, "gemma.safetensors")
+        java.io.BufferedOutputStream(java.io.FileOutputStream(st), 1 shl 20).use { os ->
+            val lenBuf = java.nio.ByteBuffer.allocate(8).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+                .putLong(headerBytes.size.toLong())
+            os.write(lenBuf.array())
+            os.write(headerBytes)
+            for (e in ext) {
+                val src = e.source as BufferHandle.Owned
+                os.write(src.data, src.offset, src.sizeInBytes.toInt())
+            }
+        }
+        println("WROTE_SAFETENSORS ${st.absolutePath} sizeMiB=${st.length() / (1024 * 1024)}")
     }
 }

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaEagerAbTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaEagerAbTest.kt
@@ -1,0 +1,64 @@
+package sk.ainet.models.gemma
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.transformer.MultiHeadAttention
+import sk.ainet.lang.types.FP32
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * Eager-vs-llama.cpp split. Runs the REAL FunctionGemma DSL network EAGERLY
+ * (DirectCpuExecutionContext, real ops) on the SAME 4 tokens fed to llama.cpp
+ * and the baked vmfb. Writes logits to a raw .bin for comparison:
+ *   - eager vs llama.cpp  -> isolates DSL/weights correctness (RoPE, dequant, norms)
+ *   - vmfb  vs eager      -> isolates the StableHLO/IREE lowering
+ * KV cache stripped so the config matches the vmfb trace exactly.
+ */
+class RealGemmaEagerAbTest {
+    @Test
+    fun eagerLogits() = runBlocking {
+        val path = "/home/miso/projects/coral/sl2610-voice-cc-kt/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+        val ctx = DirectCpuExecutionContext.create()
+        val weights = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(path) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+        val partial = (System.getProperty("partialRotary") ?: "1.0").toFloat()
+        val patched = weights.copy(
+            metadata = weights.metadata.copy(
+                ropeParametersFull = weights.metadata.ropeParametersFull.copy(partialRotaryFactor = partial),
+            ),
+        )
+        val model = GemmaNetworkLoader.fromWeights(ctx, patched, FP32::class)
+        fun stripKvCache(m: Module<*, *>) {
+            if (m is MultiHeadAttention<*, *>) m.kvCache = null
+            m.modules.forEach { stripKvCache(it) }
+        }
+        stripKvCache(model)
+
+        val tokens = floatArrayOf(2f, 887f, 506f, 2214f)
+        // Eager Embedding indexes a 1-D [seq] token tensor (not [1,seq]).
+        val input = ctx.fromFloatArray<FP32, Float>(sk.ainet.lang.tensor.Shape(tokens.size), FP32::class, tokens)
+        val out = model.forward(input, ctx as ExecutionContext)
+        val logits = out.data.copyToFloatArray()
+        println("EAGER out.shape=${out.shape} logits.size=${logits.size}")
+
+        val vocab = 262153
+        val seq = logits.size / vocab
+        for (s in 0 until seq) {
+            var best = 0; var bv = Float.NEGATIVE_INFINITY
+            for (j in 0 until vocab) { val v = logits[s * vocab + j]; if (v > bv) { bv = v; best = j } }
+            println("EAGER pos$s argmax=$best maxlogit=$bv")
+        }
+        val bb = java.nio.ByteBuffer.allocate(logits.size * 4).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        for (f in logits) bb.putFloat(f)
+        val o = File("/home/miso/projects/coral/build-mlir/out/eager_logits.bin")
+        o.parentFile?.mkdirs(); o.writeBytes(bb.array())
+        println("WROTE_EAGER ${o.absolutePath} (${seq}x$vocab)")
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaExternalParamTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaExternalParamTest.kt
@@ -1,0 +1,87 @@
+package sk.ainet.models.gemma
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.compile.hlo.ConstantMaterializationPolicy
+import sk.ainet.compile.hlo.StableHloConverterFactory
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * The production weight path: build the REAL FunctionGemma network via
+ * GemmaNetworkLoader.fromWeights (correct auto-detected topology + real weights
+ * bound to params), trace it, lower with the ExternalAlways materialization
+ * policy so every weight is lifted to a `util.global.load` + ExternalParameterRef
+ * (keyed by tensor name). Reports: does the real-topology graph lower cleanly,
+ * how many external params, and are they keyed by gguf-style names — the input
+ * to the .irpa packager + iree-compile --iree-opt-import-parameters.
+ */
+class RealGemmaExternalParamTest {
+    @Test
+    fun externalizeRealGemmaWeights() = runBlocking {
+        val path = "/home/miso/projects/coral/sl2610-voice-cc-kt/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+        val ctx = DirectCpuExecutionContext.create()
+        val weights = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(path) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+
+        // Correct topology (qkNorm/sandwich/PLE/softcap auto-detected) + real weights.
+        val model = GemmaNetworkLoader.fromWeights(ctx, weights, FP32::class)
+
+        val seqLen = (System.getProperty("seqLen") ?: "4").toInt()
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(1, seqLen)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+        val tapeCtx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = tapeCtx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                model.forward(input, this as ExecutionContext)
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+        // embedConstants=false: weights become func ARGS (shapes only, no
+        // boxing). Baking real weights via finalize().toList() OOMs at real
+        // vocab (262153x640 -> ~2.7GB boxed List<Float>); the zero-copy .irpa
+        // bake path needs a FileBacked mmap BufferHandle (not yet in SKaiNET).
+        // Weights-as-args is the deployable interface: bind weights at runtime.
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(
+            synthesizeExternalInputs = true, embedConstants = false,
+        )
+
+        val module = StableHloConverterFactory.createBasic().convert(graph, "gemma")
+        val mlir = module.content
+        val inputs = graph.nodes.filter { it.operationName.equals("input", ignoreCase = true) }
+        println("INPUTS ${inputs.size}")
+        inputs.take(14).forEach { n -> println("  ARG id=${n.id} shape=${n.outputs.firstOrNull()?.shape}") }
+        val ext = module.externalParameters
+        println("EXTPARAMS ${ext.size}")
+        val unsupported = mlir.lines().count { it.contains("Unsupported op", ignoreCase = true) }
+        val arity = mlir.lines().count { it.contains("arity", ignoreCase = true) }
+        val globals = mlir.lines().count { it.trimStart().startsWith("util.global") }
+        println("MLIR lines=${mlir.lines().size} bytes=${mlir.length} unsupported=$unsupported arity=$arity util.global=$globals")
+        val out = File("/home/miso/projects/coral/build-mlir/gemma-ext.mlir")
+        out.parentFile?.mkdirs()
+        out.writeText(mlir)
+        println("WROTE_MLIR ${out.absolutePath}")
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaLoadTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaLoadTest.kt
@@ -1,0 +1,34 @@
+package sk.ainet.models.gemma
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import kotlin.test.Test
+
+/**
+ * Loads the REAL FunctionGemma-270M gguf via the DSL-path loader
+ * (Gemma4WeightLoader + DequantOps, Q5_K -> FP32) — NOT the eager runtime.
+ * Validates: the loader handles this gemma3 gguf, and reports the real config
+ * + weight tensors for the upcoming real-config trace + arg mapping.
+ *
+ * FP32 dequant here is a correctness-first choice (clean FP32 A/B); production
+ * would keep weights packed (QuantPolicy.NATIVE_OPTIMIZED) for memory/NPU.
+ */
+class RealGemmaLoadTest {
+    @Test
+    fun loadFunctionGemmaWeights() = runBlocking {
+        val path = "/home/miso/projects/coral/sl2610-voice-cc-kt/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+        val ctx = DirectCpuExecutionContext.create()
+        val loader = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(path) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        )
+        val w = loader.loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+        val m = w.metadata
+        println("REALCFG emb=${m.embeddingLength} layers=${m.blockCount} heads=${m.headCount} kv=${m.kvHeadCount} headDim=${m.headDim} ffn=${m.intermediateSize} vocab=${m.vocabSize} sliding=${m.slidingWindow}")
+        println("TENSORS ${w.tensors.size}")
+        w.tensors.entries.sortedBy { it.key }.take(6).forEach { println("  ${it.key} ${it.value.shape}") }
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaMlirDumpTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaMlirDumpTest.kt
@@ -1,0 +1,91 @@
+package sk.ainet.models.gemma
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * Dumps the REAL FunctionGemma-270M gemma3 config (640/18/heads4/kv1/headDim256/
+ * ffn2048/vocab262153/sliding512) to StableHLO for iree-compile, AND dumps the
+ * ordered graph input nodes (id, shape) — the data we need to map gguf weights
+ * onto the vmfb function args (trace input nodes carry tensor ids, not names).
+ */
+class RealGemmaMlirDumpTest {
+    @Test
+    fun dumpRealGemmaMlir() {
+        val meta = Gemma4ModelMetadata(
+            architecture = "gemma3",
+            embeddingLength = 640,
+            contextLength = 512,
+            blockCount = 18,
+            headCount = 4,
+            kvHeadCount = 1,
+            intermediateSize = 2048,
+            headDim = 256,
+            globalHeadDim = 256,
+            vocabSize = 262153,
+            slidingWindow = 512,
+            kvSharedLayers = 0,
+            layerTypes = List(18) { "full_attention" },
+            ropeParametersFull = Gemma4RopeConfig(base = 1000000.0f),
+            ropeParametersSliding = Gemma4RopeConfig(base = 10000.0f),
+            maxPositionEmbeddings = 512,
+        )
+        val seqLen = (System.getProperty("seqLen") ?: "4").toInt()
+        val model = gemmaNetwork<FP32, Float>(meta, FP32::class, maxInferenceLen = seqLen)
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(1, seqLen)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                model.forward(input, this as ExecutionContext)
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+        // embedConstants=false: every leaf weight (incl. block-level RMSNorm
+        // weights, which otherwise self-resolve to default zeros/ones and get
+        // baked as constants) becomes an external input -> a complete
+        // weights-as-args interface to bind real gguf values onto.
+        val embed = (System.getProperty("embedConstants") ?: "false").toBoolean()
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(
+            synthesizeExternalInputs = true,
+            embedConstants = embed,
+        )
+
+        // Ordered graph input nodes = the vmfb function-arg order. Dump id+shape
+        // so we can build the gguf-tensor -> arg map.
+        val inputs = graph.nodes.filter { it.operationName.equals("input", ignoreCase = true) }
+        println("INPUTS ${inputs.size}")
+        inputs.forEachIndexed { i, n ->
+            val shp = n.outputs.firstOrNull()?.shape
+            println("  ARG$i id=${n.id} shape=$shp")
+        }
+        println("NODES ${graph.nodes.size}")
+
+        val mlir = sk.ainet.compile.hlo.toStableHlo(graph, "gemma").content
+        val unsupported = mlir.lines().count { it.contains("Unsupported op", ignoreCase = true) }
+        val arity = mlir.lines().count { it.contains("arity", ignoreCase = true) }
+        println("MLIR lines=${mlir.lines().size} unsupported=$unsupported arity=$arity")
+        val out = File(System.getProperty("gemmaMlirOut") ?: "/home/miso/projects/coral/build-mlir/gemma-real.mlir")
+        out.parentFile?.mkdirs()
+        out.writeText(mlir)
+        println("WROTE_MLIR ${out.absolutePath}")
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RopeNeoxParityTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RopeNeoxParityTest.kt
@@ -1,0 +1,54 @@
+package sk.ainet.models.gemma
+
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.transformer.RoPE
+import sk.ainet.lang.nn.transformer.RoPEMode
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.test.Test
+
+/**
+ * Does SKaiNET's SPLIT_HALF RoPE match llama.cpp's GGML_ROPE_TYPE_NEOX
+ * rotation numerically? NEOX pairs x[i] with x[i+d/2], angle = pos*base^(-2i/d):
+ *   out[i]     = x[i]*cos - x[i+d/2]*sin
+ *   out[i+d/2] = x[i]*sin + x[i+d/2]*cos
+ * (gemma3 uses NEOX rope; GGUF stores Q/K in HF layout, no permute for NEOX.)
+ */
+class RopeNeoxParityTest {
+    @Test
+    fun splitHalfMatchesNeox() {
+        val headDim = 8
+        val seq = 3
+        val base = 10000.0f
+        val ctx = DirectCpuExecutionContext.create()
+        val rope = RoPE<FP32, Float>(headDim = headDim, maxSeqLen = 8, base = base, mode = RoPEMode.SPLIT_HALF)
+
+        // input: 1 head, seq positions, headDim — distinct values per slot
+        val data = FloatArray(seq * headDim) { (it + 1).toFloat() }
+        val input = ctx.fromFloatArray<FP32, Float>(Shape(1, seq, headDim), FP32::class, data)
+        val out = rope.forward(input, position = 0, ctx as ExecutionContext).data.copyToFloatArray()
+
+        val half = headDim / 2
+        val invFreq = FloatArray(half) { i -> 1.0f / base.pow(2.0f * i / headDim) }
+        var maxErr = 0.0f
+        for (s in 0 until seq) {
+            for (i in 0 until half) {
+                val a = s * invFreq[i]
+                val c = cos(a); val sn = sin(a)
+                val xi = data[s * headDim + i]
+                val xj = data[s * headDim + i + half]
+                val expEven = xi * c - xj * sn
+                val expOdd = xi * sn + xj * c
+                val gotEven = out[s * headDim + i]
+                val gotOdd = out[s * headDim + i + half]
+                maxErr = maxOf(maxErr, kotlin.math.abs(expEven - gotEven), kotlin.math.abs(expOdd - gotOdd))
+                if (s <= 1 && i < 2) println("s=$s i=$i  even exp=$expEven got=$gotEven  odd exp=$expOdd got=$gotOdd")
+            }
+        }
+        println("ROPE_MAXERR $maxErr")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,13 @@ dependencyResolutionManagement {
     }
 }
 
-// Composite build for validating local SKaiNET fixes against this repo. Auto-enables
+// Composite build for validating local SKaiNET fixes against this repo.
+// Opt-in: run with -PuseLocalSkainet=true (or set useLocalSkainet=true in
+// gradle.properties) to substitute sk.ainet.core:* with a sibling ../SKaiNET
+// checkout instead of the published Maven artifacts. Off by default.
+if (providers.gradleProperty("useLocalSkainet").orNull == "true") {
+    includeBuild("../SKaiNET")
+}
 
 rootProject.name = "SKaiNET-transformers"
 


### PR DESCRIPTION
# feat(gemma): trace gemma3 to StableHLO + full FunctionGemma parity vs llama.cpp

Mirrors the core dtype work into the transformer modules and proves the full
gemma3 path: DSL → trace → StableHLO → IREE vmfb, numerically and behaviorally
matching llama.cpp on the real FunctionGemma-270M.

## What's in here
- **dtype mirror** — thread the DSL element dtype through MHA (incl. q/k-norm),
  RMSNorm, GeGLUFFN, lm-head and layer-scale placeholders so gemma3 traces
  weight-free (no `Unsupported dtype: Object`).
- **full gemma3 trace → StableHLO** — `finalize()`/`synthesizeExternalInputs`
  wires module weights as graph operands; dumps the `.mlir` for `iree-compile`.
- **real-config + real-weights** — recognize the `gemma3` arch prefix in
  `Gemma4WeightLoader`; `kvSharedLayers=0` default when the gguf omits the key;
  bake real FunctionGemma to a self-contained IREE artifact.
- **parity fixes** — attention scale `1/sqrt(head_dim)`; disable KV cache before
  tracing (RoPE/attention parity); q/k-norm baked `(1+w)` gain; no v_norm for
  gemma3 → **full llama.cpp parity**.

## Validation
- Eager-vs-llama.cpp split localizes the parity residual to each fix.
- **Behavioral A/B: byte-identical tool calls vs llama.cpp** on FunctionGemma.

## Notes
- 16 commits. **Depends on** SKaiNET core `feature/stablehlo-dtype` (converters +
  dtype). Verified against it via composite `-PuseLocalSkainet=true`; merge the
  core PR first, then this rebases onto a `develop` that already has it.
