### PR TITLE
chore(release): 0.29.1 — version-align with SKaiNET 0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ version line is kept in lock-step with the underlying SKaiNET engine
 The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] — 2026-06-09
+
+Version-aligned with **SKaiNET 0.29.1**.
+
+### Changed
+
+- **`gradle/libs.versions.toml` `skainet` pin: 0.28.1 → 0.29.1.** Picks up the
+  engine's new **packed-quantization matmul kernels** — Q5_0, Q5_1, Q4_K, and
+  Q6_K now have matmul support across the full provider stack (scalar
+  `commonMain` kernels, `DefaultCpuOpsBase` dispatch, Panama Vector JVM SIMD, and
+  the CPU backend matmul ops), so GGUF models quantized in those formats run on
+  the eager CPU path without a dequant-to-FP32 detour. SKaiNET 0.29.0 also added
+  the **Minerva secure-MCU export module** (a StableHLO adapter → secure
+  microcontroller bundle pipeline) on top of the same StableHLO/IREE export path
+  that powers transformers' gemma export; **0.29.1** is a follow-up that fixes
+  that module's Maven Central publication metadata (`POM_ARTIFACT_ID` /
+  `POM_NAME`). The kernel-to-platform support matrix is now auto-generated and
+  CI-gated upstream.
+- **Public API dumps refreshed (`:llm-agent`, `:llm-core`).** Two independent
+  drifts are reconciled in this release:
+  - `:llm-agent` — `generateUntilStop` / `AgentListener` gained the
+    `onPrefill` / `onPrefillProgress` prefill-progress callback (merged earlier
+    via "feat(agent): expose prefill progress via AgentListener"); the dump had
+    not been regenerated since 0.23.2.
+  - `:llm-core` — the re-exported engine `sk.ainet.lang.nn.*` constructors
+    (`MultiHeadAttention`, `AttentionImpl`, `RMSNormalization`, `GeGLUFFN`,
+    `LayerScalarMul`, `VoidDense`) gained a trailing dtype type-token
+    (`KClass<…>`) parameter from the engine bump. The new parameter carries a
+    default, so existing source-level callers compile unchanged — only the
+    binary signature (and therefore the API baseline) moved.
+
+### Verified
+
+- `./gradlew check` green against the published SKaiNET 0.29.1 — all module
+  compilations, unit tests, and `apiCheck` baselines pass.
+
 ## [0.28.1] — 2026-06-06
 
 Version-aligned with **SKaiNET 0.28.1**. Skips 0.26.x / 0.27.x —

--- a/README.md
+++ b/README.md
@@ -103,22 +103,23 @@ Honest status — see the project-status note at the top of this README.
 
 ## Current release
 
