### PR TITLE
feat(llm-runtime): add gemma-iree — on-device Gemma decode over an IREE vmfb

### DIFF
--- a/llm-runtime/gemma-iree/build.gradle.kts
+++ b/llm-runtime/gemma-iree/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.vanniktech.mavenPublish)
+}
+
+// Reusable Gemma-on-IREE runtime: the on-device decode side of the
+// DSL -> StableHLO -> IREE path. Given a compiled vmfb + its .irpa weights +
+// the matching GGUF (tokenizer), it runs the greedy decode loop and parses the
+// compact tool-call output. Pairs with the gemma3 -> StableHLO export in
+// :llm-inference:gemma (host) that produces the vmfb this module consumes.
+//
+//   commonMain  — CompactCodec + ToolCall (pure Kotlin: the tool-call grammar)
+//   native      — IreeRuntime (drives iree-run-module) + GemmaDecoder
+kotlin {
+    jvm()
+    linuxX64()
+    linuxArm64()
+
+    sourceSets {
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
+
+        // Native (board + host) gets the IREE driver + decode loop. The SL2610
+        // ships only a statically-linked iree-run-module (no libiree C API), so
+        // IreeRuntime drives it as a posix subprocess; GemmaDecoder needs the
+        // GGUF tokenizer from :llm-core and kotlinx-io for file access. nativeMain
+        // is the default-hierarchy parent of linux{X64,Arm64}Main.
+        nativeMain.dependencies {
+            implementation(project.dependencies.platform(project(":llm-bom")))
+            implementation(project(":llm-core"))
+            implementation(libs.kotlinx.io.core)
+        }
+    }
+}

--- a/llm-runtime/gemma-iree/gradle.properties
+++ b/llm-runtime/gemma-iree/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=skainet-transformers-runtime-gemma-iree
+POM_NAME=skainet gemma IREE runtime
+POM_DESCRIPTION=On-device Gemma decode over an IREE vmfb (DSL->StableHLO->IREE): IreeRuntime + GemmaDecoder + compact tool-call codec.

