### PR TITLE
fix(gemma): dequant kernel-less quant types in NATIVE_OPTIMIZED instead of leaving raw bytes

### DIFF
--- a/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/GemmaMemSegConverter.kt
+++ b/llm-inference/gemma/src/jvmMain/kotlin/sk/ainet/models/gemma/GemmaMemSegConverter.kt
@@ -197,17 +197,40 @@ private fun <T : DType, V> convertOne(
             ctx.fromData(data as TensorData<FP32, Float>, advertisedDtype) as Tensor<T, V>
         }
         GGMLQuantizationType.Q5_K -> {
-            // No native matmul kernel yet for Q5_K (not needed for Gemma 4
-            // E2B Q4_K_M — it has no Q5_K tensors). Fall back to dequant.
-            val elemCount = shape.volume
-            val floats = DequantOps.dequantFromBytes(bytes, qt, elemCount)
-            ctx.fromFloatArray<FP32, Float>(shape, advertisedDtype, floats) as Tensor<T, V>
+            // No native matmul kernel yet for Q5_K. Fall back to a correct FP32 dequant.
+            dequantPackedToFp32<T, V>(bytes, qt, shape, ctx)
         }
         else -> {
-            println("WARNING: GemmaMemSegConverter: unsupported quant type $qt for '$name'; leaving as-is")
-            tensor
+            // Any other quant type without a packed SIMD kernel (Q5_0/Q5_1/Q4_1/Q2_K/…)
+            // would otherwise be left as raw 1-D bytes, which `linearProject` then can't
+            // transpose ("Transpose requires at least 2 dimensions"). Dequantize to a
+            // correct FP32 `[out, in]` weight so the DSL path runs; the supported packed
+            // types (Q4_0/Q8_0/Q4_K/Q6_K) above keep their fast SIMD form. This trades
+            // those tensors' memory savings for correctness until a packed kernel exists.
+            dequantPackedToFp32<T, V>(bytes, qt, shape, ctx)
         }
     }
+}
+
+/**
+ * Dequantize raw GGUF quant `bytes` of logical shape `[out, in]` to a canonical FP32
+ * `[out, in]` row-major weight — the same layout `Gemma4WeightLoader.createTensor` produces
+ * on the `DEQUANTIZE_TO_FP32` path. GGUF stores K/legacy-quant blocks column-major within a
+ * row, so the dequantized floats are transposed column-major → row-major (rows = `in`,
+ * cols = `out`) to match what `linearProject` (`x @ W.t()`) expects.
+ */
+@Suppress("UNCHECKED_CAST")
+private fun <T : DType, V> dequantPackedToFp32(
+    bytes: ByteArray,
+    qt: GGMLQuantizationType,
+    shape: Shape,
+    ctx: ExecutionContext,
+): Tensor<T, V> {
+    val floats = DequantOps.dequantFromBytes(bytes, qt, shape.volume)
+    val out = shape[0]
+    val inDim = shape[1]
+    val rowMajor = DequantOps.transposeColumnMajorToRowMajor(floats, inDim, out)
+    return ctx.fromFloatArray<FP32, Float>(shape, FP32::class, rowMajor) as Tensor<T, V>
 }
 
 /**


### PR DESCRIPTION
## Problem

Loading a Gemma GGUF whose attention/FFN weights use a quant type with **no packed SIMD kernel** (e.g. **Q5_1** — as in `functiongemma-270m` "Q5_K_M") under `QuantPolicy.NATIVE_OPTIMIZED` crashes at the first decode step:

```
java.lang.IllegalArgumentException: Transpose requires at least 2 dimensions
  at MultiHeadAttention.attentionImpl -> linearProject -> ops.transpose
```

i.e. `skainet -m functiongemma-...-Q5_K_M.gguf "..."` loads the model fine, then dies as soon as it generates.

## Root cause

`GemmaMemSegConverter.convertOne` only handled `Q4_0/Q8_0/Q4_K/Q6_K/Q5_K`. Every other quant type fell into the `else` branch, which logged a warning and **left the tensor as raw 1-D bytes** (`DenseIntArrayTensorData [N]`). `linearProject` (`x @ W.t()`) then tried to `ops.transpose` a rank-1 tensor → the exception.

(Confirmed by instrumenting `linearProject`: `data=DenseIntArrayTensorData shape=[491520] rank=1` + `WARNING: ... unsupported quant type Q5_1 for 'blk.0.attn_q.weight'; leaving as-is`.)

## Fix

Dequantize any kernel-less quant type to a correct FP32 `[out, in]` weight via a new `dequantPackedToFp32` helper, instead of leaving raw bytes. The helper mirrors the **proven** `Gemma4WeightLoader.createTensor` (`DEQUANTIZE_TO_FP32`) layout: GGUF stores quant blocks column-major within a row, so the dequantized floats are transposed **column-major → row-major** (`rows = in, cols = out`) to land in the canonical `[out, in]` layout `linearProject` expects.

- The previous `Q5_K` branch dequantized **without** that transpose — untested (its own comment notes Gemma 4 E2B has no Q5_K tensors) and a latent layout bug; it now routes through the same correct helper.
- The supported packed types (`Q4_0/Q8_0/Q4_K/Q6_K`) are **unchanged** and keep their fast SIMD form. Only kernel-less types pay the FP32 dequant (correctness over the packed memory saving until a kernel exists).

## Verification

- `skainet -m functiongemma-physical-ai-v10-Q5_K_M.gguf "The capital of France is"` now loads **and generates** `Paris.` under `NATIVE_OPTIMIZED` (the default), matching the `DEQUANTIZE_TO_FP32` reference output.
- ~**3× the tok/s** of the global-dequant workaround (0.67 vs 0.23), because `Q4_K/Q6_K` stay packed and only the `Q5_1` tensors dequant.
- `GemmaDslQuantizedTest` (Q8_0 MemSeg path) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)