-The current release is **0.28.1** — version-aligned with **SKaiNET 0.28.1**.
-Skips 0.26.x / 0.27.x: SKaiNET-transformers tracked the engine internally across
-that window without a tagged release. The headline is that the engine's
-**Kotlin DSL → StableHLO → IREE export path is now complete** — a full gemma3
-graph traces and lowers to StableHLO that `iree-compile`s to a `vmfb`
-(`GemmaMlirDumpTest` / `GemmaTraceTest` are green against 0.28.1). SKaiNET
-0.28.0/0.28.1 fixed the remaining export bugs: result-type inference for
-`reshape`/`matmul`/`concatenate` ([#673](https://github.com/SKaiNET-developers/SKaiNET/issues/673))
-and `conv1d`/`gather`/pooling/`flatten` shapes plus the `reduce_window` emission
-form ([#675](https://github.com/SKaiNET-developers/SKaiNET/issues/675)).
+The current release is **0.29.1** — version-aligned with **SKaiNET 0.29.1**.
+The headline is the engine's new **packed-quantization matmul kernels**: Q5_0,
+Q5_1, Q4_K, and Q6_K now have matmul support across the provider stack (scalar
+`commonMain` kernels, `DefaultCpuOpsBase` dispatch, Panama Vector JVM SIMD, and
+the CPU backend), so GGUF models quantized in those formats run on the eager CPU
+path without a dequant-to-FP32 detour. SKaiNET 0.29.0 also introduced the
+**Minerva secure-MCU export module**, which builds on the same StableHLO/IREE
+export path that powers transformers' gemma export; 0.29.1 is a follow-up that
+fixes that module's Maven Central publication metadata. Existing source-level
+callers compile unchanged — the only API-baseline movement is the engine's
+re-exported `nn` constructors gaining a defaulted dtype type-token.
 
 The recommended way to consume is via the BOM. It pins every published `skainet-transformers-*` artifact and re-exports the upstream `sk.ainet:skainet-bom`, so the engine-side `sk.ainet.core:skainet-*` artifacts get the matching version too — you only need to declare the BOM version in one place.
 
 ```kotlin
 dependencies {
-    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.28.1"))
+    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.29.1"))
 
     // Versions resolved from the BOM:
     implementation("sk.ainet.transformers:skainet-transformers-core")
@@ -194,6 +195,21 @@ try (KLlamaSession session = KLlamaJava.loadGGUF(modelPath, /* systemPrompt */ n
 ```
 
 See `llm-test/llm-test-java/src/test/java/.../KLlamaJavaToolCallingTest.java` for a runnable reference.
+
+## What's new in 0.29.1
+
+- **Engine pin `skainet 0.28.1 → 0.29.1`.** Adds **packed-quantization matmul
+  kernels** for Q5_0, Q5_1, Q4_K, and Q6_K across the provider stack (scalar,
+  Panama Vector SIMD, and CPU backend), so GGUF models in those quant formats run
+  on the eager CPU path without a dequant-to-FP32 detour. SKaiNET 0.29.0 also
+  shipped the **Minerva secure-MCU export module** on top of the shared
+  StableHLO/IREE export path; 0.29.1 fixes that module's Maven Central
+  publication metadata.
+- **Public API baselines refreshed (`:llm-agent`, `:llm-core`).** Picks up the
+  earlier-merged `AgentListener` prefill-progress callback (`onPrefill` /
+  `onPrefillProgress`) and the engine's re-exported `nn` constructors gaining a
+  defaulted dtype type-token. Source-level callers are unaffected.
+- Verified end-to-end: `./gradlew check` green against the published 0.29.1.
 
 ## What's new in 0.28.1
 

--- a/docs/modules/ROOT/pages/tutorials/getting-started-java.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started-java.adoc
@@ -25,7 +25,7 @@ In your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.28.1"))
+    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.29.1"))
 
     implementation("sk.ainet.transformers:skainet-transformers-runtime-kllama")
     implementation("sk.ainet.transformers:skainet-transformers-agent")
@@ -41,7 +41,7 @@ Or in Maven (Maven needs the `-jvm` classifier suffix on platform artifacts):
     <dependency>
       <groupId>sk.ainet.transformers</groupId>
       <artifactId>skainet-transformers-bom</artifactId>
-      <version>0.28.1</version>
+      <version>0.29.1</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/modules/ROOT/pages/tutorials/llama3-tool-calling.adoc
+++ b/docs/modules/ROOT/pages/tutorials/llama3-tool-calling.adoc
@@ -52,7 +52,7 @@ The pieces you need live in three modules:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.28.1"))
+    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.29.1"))
 
     implementation("sk.ainet.transformers:skainet-transformers-runtime-kllama")
     implementation("sk.ainet.transformers:skainet-transformers-agent")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.transformers
-VERSION_NAME=0.28.1
+VERSION_NAME=0.29.1
 
 POM_DESCRIPTION=SKaiNET-transformers
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-skainet = "0.28.1"
+skainet = "0.29.1"
 agp = "9.2.1"
 jacksonDatabind = "2.22.0"
 jsonSchemaValidator = "3.0.3"

--- a/llm-agent/api/jvm/llm-agent.api
+++ b/llm-agent/api/jvm/llm-agent.api
@@ -1,6 +1,6 @@
 public final class sk/ainet/apps/kllama/agent/GenerateExtensionsKt {
-	public static final fun generateUntilStop (Lsk/ainet/apps/llm/InferenceRuntime;[IIIFLkotlin/random/Random;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lsk/ainet/apps/kllama/agent/GenerateResult;
-	public static synthetic fun generateUntilStop$default (Lsk/ainet/apps/llm/InferenceRuntime;[IIIFLkotlin/random/Random;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lsk/ainet/apps/kllama/agent/GenerateResult;
+	public static final fun generateUntilStop (Lsk/ainet/apps/llm/InferenceRuntime;[IIIFLkotlin/random/Random;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lsk/ainet/apps/kllama/agent/GenerateResult;
+	public static synthetic fun generateUntilStop$default (Lsk/ainet/apps/llm/InferenceRuntime;[IIIFLkotlin/random/Random;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lsk/ainet/apps/kllama/agent/GenerateResult;
 	public static final fun sampleFromLogits (Lsk/ainet/lang/tensor/Tensor;FLkotlin/random/Random;)I
 	public static synthetic fun sampleFromLogits$default (Lsk/ainet/lang/tensor/Tensor;FLkotlin/random/Random;ILjava/lang/Object;)I
 }
@@ -45,6 +45,7 @@ public final class sk/ainet/apps/kllama/chat/AgentConfig {
 public abstract interface class sk/ainet/apps/kllama/chat/AgentListener {
 	public fun onAssistantMessage (Ljava/lang/String;)V
 	public fun onComplete (Ljava/lang/String;)V
+	public fun onPrefillProgress (II)V
 	public fun onThinking (Ljava/lang/String;)V
 	public fun onToken (Ljava/lang/String;)V
 	public fun onToolCallValidationFailed (Lsk/ainet/apps/kllama/chat/ToolCall;Ljava/lang/String;)V
@@ -55,6 +56,7 @@ public abstract interface class sk/ainet/apps/kllama/chat/AgentListener {
 public final class sk/ainet/apps/kllama/chat/AgentListener$DefaultImpls {
 	public static fun onAssistantMessage (Lsk/ainet/apps/kllama/chat/AgentListener;Ljava/lang/String;)V
 	public static fun onComplete (Lsk/ainet/apps/kllama/chat/AgentListener;Ljava/lang/String;)V
+	public static fun onPrefillProgress (Lsk/ainet/apps/kllama/chat/AgentListener;II)V
 	public static fun onThinking (Lsk/ainet/apps/kllama/chat/AgentListener;Ljava/lang/String;)V
 	public static fun onToken (Lsk/ainet/apps/kllama/chat/AgentListener;Ljava/lang/String;)V
 	public static fun onToolCallValidationFailed (Lsk/ainet/apps/kllama/chat/AgentListener;Lsk/ainet/apps/kllama/chat/ToolCall;Ljava/lang/String;)V

--- a/llm-core/api/jvm/llm-core.api
+++ b/llm-core/api/jvm/llm-core.api
@@ -543,8 +543,8 @@ public final class sk/ainet/lang/nn/dsl/ATTENTION$DefaultImpls {
 }
 
 public final class sk/ainet/lang/nn/dsl/AttentionImpl : sk/ainet/lang/nn/dsl/ATTENTION {
-	public fun <init> (Lsk/ainet/context/ExecutionContext;IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lsk/ainet/context/ExecutionContext;IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Ljava/lang/Integer;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Ljava/lang/Integer;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun create ()Lsk/ainet/lang/nn/transformer/MultiHeadAttention;
 	public fun getExecutionContext ()Lsk/ainet/context/ExecutionContext;
 	public fun kvCache (III)V
@@ -653,8 +653,8 @@ public abstract interface class sk/ainet/lang/nn/normalization/FusedRmsNormOps {
 }
 
 public final class sk/ainet/lang/nn/normalization/RMSNormalization : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
-	public fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;Z)V
-	public synthetic fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;ZLkotlin/reflect/KClass;)V
+	public synthetic fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;ZLkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun forward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/context/ExecutionContext;)Lsk/ainet/lang/tensor/Tensor;
 	public fun getModules ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
@@ -670,8 +670,8 @@ public final class sk/ainet/lang/nn/transformer/AppendKVCache : sk/ainet/lang/nn
 }
 
 public final class sk/ainet/lang/nn/transformer/GeGLUFFN : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
-	public fun <init> (IILjava/lang/String;)V
-	public synthetic fun <init> (IILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IILjava/lang/String;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (IILjava/lang/String;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDim ()I
 	public final fun getHiddenDim ()I
 	public fun getModules ()Ljava/util/List;
@@ -695,8 +695,8 @@ public abstract class sk/ainet/lang/nn/transformer/KVCache : sk/ainet/lang/nn/Mo
 
 public final class sk/ainet/lang/nn/transformer/LayerScalarMul : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getModules ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
 	public fun getParams ()Ljava/util/List;
@@ -707,8 +707,8 @@ public final class sk/ainet/lang/nn/transformer/LinearProjectionKt {
 }
 
 public final class sk/ainet/lang/nn/transformer/MultiHeadAttention : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
-	public fun <init> (IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Lsk/ainet/lang/nn/transformer/RoPE;Lsk/ainet/lang/nn/transformer/KVCache;Ljava/lang/Integer;Ljava/lang/Integer;)V
-	public synthetic fun <init> (IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Lsk/ainet/lang/nn/transformer/RoPE;Lsk/ainet/lang/nn/transformer/KVCache;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Lsk/ainet/lang/nn/transformer/RoPE;Lsk/ainet/lang/nn/transformer/KVCache;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (IIIZZZDLjava/lang/Float;ZZLjava/lang/String;Lsk/ainet/lang/nn/transformer/RoPE;Lsk/ainet/lang/nn/transformer/KVCache;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun forward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/context/ExecutionContext;)Lsk/ainet/lang/tensor/Tensor;
 	public final fun getAttentionScale ()Ljava/lang/Float;
 	public final fun getBias ()Z
@@ -847,7 +847,8 @@ public final class sk/ainet/lang/nn/transformer/SwiGLUFFN : sk/ainet/lang/nn/Mod
 }
 
 public final class sk/ainet/lang/nn/transformer/VoidDense : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
-	public fun <init> (Ljava/lang/String;II)V
+	public fun <init> (Ljava/lang/String;IILkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;IILkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getInDim ()I
 	public fun getModules ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;


### PR DESCRIPTION
Bump engine pin and project version 0.28.1 → 0.29.1.

- gradle/libs.versions.toml: skainet 0.28.1 → 0.29.1
- gradle.properties: VERSION_NAME 0.28.1 → 0.29.1
- README + tutorial BOM snippets bumped to 0.29.1 (doc-version check green)
- CHANGELOG: [0.29.1] entry
- Refresh public API dumps (:llm-agent, :llm-core):
  - :llm-agent — AgentListener prefill-progress callback (stale since 0.23.2)
  - :llm-core — engine nn constructors gained a defaulted dtype type-token

Verified: ./gradlew check green against published SKaiNET 0.29.1.