--- a/llm-runtime/gemma-iree/src/commonMain/kotlin/sk/ainet/transformers/gemma/iree/CompactCodec.kt
+++ b/llm-runtime/gemma-iree/src/commonMain/kotlin/sk/ainet/transformers/gemma/iree/CompactCodec.kt
@@ -1,0 +1,38 @@
+package sk.ainet.transformers.gemma.iree
+
+/**
+ * A tool call decoded from the model's output: the tool the model chose + the
+ * named args it emitted. This is the runtime's OWN type — it deliberately does
+ * NOT depend on any consuming app's action/intent type, so the module stays
+ * reusable. The consumer maps [ToolCall] onto whatever action type it uses.
+ */
+public data class ToolCall(
+    val tool: String,
+    val args: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Decodes FunctionGemma's compact tool-call format into [ToolCall]s (v10
+ * Octopus-v2 named-arg style, which the FunctionGemma fine-tune emits):
+ *   <tool_0>(state="on")<end>          -> ToolCall("set_lights", {state:on})
+ *   <tool_4>(metric="all")<end>        -> ToolCall("get_system_status", {metric:all})
+ *   <tool_5>(message="hi")<end>        -> ToolCall("respond", {message:hi})
+ */
+public object CompactCodec {
+    private val TOKEN_TO_NAME: Map<String, String?> = mapOf(
+        "0" to "set_lights", "1" to "play_buzzer", "2" to "set_alarm",
+        "3" to "cancel_alarm", "4" to "get_system_status", "5" to "respond",
+        "none" to null,
+    )
+    private val CALL_RE = Regex("""<tool_(\d+|none)>\(([^)]*)\)(?:<end>)?""")
+    private val NAMED_ARG_RE = Regex("""(\w+)\s*=\s*"([^"]*)"""")
+
+    /** Parse all tool calls in [raw] (special-token text from the model). */
+    public fun parse(raw: String): List<ToolCall> =
+        CALL_RE.findAll(raw).mapNotNull { m ->
+            val name = TOKEN_TO_NAME[m.groupValues[1]] ?: return@mapNotNull null
+            val args = NAMED_ARG_RE.findAll(m.groupValues[2])
+                .associate { it.groupValues[1] to it.groupValues[2] }
+            ToolCall(name, args)
+        }.toList()
+}

--- a/llm-runtime/gemma-iree/src/commonTest/kotlin/sk/ainet/transformers/gemma/iree/CompactCodecTest.kt
+++ b/llm-runtime/gemma-iree/src/commonTest/kotlin/sk/ainet/transformers/gemma/iree/CompactCodecTest.kt
@@ -1,0 +1,30 @@
+package sk.ainet.transformers.gemma.iree
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CompactCodecTest {
+    @Test
+    fun parsesNamedArgCall() {
+        assertEquals(
+            listOf(ToolCall("set_lights", mapOf("state" to "on"))),
+            CompactCodec.parse("""<tool_0>(state="on")<end>"""),
+        )
+    }
+
+    @Test
+    fun parsesMultipleArgsAndCalls() {
+        assertEquals(
+            listOf(
+                ToolCall("set_lights", mapOf("color" to "red", "state" to "on")),
+                ToolCall("respond", mapOf("message" to "ok")),
+            ),
+            CompactCodec.parse("""<tool_0>(color="red", state="on")<end><tool_5>(message="ok")<end>"""),
+        )
+    }
+
+    @Test
+    fun dropsNoneTool() {
+        assertEquals(emptyList(), CompactCodec.parse("""<tool_none>()<end>"""))
+    }
+}

--- a/llm-runtime/gemma-iree/src/nativeMain/kotlin/sk/ainet/transformers/gemma/iree/GemmaDecoder.kt
+++ b/llm-runtime/gemma-iree/src/nativeMain/kotlin/sk/ainet/transformers/gemma/iree/GemmaDecoder.kt
@@ -1,0 +1,85 @@
+package sk.ainet.transformers.gemma.iree
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
+
+/**
+ * FunctionGemma-270M decoder: OUR DSL->StableHLO->IREE f16 vmfb (CPU), driven on
+ * the SL2610 board through [IreeRuntime]. Self-contained and reusable — give it
+ * a vmfb + its `.irpa` weights + the matching GGUF (for the tokenizer), then
+ * call [generate] with user text; it applies the Octopus-v2 chat template, runs
+ * the greedy decode loop, and returns the tool-call text + parsed [ToolCall]s.
+ *
+ * The vmfb is a fixed seq=[seq] prefill graph with an in-graph per-position
+ * argmax tail, so each step returns small token ids (not the 262153-wide logits
+ * that OOM the board's result formatter); causal masking makes padding to [seq]
+ * safe as the sequence grows.
+ */
+@OptIn(kotlin.native.runtime.NativeRuntimeApi::class)
+public class GemmaDecoder(
+    private val vmfb: String,
+    private val irpa: String,
+    private val gguf: String,
+    private val seq: Int = 24,
+    ireeBin: String = "iree-run-module",
+) {
+    private val rt = IreeRuntime(ireeBin = ireeBin)
+
+    /** The model's output for one prompt. */
+    public data class Generation(
+        /** Decoded special-token text, e.g. `<tool_0>(state="on")<end>`. */
+        val toolCallText: String,
+        /** [toolCallText] parsed by [CompactCodec]. */
+        val calls: List<ToolCall>,
+    )
+
+    public fun generate(userText: String): Generation {
+        val prompt = "<start_of_turn>user\n$userText<end_of_turn>\n<start_of_turn>model\n"
+
+        // Hold the tokenizer ONLY to encode, then free it — the vocab (262153)
+        // resident alongside the ~905MB gen subprocess OOMs the 1.9GB board.
+        // Scope it in run {} so the reference is dropped before GC.collect();
+        // reload it after gen, just to detokenize.
+        val eot: Int
+        val eos: Int
+        val ptoks: List<Int>
+        run {
+            val tok = GGUFTokenizer.fromSource(SystemFileSystem.source(Path(gguf)).buffered())
+            eot = tok.encode("<end_of_turn>").single()
+            eos = tok.eosTokenId
+            ptoks = listOf(tok.bosTokenId) + tok.encode(prompt).toList()
+        }
+        kotlin.native.runtime.GC.collect()
+        if (ptoks.size > seq - 4) {
+            // Too long for the fixed seq=$seq prefill graph -> not a short command; skip
+            // gracefully rather than throwing (a listen daemon must survive this).
+            return Generation("(skipped: prompt ${ptoks.size} tokens > ${seq - 4})", emptyList())
+        }
+
+        platform.posix.system("sync; echo 3 > /proc/sys/vm/drop_caches 2>/dev/null")
+        val buf = IntArray(seq) { if (it < ptoks.size) ptoks[it] else 0 }
+        val gen = mutableListOf<Int>()
+        var step = 0
+        while (ptoks.size + step < seq) {
+            val r = rt.invoke(
+                vmfb, "gemma",
+                listOf("1x${seq}xi32=" + buf.joinToString(",")),
+                mapOf("model" to irpa), "file",
+            )
+            val arr = IreeRuntime.parseIntResult(r.stdout) ?: break
+            val next = arr[ptoks.size - 1 + step]
+            if (next == eos) break
+            gen.add(next)
+            if (next == eot) break
+            buf[ptoks.size + step] = next
+            step++
+        }
+
+        // reload tokenizer (gen subprocess has exited, RAM freed) to detokenize
+        val tok2 = GGUFTokenizer.fromSource(SystemFileSystem.source(Path(gguf)).buffered())
+        val toolCall = tok2.decode(gen.toIntArray())
+        return Generation(toolCall, CompactCodec.parse(toolCall))
+    }
+}

--- a/llm-runtime/gemma-iree/src/nativeMain/kotlin/sk/ainet/transformers/gemma/iree/IreeRuntime.kt
+++ b/llm-runtime/gemma-iree/src/nativeMain/kotlin/sk/ainet/transformers/gemma/iree/IreeRuntime.kt
@@ -1,0 +1,174 @@
+package sk.ainet.transformers.gemma.iree
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKString
+import platform.posix.fgets
+import platform.posix.pclose
+import platform.posix.popen
+
+/**
+ * Board-side IREE runtime binding. The SL2610 ships a statically-linked
+ * `iree-run-module` (Torq fork g165e12a) and no shared libiree C API, so we
+ * drive it as a subprocess via `popen` — the runtime/ binding the plan calls
+ * the interim. It is enough to load a vmfb, bind weights from an `.irpa`
+ * parameter archive, set inputs, invoke, and read back result tensors.
+ *
+ * vmfbs MUST be compiled with the Torq-fork iree-compile (g165e12a) — the
+ * stock IREE 3.x compiler emits a bytecode feature ("Ch") the board runtime
+ * rejects with INVALID_ARGUMENT.
+ */
+@OptIn(ExperimentalForeignApi::class)
+public class IreeRuntime(
+    private val ireeBin: String = "iree-run-module",
+    private val device: String = "local-task",
+) {
+    public data class Result(val exitCode: Int, val stdout: String) {
+        val ok: Boolean get() = exitCode == 0
+    }
+
+    /**
+     * Invoke [function] in [module]. [parameters] maps an .irpa scope name
+     * (e.g. "model") to its file path; [inputs] are IREE `--input=` specs
+     * such as `"1x4xi32=2,887,506,2214"`.
+     */
+    public fun invoke(
+        module: String,
+        function: String,
+        inputs: List<String>,
+        parameters: Map<String, String> = emptyMap(),
+        // "file" mmaps the .irpa on demand (required on the 1.9GB-RAM board for
+        // the 1.74GB FP32 gemma archive); "preload" wires it all into RAM.
+        parameterMode: String? = null,
+    ): Result {
+        val args = buildList {
+            add(ireeBin)
+            add("--device=$device")
+            if (parameterMode != null) add("--parameter_mode=$parameterMode")
+            add("--module=$module")
+            add("--function=$function")
+            for ((scope, path) in parameters) add("--parameters=$scope=$path")
+            for (i in inputs) add("--input=$i")
+        }
+        return exec(args)
+    }
+
+    /**
+     * Run [module]/[function] and compute the per-position argmax of a single
+     * `[1, seqLen, vocab]` f32 result by STREAMING stdout — never buffering the
+     * full ~vocab*seqLen float dump. Essential on the board: holding the 1M-float
+     * gemma result in memory on top of iree-run-module's ~1.44GB working set
+     * OOMs the 1.9GB device. Returns one argmax per sequence position, or null
+     * if the run failed / no f32 result line was seen.
+     */
+    public fun argmaxLogits(
+        module: String,
+        function: String,
+        inputs: List<String>,
+        vocab: Int,
+        seqLen: Int,
+        parameters: Map<String, String> = emptyMap(),
+        parameterMode: String? = "file",
+    ): IntArray? {
+        val args = buildList {
+            add(ireeBin); add("--device=$device")
+            if (parameterMode != null) add("--parameter_mode=$parameterMode")
+            add("--module=$module"); add("--function=$function")
+            for ((s, p) in parameters) add("--parameters=$s=$p")
+            for (i in inputs) add("--input=$i")
+        }
+        val cmd = args.joinToString(" ") { shellQuote(it) } + " 2>&1"
+        val fp = popen(cmd, "r") ?: return null
+
+        val bestVal = FloatArray(seqLen) { Float.NEGATIVE_INFINITY }
+        val bestIdx = IntArray(seqLen) { -1 }
+        var afterEq = false          // past the "xf32=" marker of the result line
+        var floatIdx = 0
+        val tok = StringBuilder()    // current partial number across chunk boundaries
+        val tail = StringBuilder()   // small rolling buffer to detect "xf32=" before data
+        var sawF32 = false
+
+        fun consumeNumber() {
+            if (tok.isEmpty()) return
+            val v = tok.toString().toFloatOrNull()
+            tok.setLength(0)
+            if (v == null) return
+            val pos = floatIdx / vocab
+            if (pos < seqLen && v > bestVal[pos]) { bestVal[pos] = v; bestIdx[pos] = floatIdx % vocab }
+            floatIdx++
+        }
+
+        memScoped {
+            val n = 65536
+            val buf = allocArray<ByteVar>(n)
+            while (fgets(buf, n, fp) != null) {
+                val chunk = buf.toKString()
+                for (c in chunk) {
+                    if (!afterEq) {
+                        tail.append(c)
+                        if (tail.length > 8) tail.deleteAt(0)
+                        if (tail.endsWith("xf32=")) { afterEq = true; sawF32 = true }
+                    } else if (c == '\n') {
+                        consumeNumber(); afterEq = false  // result line ended
+                    } else if (c == ' ' || c == '\t' || c == '\r') {
+                        consumeNumber()
+                    } else {
+                        tok.append(c)
+                    }
+                }
+            }
+            consumeNumber()
+        }
+        val status = pclose(fp)
+        val code = if (status == -1) -1 else (status shr 8) and 0xff
+        return if (code == 0 && sawF32 && bestIdx.none { it < 0 }) bestIdx else null
+    }
+
+    private fun exec(args: List<String>): Result {
+        // 2>&1 so runtime errors (verifier rejects, OOM) land in stdout too.
+        val cmd = args.joinToString(" ") { shellQuote(it) } + " 2>&1"
+        val fp = popen(cmd, "r") ?: return Result(-1, "popen failed: $cmd")
+        val sb = StringBuilder()
+        memScoped {
+            val n = 8192
+            val buf = allocArray<ByteVar>(n)
+            while (fgets(buf, n, fp) != null) sb.append(buf.toKString())
+        }
+        val status = pclose(fp)
+        // pclose returns the wait status; shift to the exit code (POSIX).
+        val code = if (status == -1) -1 else (status shr 8) and 0xff
+        return Result(code, sb.toString())
+    }
+
+    private fun shellQuote(s: String): String =
+        if (s.all { it.isLetterOrDigit() || it in "-_=/.,:+@" }) s
+        else "'" + s.replace("'", "'\\''") + "'"
+
+    public companion object {
+        /**
+         * Parse iree-run-module's textual result lines, e.g.
+         *   result[0]: hal.buffer_view
+         *   4xf32=4 5 6 7
+         * into FloatArrays (one per `=`-bearing line). Robust enough for the
+         * smoke path; the real decode loop reads `--output=@file.npy` instead.
+         */
+        /** Parse a single `NxiNN=` integer result line, e.g. `24xi32=3617 107 ...`. */
+        public fun parseIntResult(stdout: String): IntArray? =
+            stdout.lineSequence()
+                .firstOrNull { it.substringBefore('=').contains("xi32") }
+                ?.substringAfter('=')?.trim()?.split(Regex("\\s+"))
+                ?.let { p -> runCatching { IntArray(p.size) { p[it].toInt() } }.getOrNull() }
+
+        public fun parseFloatResults(stdout: String): List<FloatArray> =
+            stdout.lineSequence()
+                .mapNotNull { line ->
+                    val eq = line.indexOf('=')
+                    if (eq < 0 || !line.substringBefore('=').contains("xf32")) return@mapNotNull null
+                    val nums = line.substring(eq + 1).trim().split(Regex("\\s+"))
+                    runCatching { FloatArray(nums.size) { nums[it].toFloat() } }.getOrNull()
+                }
+                .toList()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,9 @@ include("llm-runtime:kgemma")
 // swap). The legacy `QwenIngestion` facade had no remaining consumers
 // after the architectural refactor — see PR closing this module.
 include("llm-runtime:kapertus")
+// Gemma-on-IREE runtime: decode loop + iree-run-module driver + tool-call codec
+// (the on-device side of the DSL -> StableHLO -> IREE path).
+include("llm-runtime:gemma-iree")
 include("llm-performance")
 include("llm-apps:skainet-cli")
 include("llm-apps:kllama-cli")


### PR DESCRIPTION
# feat(llm-runtime): add gemma-iree — on-device Gemma decode over an IREE vmfb

Promotes the reusable **runtime** half of the DSL → StableHLO → IREE Gemma path
into a proper module, alongside `runtime-kgemma` / `runtime-kllama`. Previously
this lived as app-local `:llm`/`:runtime` modules in the `sl2610-function-calling`
sample; pulling it here means any KMP app can consume it via one coordinate.

## Module
`:llm-runtime:gemma-iree` → `sk.ainet.transformers:skainet-transformers-runtime-gemma-iree`
(package `sk.ainet.transformers.gemma.iree`), targeting **jvm + linuxX64 + linuxArm64**.

- **commonMain** — `CompactCodec` + `ToolCall`: the v10 Octopus-v2 compact
  tool-call grammar (`<tool_N>(args)<end>`), pure Kotlin, no deps.
- **native** — `IreeRuntime`: drives the board's statically-linked
  `iree-run-module` as a posix subprocess (the SL2610 ships no libiree C API),
  incl. a streaming per-position argmax to avoid OOMing on the full logits.
  `GemmaDecoder`: greedy decode loop over a compiled vmfb + `.irpa` weights +
  the GGUF tokenizer from `:llm-core`.

Pairs with the gemma3 → StableHLO export in `:llm-inference:gemma` (host) that
produces the vmfb this module runs.

## Validation
- `CompactCodecTest` (commonTest) green on jvm.
- Compiles for jvm + linuxArm64.
- The `sl2610-function-calling` sample cross-compiles its aarch64 board binary
  against this module via composite build.

## Notes
- Branched off `develop` (which now has the gemma3→StableHLO export work).
- Publish/BOM wiring is intentionally minimal; full release config (BOM entry,
  API dump) can follow when cutting the next release.
