### PR TITLE
fix(gemma): write MLIR dump tests to portable build dir, not a hardco…

### DIFF
--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/GemmaMlirDumpTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/GemmaMlirDumpTest.kt
@@ -56,7 +56,7 @@ class GemmaMlirDumpTest {
         val graph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
         val mlir = sk.ainet.compile.hlo.toStableHlo(graph, "gemma").content
 
-        val out = File(System.getProperty("gemmaMlirOut") ?: "/home/miso/projects/coral/build-mlir/gemma.mlir")
+        val out = File(System.getProperty("gemmaMlirOut") ?: "build/build-mlir/gemma.mlir")
         out.parentFile?.mkdirs()
         out.writeText(mlir)
         println("WROTE_MLIR ${out.absolutePath} (${mlir.lines().size} lines)")

--- a/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaMlirDumpTest.kt
+++ b/llm-inference/gemma/src/jvmTest/kotlin/sk/ainet/models/gemma/RealGemmaMlirDumpTest.kt
@@ -83,7 +83,7 @@ class RealGemmaMlirDumpTest {
         val unsupported = mlir.lines().count { it.contains("Unsupported op", ignoreCase = true) }
         val arity = mlir.lines().count { it.contains("arity", ignoreCase = true) }
         println("MLIR lines=${mlir.lines().size} unsupported=$unsupported arity=$arity")
-        val out = File(System.getProperty("gemmaMlirOut") ?: "/home/miso/projects/coral/build-mlir/gemma-real.mlir")
+        val out = File(System.getProperty("gemmaMlirOut") ?: "build/build-mlir/gemma-real.mlir")
         out.parentFile?.mkdirs()
         out.writeText(mlir)
         println("WROTE_MLIR ${out.absolutePath}")


### PR DESCRIPTION
…ded local path

GemmaMlirDumpTest and RealGemmaMlirDumpTest defaulted their StableHLO dump output to /home/miso/projects/coral/build-mlir/, the original author's local checkout. On CI (home is /home/runner) parentFile.mkdirs() can't create that tree, so writeText throws FileNotFoundException and :llm-inference:gemma:allTests fails — turning develop (and every PR branched off it) red.

The Gemma3 -> StableHLO lowering itself is healthy (0 unsupported ops, 0 arity gaps); only the final file write was broken. Default to the module's build/ dir (build/build-mlir/*.mlir), which both tests already mkdirs and which is writable everywhere. The -DgemmaMlirOut=<path> override is unchanged.