### PR TITLE
feat(gemma-iree): add macosArm64 target

### DIFF
--- a/llm-runtime/gemma-iree/build.gradle.kts
+++ b/llm-runtime/gemma-iree/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
     jvm()
     linuxX64()
     linuxArm64()
+    macosArm64() // Apple Silicon host dev (mirrors :llm-runtime:kgemma); uses the same nativeMain sources
 
     sourceSets {
         commonTest.dependencies {


### PR DESCRIPTION
Adds Apple-Silicon support to `:llm-runtime:gemma-iree`, mirroring `:llm-runtime:kgemma` (which already publishes `macos_arm64`).

The `IreeRuntime` + `GemmaDecoder` sources are in `nativeMain`, so `macosArm64Main` picks them up with **no new code** — posix `popen`/`fgets`/`pclose` + kotlinx-io + the GGUF tokenizer are all available on macOS.

Enables downstream KMP consumers to target macOS (e.g. the standalone `gemma-tool-calling` project). macOS compile/link happens on the macOS publish runner; Linux CI skips mac link tasks (as it already does for kgemma).

⚠️ I can't verify mac builds on a Linux host — relying on the macOS runner.