### PR TITLE
ci: disable configuration cache in build.yml (AGP × Kotlin/JS npm)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,14 @@ jobs:
         env:
           GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8"
         run: |
+          # Config cache is disabled in CI: KGP's KotlinPackageJsonTask resolves
+          # the *NpmAggregated configs during configuration, which AGP's
+          # DependencyResolutionChecks rejects under config-cache (gradle#31483).
+          # Local dev keeps it on (gradle.properties) where warm caches skip
+          # re-configuration. release.yml already publishes with --no-configuration-cache.
           ./gradlew --no-daemon --stacktrace --info \
             -Dorg.gradle.caching=true \
-            -Dorg.gradle.configuration-cache=true \
+            --no-configuration-cache \
             clean assemble allTests
 
       - name: Build and Test (push)
@@ -47,9 +52,10 @@ jobs:
         env:
           GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8"
         run: |
+          # See the PR step above: config cache disabled in CI (gradle#31483).
           ./gradlew --no-daemon --stacktrace --info \
             -Dorg.gradle.caching=true \
-            -Dorg.gradle.configuration-cache=true \
+            --no-configuration-cache \
             assemble allTests
 
       - name: Memory info (on failure)


### PR DESCRIPTION
Build & Test is red under config-cache: KGP's `KotlinPackageJsonTask` resolves the js/wasm `*NpmAggregated` configs during configuration, and AGP's `DependencyResolutionChecks` throws on config-time resolution when the config cache is active ([gradle#31483](https://github.com/gradle/gradle/issues/31483)).

**Fix:** run CI with `--no-configuration-cache` (as `release.yml` already does). Local dev keeps config-cache on via `gradle.properties` — warm caches skip re-configuration so the throw never fires.

Verified locally on develop: `assemble allTests --no-configuration-cache` → BUILD SUCCESSFUL, 0 failed tasks (the config-time-resolution notices become non-fatal). Letting CI confirm on a clean runner.