### PR TITLE
ci: configure js/wasm browser tests lazily (fix config-time npm resolution)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,10 +67,16 @@ subprojects {
     //      agents. The same tests already run on jvmTest, so skipping the
     //      browser variants loses no coverage in practice.
     // `-PincludeBrowserTests` re-enables them when a browser is available.
+    // Use the lazy withType().configureEach (NOT tasks.matching{byName}, which
+    // eagerly realizes the js/wasm test tasks during configuration — that
+    // cascades into KGP's KotlinPackageJsonTask resolving *NpmAggregated at
+    // config time, which AGP's DependencyResolutionChecks then rejects).
     val includeBrowserTests = project.hasProperty("includeBrowserTests")
-    tasks.matching { it.name == "jsBrowserTest" || it.name == "wasmJsBrowserTest" }.configureEach {
-        (this as? org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest)
-            ?.failOnNoDiscoveredTests = false
-        enabled = includeBrowserTests
-    }
+    tasks.withType(org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest::class.java)
+        .configureEach {
+            if (name == "jsBrowserTest" || name == "wasmJsBrowserTest") {
+                failOnNoDiscoveredTests = false
+                enabled = includeBrowserTests
+            }
+        }
 }


### PR DESCRIPTION
Follow-up to #163 (which didn't fix it — AGP's check is phase-based, not config-cache-based).

**Root cause:** the root `tasks.matching { it.name == "jsBrowserTest" || ... }` is **eager** — it realizes the js/wasm test tasks during configuration, cascading into KGP's `KotlinPackageJsonTask` resolving `*NpmAggregated` at config time, which AGP's `DependencyResolutionChecks` rejects ([gradle#31483](https://github.com/gradle/gradle/issues/31483)).

**Fix:** lazy `tasks.withType<KotlinJsTest>().configureEach {}` + name guard — doesn't realize the tasks at config time.

⚠️ Hypothesis — I can't reproduce the cold-CI condition locally (warm npm state masks it). CI on this PR is the real test.