### PR TITLE
test: 60s browser Mocha timeout for parity with the engine repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,11 @@ subprojects {
             if (name == "jsBrowserTest" || name == "wasmJsBrowserTest") {
                 failOnNoDiscoveredTests = false
                 enabled = includeBrowserTests
+                // Generous Mocha timeout (default is 2s): browser engines — wasmJs
+                // especially — run slower under CI/parallel load, so a heavier test
+                // can exceed the default before it finishes computing. Mirrors the
+                // engine repo's per-module bump. Harmless for the fast tests here.
+                useMocha { timeout = "60s" }
             }
         }
 }


### PR DESCRIPTION
Adds a defensive `useMocha { timeout = "60s" }` to the shared root browser-test config (one place, applies to every module's `jsBrowserTest` / `wasmJsBrowserTest`).

**Why:** parity with the engine repo (SKaiNET#703). Mocha's 2s default can trip a heavier browser test under CI/parallel load *after* it has already computed the right result — the engine repo hit exactly this with its micrograd training demo on wasmJs. Transformers' browser suites are all fast (tokenizer/validation/trace), so this is purely future-proofing; it changes no current behaviour.

**Verified green:**
- CI-equivalent (fresh `kotlin-js-store`, `clean assemble allTests` in **default mode** — exactly what `build.yml` runs): **BUILD SUCCESSFUL**, `kotlinStoreYarnLock` clean, 0 failing tests.
- With `-PincludeBrowserTests` + a browser: **616 browser testcases, 0 failures**.

`kotlin-js-store/yarn.lock` is regenerated per build (not tracked in the repo), so no lockfile change ships in this PR — only the one-line build config.