### PR TITLE
test(gemma): tag real-model dequant/eager tests as integration

### DIFF
--- a/llm-inference/gemma/build.gradle.kts
+++ b/llm-inference/gemma/build.gradle.kts
@@ -115,4 +115,5 @@ tasks.matching { it.name == "jsBrowserTest" || it.name == "wasmJsBrowserTest" }.
 // override via -PgemmaTestMaxHeap (default 8g).
 tasks.withType<Test>().configureEach {
     maxHeapSize = (findProperty("gemmaTestMaxHeap") as? String) ?: "8g"
+    (findProperty("seqLen") as? String)?.let { systemProperty("seqLen", it) }
 }

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaDequantDumpTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaDequantDumpTest.kt
@@ -1,0 +1,43 @@
+package sk.ainet.models.gemma
+
+import org.junit.jupiter.api.Tag
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import java.io.File
+import kotlin.test.Test
+
+/** Dumps SKaiNET's dequantized values for representative tensors (one per quant
+ *  type: Q5_1 attn_q, Q6_K ffn_down, Q8_0 token_embd) so they can be diffed
+ *  against gguf's reference dequantize. Pins whether the parity residual is a
+ *  SKaiNET dequant bug. */
+@Tag("integration")
+class RealGemmaDequantDumpTest {
+    @Test
+    fun dumpDequant() = runBlocking {
+        val path = "/home/miso/projects/coral/sl2610-voice-cc-kt/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+        val ctx = DirectCpuExecutionContext.create()
+        val weights = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(path) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+        val m = weights.metadata
+        println("ROPE full.base=${m.ropeParametersFull.base} sliding.base=${m.ropeParametersSliding.base}")
+        println("ROPE full.partial=${m.ropeParametersFull.partialRotaryFactor} full.type=${m.ropeParametersFull.ropeType} full.factor=${m.ropeParametersFull.factor}")
+        for (l in 0 until m.blockCount) {
+            print("L$l=${m.getLayerType(l)}:${m.getRopeBase(l)} "); if (l % 6 == 5) println()
+        }
+        println()
+        val outDir = File("/home/miso/projects/coral/build-mlir/out").apply { mkdirs() }
+        for (nm in listOf("blk.0.attn_q.weight", "blk.0.ffn_down.weight", "token_embd.weight")) {
+            val t = weights.tensors[nm] ?: run { println("MISSING $nm"); continue }
+            val a = t.data.copyToFloatArray()
+            println("DUMP $nm shape=${t.shape} n=${a.size}")
+            val bb = java.nio.ByteBuffer.allocate(a.size * 4).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            for (f in a) bb.putFloat(f)
+            File(outDir, "dq_${nm.replace('.', '_')}.bin").writeBytes(bb.array())
+        }
+    }
+}

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaEagerAbTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaEagerAbTest.kt
@@ -43,7 +43,14 @@ class RealGemmaEagerAbTest {
         }
         stripKvCache(model)
 
-        val tokens = floatArrayOf(2f, 887f, 506f, 2214f)
+        // Read the exact token ids llama.cpp used (ab_llama.py writes tokens.json)
+        // so both sides see an identical prefix; fall back to a default.
+        val tokFile = File("/home/miso/projects/coral/build-mlir/out/tokens.json")
+        val tokens = if (tokFile.exists()) {
+            tokFile.readText().trim().removeSurrounding("[", "]")
+                .split(",").map { it.trim().toFloat() }.toFloatArray()
+        } else floatArrayOf(2f, 887f, 506f, 2214f)
+        println("TOKENS_USED ${tokens.toList()}")
         // Eager Embedding indexes a 1-D [seq] token tensor (not [1,seq]).
         val input = ctx.fromFloatArray<FP32, Float>(sk.ainet.lang.tensor.Shape(tokens.size), FP32::class, tokens)
         val out = model.forward(input, ctx as ExecutionContext)


### PR DESCRIPTION
## Summary
- `RealGemmaDequantDumpTest` loaded a real FunctionGemma GGUF from an absolute local path and threw `IllegalArgumentException` under `allTests` on any machine/CI without the model file, breaking the build.
- Tagged it `@Tag("integration")` so the root build's `excludeTags("integration")` skips it in normal runs — matching its sibling `RealGemmaEagerAbTest`.
- Also parks the in-progress eager A/B harness tweaks: read llama.cpp's exact token ids from `tokens.json` (fallback to the default prefix), and wire a `-PseqLen` system property through the gemma `Test` task.

## Test plan
- `./gradlew :llm-inference:gemma:allTests` — green (previously failed on `RealGemmaDequantDumpTest.dumpDequant()`).
- Integration tests still runnable locally with the real model via `-PincludeIntegration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)