### PR TITLE
feat(gemma): optional maxInferenceLen on load() to cap KV cache on constrained devices (#178)

### DIFF
--- a/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkLoader.kt
+++ b/llm-inference/gemma/src/commonMain/kotlin/sk/ainet/models/gemma/GemmaNetworkLoader.kt
@@ -120,7 +120,8 @@ public class GemmaNetworkLoader @PublishedApi internal constructor(
      * Load weights and build a fully initialized DSL network.
      */
     public suspend inline fun <reified T : DType, V> load(
-        ctx: ExecutionContext
+        ctx: ExecutionContext,
+        maxInferenceLen: Int? = null,
     ): Module<T, V> {
         val rawWeights: Gemma4Weights<T, V> = when (val wp = weightsProvider) {
             is WeightsProvider.GgufSource -> {
@@ -160,14 +161,15 @@ public class GemmaNetworkLoader @PublishedApi internal constructor(
                 rawWeights
             }
 
-        return applyWeightsToNetwork(ctx, weights)
+        return applyWeightsToNetwork(ctx, weights, maxInferenceLen)
     }
 
     @PublishedApi
     internal inline fun <reified T : DType, V> applyWeightsToNetwork(
         ctx: ExecutionContext,
-        weights: Gemma4Weights<T, V>
-    ): Module<T, V> = applyWeightsToNetworkNonReified(ctx, weights, T::class, debug)
+        weights: Gemma4Weights<T, V>,
+        maxInferenceLen: Int? = null,
+    ): Module<T, V> = applyWeightsToNetworkNonReified(ctx, weights, T::class, debug, maxInferenceLen)
 }
 
 /** Shared non-reified impl used by both the inline-reified companion helpers
@@ -177,7 +179,8 @@ internal fun <T : DType, V> applyWeightsToNetworkNonReified(
     ctx: ExecutionContext,
     weights: Gemma4Weights<T, V>,
     dtype: kotlin.reflect.KClass<T>,
-    debug: Boolean
+    debug: Boolean,
+    maxInferenceLen: Int? = null,
 ): Module<T, V> {
     // Enable optional Gemma 4 features iff the checkpoint actually carries
     // their weights. Real Gemma 4 GGUFs do; synthetic toy-model tests do not,
@@ -197,6 +200,7 @@ internal fun <T : DType, V> applyWeightsToNetworkNonReified(
     val model = gemmaNetwork<T, V>(
         weights.metadata,
         dtype,
+        maxInferenceLen = maxInferenceLen ?: minOf(weights.metadata.contextLength, 4096),
         qkNorm = hasQKNorm,
         sandwichNorms = hasSandwichNorms,
         layerOutputScale = hasLayerOutputScale,


### PR DESCRIPTION
Follow-up to #179. Adds an optional `maxInferenceLen` to `GemmaNetworkLoader.load()` (threaded through `applyWeightsToNetwork[NonReified]` → `gemmaNetwork`).

## Why
The eager network sizes its **KV cache + RoPE tables** for `maxInferenceLen` (default `min(contextLength, 4096)`). On the 1.9 GB SL2610, after #179 dropped the weight footprint to ~1.06 GB resident (packed Q8_0 lm_head), the **first forward** still allocates the ~0.4 GB KV cache for a 4096-token context and OOMs the board — even though a tool-call prompt is ~13 tokens.

Capping `maxInferenceLen` (e.g. 32) shrinks the KV cache ~100×, so the eager decode fits. Default `null` preserves existing behaviour.

## On-board evidence
A composite build of #736+#737+#179 loaded FunctionGemma to a **stable 1.06 GB** on the SL2610 (vs the prior 1.5 GB OOM-at-load), confirming the packed-Q8_0-lm_head fix works on hardware; the remaining OOM was the uncapped KV cache this param addresses.

Part of #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)