### PR TITLE
release: 0.33.0 — ship against SKaiNET engine 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ version line is kept in lock-step with the underlying SKaiNET engine
 The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] — 2026-06-29
+
+Ships against **SKaiNET engine 0.33.0**. No transformers API changes — this release adopts the new
+engine line and routine dependency updates.
+
+### Changed
+
+- **Engine → 0.33.0.** Transformer models authored with this layer inherit the engine's 0.33.0 work;
+  most relevant here, `layerNorm` / `rmsNorm` now lower to real `stablehlo.reduce`, so transformer
+  exports compile and run on stock IREE (engine #769). The engine also fixes a silent autodiff
+  gradient-drop (`elu`/`leakyRelu`/`permute`) and adds new differentiable ops (`cos`/`sin`/`gather`/…),
+  available to model authors. (engine 0.33.0)
+- **Dependencies:** Ktor client `3.5.1` (#198), Logback `1.5.36` (#199).
+
 ## [0.32.1] — 2026-06-26
 
 Fixes streaming detokenization — generated text no longer runs words together

--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ Honest status — see the project-status note at the top of this README.
 
 ## Current release
 
-The current release is **0.32.1** (against **SKaiNET 0.32.4**). It fixes streaming
-detokenization — per-token decode now keeps each word's leading space, so generated text
-no longer runs together (`"the process"` not `"theprocess"`). On top of the **0.32.0**
-real-GGUF **Llama** eager + StableHLO/IREE export work:
+The current release is **0.33.0** (against **SKaiNET 0.33.0**). It adopts the new engine line —
+no transformers API changes — so transformer models inherit the engine's 0.33.0 work: `layerNorm`/
+`rmsNorm` now lower to real `stablehlo.reduce` (exports compile on stock IREE), a silent autodiff
+gradient-drop is fixed, and new differentiable ops (`cos`/`sin`/`gather`/…) are available. On top of
+the **0.32.1** streaming-detokenization fix and the **0.32.0** real-GGUF **Llama** eager +
+StableHLO/IREE export work:
 
 - The eager **`NATIVE_OPTIMIZED` path now works for Llama** (`Q4_K`/`Q6_K`): weights stay
   packed and `LlamaNetworkLoader.fromGguf(NATIVE_OPTIMIZED) + OptimizedLLMRuntime` decodes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.transformers
-VERSION_NAME=0.32.1
+VERSION_NAME=0.33.0
 
 POM_DESCRIPTION=SKaiNET-transformers
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-skainet = "0.32.4"
+skainet = "0.33.0"
 agp = "9.2.1"
 jacksonDatabind = "2.22.0"
 jsonSchemaValidator = "3.0.5"


### PR DESCRIPTION
Cuts **transformers 0.33.0**, tracking the engine version line in lock-step (a transformers `X.Y.Z` ships against engine `X.Y.Z`).

- `VERSION_NAME` 0.32.1 → **0.33.0**; engine dependency 0.32.4 → **0.33.0** (now on Maven Central).
- **No transformers API changes.** Adopting engine 0.33.0 gives transformer models: `layerNorm`/`rmsNorm` lowering to real `stablehlo.reduce` (exports compile on stock IREE, engine #769), the autodiff dispatch correctness fix + new differentiable ops (engine #774).
- Includes the dependabot bumps already on develop: Ktor `3.5.1` (#198), Logback `1.5.36` (#199).

**Verified:** compiles + full `jvmTest` green against `sk.ainet.core:*:0.33.0` (engine's `TensorOps.sin/cos/convTranspose1d`-abstract break does not affect this layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)