### PR TITLE
Authors the Moonshine ASR **decoder** in the NN DSL, completing the DSL encoder-decoder

### DIFF
--- a/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshineConfig.kt
+++ b/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshineConfig.kt
@@ -25,6 +25,7 @@ public data class MoonshineConfig(
     val vocabSize: Int = 32768,
     val maxAudioSamples: Int = 64000, // 4 s @ 16 kHz → 165 frames
     val maxFrames: Int = 165,         // encoder sequence length after the conv frontend
+    val maxDecodeTokens: Int = 194,   // decoder RoPE table size = config max_position_embeddings (board uses ≤30)
     val ropeBase: Float = 10000.0f,
     // Moonshine uses PARTIAL rotary: only rotaryDim = headDim*partialRotaryFactor = 36*0.9 = 32
     // head dims are rotated (rotate-half / SPLIT_HALF), the trailing 4 pass through. Verified

--- a/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshineDecoder.kt
+++ b/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshineDecoder.kt
@@ -1,0 +1,422 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.hooks.withForwardHooks
+import sk.ainet.lang.nn.normalization.LayerNormalization
+import sk.ainet.lang.nn.transformer.MultiHeadAttention
+import sk.ainet.lang.nn.transformer.RoPE
+import sk.ainet.lang.nn.transformer.RoPEMode
+import sk.ainet.lang.nn.transformer.VoidDense
+import sk.ainet.lang.nn.transformer.linearProject
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.operators.bind
+import sk.ainet.lang.types.DType
+import kotlin.math.sqrt
+import kotlin.reflect.KClass
+
+/**
+ * Moonshine-tiny DECODER, authored in the SKaiNET NN DSL (Phase A stub).
+ *
+ * The decoder is seq2seq. Each pre-norm layer is three sublayers:
+ *   x + SelfAttn(LN(x))                       — causal, RoPE, no bias, KV-cached at runtime
+ *   x + CrossAttn(LN(x), encoderMemory)       — attends to the encoder memory, no RoPE, non-causal
+ *   x + MLP(LN(x))                            — GATED SiLU MLP (see below)
+ * then a final LayerNorm and the `proj_out` vocab projection (tied to `embed_tokens`).
+ *
+ * The MLP is the gated form Moonshine's decoder uses (verified against HF
+ * `MoonshineDecoderMLP`, `decoder_hidden_act="silu"`): a single fused `fc1`
+ * `[2·ffnDim, dim]` produces `[value | gate]`, then `silu(gate) * value`, then `fc2`
+ * `[dim, ffnDim]`; both fc1 and fc2 are biased. (The encoder MLP, by contrast, is a
+ * plain biased GELU MLP.)
+ *
+ * ## Why a bespoke module instead of the `HybridTransformerBlock` used by the encoder
+ * Cross-attention needs a **second** input — the encoder memory — but the DSL's
+ * `Stage`/`HybridTransformerBlock` thread a single tensor through a module list, so
+ * there is no way to route the memory through them. [MultiHeadAttention] already
+ * exposes the cross-attention entry `forward(input, encoderMemory, ctx)` (Q from the
+ * decoder state, K/V from the memory, RoPE + KV-cache bypassed, causal forced off);
+ * this layer just drives it imperatively, mirroring that two-argument contract. This
+ * keeps all decoder wiring inside the moonshine module — no `transformer-core` change.
+ *
+ * ## Scope of this stub
+ * Phase A proves the wiring: the model builds and traces to StableHLO with two graph
+ * inputs (`inputs_embeds` + encoder memory). It is **not** yet numerically validated
+ * (weights, Phase B) and does **not** yet export the two KV-cached decode graphs
+ * (Phase D) — self-attention here runs a plain causal prefill with no exported cache,
+ * and cross-K/V are re-projected rather than cached. The token embedding lookup is
+ * intentionally left OUT of the graph: the board decoder consumes `inputs_embeds`
+ * `[1, seq, dim]` (the embedding table is applied host-side), matching the vendor.
+ *
+ * ⚠️ Known Phase D blocker surfaced by this stub: at seq == 1 (the real one-token
+ * decode shape) the self-attention takes [MultiHeadAttention]'s fused-decode fast
+ * path, whose buffer-direct ops do not record on the trace tape — the seq=1 graph
+ * leaks per-layer self K/V as dangling outputs. seq ≥ 2 traces cleanly (general SDPA
+ * path). Exporting the KV-cached decode graphs must disable the fast path for tracing.
+ *
+ * Build with `BF16` so the DSL→StableHLO export keeps bf16 weights at the matmul (the
+ * Torq NPU requirement); param ids are layer-qualified for by-name weight loading.
+ */
+
+/** One Moonshine decoder layer: causal self-attn → cross-attn(memory) → GELU MLP, all pre-norm. */
+public class MoonshineDecoderLayer<T : DType, V>(
+    cfg: MoonshineConfig,
+    layer: Int,
+    dtype: KClass<T>,
+) : Module<T, V>() {
+
+    override val name: String = "dec.$layer"
+
+    private val dim = cfg.dim
+
+    private val selfNorm = LayerNormalization<T, V>(
+        normalizedShape = intArrayOf(dim),
+        eps = cfg.layerNormEps.toDouble(),
+        name = "dec.$layer.self_attn_norm",
+        dtype = dtype,
+    )
+
+    private val selfAttn = MultiHeadAttention<T, V>(
+        dim = dim,
+        nHeads = cfg.nHeads,
+        nKVHeads = cfg.nHeads,
+        causal = true, // decoder self-attention is causal
+        bias = false,
+        name = "dec.$layer.self_attn",
+        rope = RoPE(
+            headDim = cfg.headDim,
+            maxSeqLen = cfg.maxDecodeTokens,
+            base = cfg.ropeBase,
+            mode = RoPEMode.INTERLEAVED, // same partial-rotary form as the encoder (verified bit-exact vs ONNX)
+            partialRotaryFactor = cfg.partialRotaryFactor,
+            freqDenomRotaryDim = true, // inv_freq denom = rotaryDim (32), not headDim (36)
+            name = "dec.$layer.self_attn.rope",
+        ),
+        kvCache = null, // Phase D exports the self KV cache as graph I/O
+        dtype = dtype,
+    )
+
+    private val crossNorm = LayerNormalization<T, V>(
+        normalizedShape = intArrayOf(dim),
+        eps = cfg.layerNormEps.toDouble(),
+        name = "dec.$layer.cross_attn_norm",
+        dtype = dtype,
+    )
+
+    // Cross-attention: Q from the decoder state, K/V from the encoder memory. No RoPE
+    // (memory frames are already positioned by the encoder), non-causal, no cache here
+    // (cross-K/V are cached at the runtime/graph layer — the module rejects kvCache in
+    // cross mode). causal=false is also enforced internally for the cross path.
+    private val crossAttn = MultiHeadAttention<T, V>(
+        dim = dim,
+        nHeads = cfg.nHeads,
+        nKVHeads = cfg.nHeads,
+        causal = false,
+        bias = false,
+        name = "dec.$layer.cross_attn",
+        rope = null,
+        kvCache = null,
+        dtype = dtype,
+    )
+
+    private val mlpNorm = LayerNormalization<T, V>(
+        normalizedShape = intArrayOf(dim),
+        eps = cfg.layerNormEps.toDouble(),
+        name = "dec.$layer.mlp_norm",
+        dtype = dtype,
+    )
+
+    // Gated SiLU MLP. Fused fc1 [2·ffnDim, dim] emits [value | gate]; fc2 [dim, ffnDim].
+    private val ffnDim = cfg.ffnDim
+    private val mlpFc1 = VoidDense<T, V>("dec.$layer.mlp_fc1", cfg.ffnDim * 2, dim, dtype, addBias = true)
+    private val mlpFc2 = VoidDense<T, V>("dec.$layer.mlp_fc2", dim, cfg.ffnDim, dtype, addBias = true)
+
+    override val modules: List<Module<T, V>> =
+        listOf(selfNorm, selfAttn, crossNorm, crossAttn, mlpNorm, mlpFc1, mlpFc2)
+
+    /** The self-attention RoPE (all layers share config) — used to build runtime cos/sin tables. */
+    public val selfRope: RoPE<T, V> get() = selfAttn.rope!!
+
+    /**
+     * Cross-attention-aware forward. [input] is the decoder hidden state
+     * `[·, seq, dim]`; [encoderMemory] is the encoder output `[·, frames, dim]`.
+     */
+    public fun forward(
+        input: Tensor<T, V>,
+        encoderMemory: Tensor<T, V>,
+        ctx: ExecutionContext,
+    ): Tensor<T, V> {
+        val boundInput = input.bind(ctx)
+        val boundMemory = encoderMemory.bind(ctx)
+        return withForwardHooks(ctx, this, boundInput) {
+            val ops = ctx.ops
+            // x + SelfAttn(LN(x))
+            val afterSelf = ops.add(boundInput, selfAttn.forward(selfNorm.forward(boundInput, ctx), ctx))
+            // x + CrossAttn(LN(x), memory)
+            val afterCross = ops.add(afterSelf, crossAttn.forward(crossNorm.forward(afterSelf, ctx), boundMemory, ctx))
+            // x + MLP(LN(x)) — gated SiLU: fc1 → [value | gate] → silu(gate)*value → fc2
+            val h = mlpFc1.forward(mlpNorm.forward(afterCross, ctx), ctx)
+            val lastDim = h.rank - 1
+            val value = ops.narrow(h, lastDim, 0, ffnDim)
+            val gate = ops.narrow(h, lastDim, ffnDim, ffnDim)
+            val mlpOut = mlpFc2.forward(ops.multiply(ops.silu(gate), value), ctx)
+            ops.add(afterCross, mlpOut)
+        }
+    }
+
+    /**
+     * Prefill variant of [forward] that also returns the K/V this layer computed:
+     * `selfK/selfV` `[nHeads, seq, headDim]` (post-RoPE) and `crossK/crossV`
+     * `[nHeads, frames, headDim]` (memory projections). Used to export the KV-cached
+     * decode graphs — the `decoder` prefill graph surfaces these so `decoder_with_past`
+     * can consume them. Numerically identical to [forward] (same attention code).
+     */
+    public fun forwardWithKV(
+        input: Tensor<T, V>,
+        encoderMemory: Tensor<T, V>,
+        ctx: ExecutionContext,
+    ): MoonshineLayerKV<T, V> {
+        val ops = ctx.ops
+        val selfKV = selfAttn.forwardWithKV(selfNorm.forward(input, ctx), null, ctx)
+        val afterSelf = ops.add(input, selfKV.output)
+        val crossKV = crossAttn.forwardWithKV(crossNorm.forward(afterSelf, ctx), encoderMemory, ctx)
+        val afterCross = ops.add(afterSelf, crossKV.output)
+        val h = mlpFc1.forward(mlpNorm.forward(afterCross, ctx), ctx)
+        val lastDim = h.rank - 1
+        val value = ops.narrow(h, lastDim, 0, ffnDim)
+        val gate = ops.narrow(h, lastDim, ffnDim, ffnDim)
+        val mlpOut = mlpFc2.forward(ops.multiply(ops.silu(gate), value), ctx)
+        return MoonshineLayerKV(ops.add(afterCross, mlpOut), selfKV.k, selfKV.v, crossKV.k, crossKV.v)
+    }
+
+    /**
+     * `decoder_with_past` step for ONE new token at [position]. Self-attention appends the
+     * token's K/V to the incoming self cache ([selfKIn]/[selfVIn], `[1, nHeads, pos, headDim]`)
+     * and attends over the full cache; cross-attention consumes the CACHED cross K/V
+     * ([crossKIn]/[crossVIn], `[1, nHeads, frames, headDim]`) directly — no memory, no cross
+     * projection. Returns the layer output + the extended self cache (`[1, nHeads, pos+1, headDim]`).
+     *
+     * Hand-wired (not via `MultiHeadAttention.forward`) because the cache is graph I/O and RoPE
+     * must apply at the runtime [position]; it reuses the module's projection weights, RoPE module
+     * and the shared SDPA op, and for a single token the head reshape is a plain reshape — so it is
+     * numerically identical to the validated attention (checked by the two-graph transcript test).
+     */
+    public fun forwardWithPast(
+        input: Tensor<T, V>,
+        ropeCos: Tensor<T, V>,
+        ropeSin: Tensor<T, V>,
+        selfKIn: Tensor<T, V>,
+        selfVIn: Tensor<T, V>,
+        crossKIn: Tensor<T, V>,
+        crossVIn: Tensor<T, V>,
+        ctx: ExecutionContext,
+    ): MoonshinePastKV<T, V> {
+        val ops = ctx.ops
+        // --- self-attention: project, RoPE@runtime-position (cos/sin fed in), append + attend ---
+        val sn = selfNorm.forward(input, ctx)
+        val q = selfAttn.rope!!.forwardWithCosSin(projHeads(selfAttn, sn, 0, ctx), ropeCos, ropeSin, ctx)
+        val nk = selfAttn.rope!!.forwardWithCosSin(projHeads(selfAttn, sn, 1, ctx), ropeCos, ropeSin, ctx)
+        val nv = projHeads(selfAttn, sn, 2, ctx)
+        val fullK = ops.concat(listOf(selfKIn, ops.unsqueeze(nk, 0)), dim = 2) // [1, nHeads, pos+1, headDim]
+        val fullV = ops.concat(listOf(selfVIn, ops.unsqueeze(nv, 0)), dim = 2)
+        val afterSelf = ops.add(input, sdpaMerge(selfAttn, q, fullK, fullV, ctx))
+        // --- cross-attention: project Q only, attend over the CACHED cross K/V ---
+        val cq = projHeads(crossAttn, crossNorm.forward(afterSelf, ctx), 0, ctx)
+        val afterCross = ops.add(afterSelf, sdpaMerge(crossAttn, cq, crossKIn, crossVIn, ctx))
+        // --- gated SiLU MLP ---
+        val h = mlpFc1.forward(mlpNorm.forward(afterCross, ctx), ctx)
+        val ld = h.rank - 1
+        val mlpOut = mlpFc2.forward(ops.multiply(ops.silu(ops.narrow(h, ld, ffnDim, ffnDim)), ops.narrow(h, ld, 0, ffnDim)), ctx)
+        return MoonshinePastKV(ops.add(afterCross, mlpOut), fullK, fullV)
+    }
+
+    // Project one of q/k/v (paramIdx 0/1/2) for a single-token input to heads-first
+    // [nHeads, 1, headDim]. For seq==1 the reshape equals MHA's swap-then-reshape.
+    private fun projHeads(mha: MultiHeadAttention<T, V>, x: Tensor<T, V>, paramIdx: Int, ctx: ExecutionContext): Tensor<T, V> {
+        val p = linearProject(ctx.ops, x, mha.params[paramIdx].value) // [1, 1, qDim]
+        return ctx.ops.reshape(p, Shape(mha.nHeads, 1, mha.headDim))
+    }
+
+    // SDPA over cached K/V then output projection. q [nHeads,1,headDim]; k/v [1,nHeads,S,headDim].
+    private fun sdpaMerge(mha: MultiHeadAttention<T, V>, q: Tensor<T, V>, k: Tensor<T, V>, v: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> {
+        val ops = ctx.ops
+        val o = ops.scaledDotProductAttention(
+            query = ops.unsqueeze(q, 0), key = k, value = v,
+            mask = null, scale = 1f / sqrt(mha.headDim.toFloat()), causal = false,
+        ) // [1, nHeads, 1, headDim]; single query attends to all cached positions → no mask needed
+        val merged = ops.reshape(ops.squeeze(o, 0), Shape(1, mha.nHeads * mha.headDim)) // [1, qDim]
+        return linearProject(ops, merged, mha.params[3].value) // o_proj (bias=false)
+    }
+
+    // This layer must be driven through the two-argument [forward] so the encoder
+    // memory is supplied; the single-input entry has no memory to cross-attend to.
+    override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> =
+        error("MoonshineDecoderLayer requires encoder memory: call forward(input, encoderMemory, ctx)")
+}
+
+/** `decoder_with_past` layer output + extended self cache (`[1, nHeads, pos+1, headDim]`). */
+public class MoonshinePastKV<T : DType, V>(
+    public val out: Tensor<T, V>,
+    public val newSelfK: Tensor<T, V>,
+    public val newSelfV: Tensor<T, V>,
+)
+
+/** One layer's output plus its self/cross K/V (`[nHeads, seq, headDim]`), for prefill KV export. */
+public class MoonshineLayerKV<T : DType, V>(
+    public val out: Tensor<T, V>,
+    public val selfK: Tensor<T, V>,
+    public val selfV: Tensor<T, V>,
+    public val crossK: Tensor<T, V>,
+    public val crossV: Tensor<T, V>,
+)
+
+/**
+ * Full Moonshine decoder: N [MoonshineDecoderLayer]s + final LayerNorm + `lm_head`.
+ * Input is `inputs_embeds` `[·, seq, dim]` (embedding lookup is host-side); output is
+ * logits `[·, seq, vocab]`.
+ */
+public class MoonshineDecoderModel<T : DType, V>(
+    private val cfg: MoonshineConfig,
+    private val dtype: KClass<T>,
+) : Module<T, V>() {
+
+    override val name: String = "moonshine_decoder"
+
+    private val layers: List<MoonshineDecoderLayer<T, V>> =
+        (0 until cfg.decoderLayers).map { MoonshineDecoderLayer<T, V>(cfg, it, dtype) }
+
+    private val outNorm = LayerNormalization<T, V>(
+        normalizedShape = intArrayOf(cfg.dim),
+        eps = cfg.layerNormEps.toDouble(),
+        name = "dec_out_norm",
+        dtype = dtype,
+    )
+
+    // lm_head vocab projection [vocab, dim], no bias. Moonshine's `proj_out` is TIED to
+    // `decoder.embed_tokens` (the checkpoint stores only embed_tokens; there is no separate
+    // proj_out tensor) — the weight baker feeds embed_tokens here. logits = hidden @ Wᵀ.
+    private val lmHead = VoidDense<T, V>("lm_head", cfg.vocabSize, cfg.dim, dtype, addBias = false)
+
+    override val modules: List<Module<T, V>> = layers + listOf(outNorm, lmHead)
+
+    /**
+     * Prefill/decode forward over [inputsEmbeds] `[·, seq, dim]` attending to
+     * [encoderMemory] `[·, frames, dim]`; returns logits `[·, seq, vocab]`.
+     */
+    public fun forward(
+        inputsEmbeds: Tensor<T, V>,
+        encoderMemory: Tensor<T, V>,
+        ctx: ExecutionContext,
+    ): Tensor<T, V> {
+        val memory = encoderMemory.bind(ctx)
+        var h = inputsEmbeds.bind(ctx)
+        for (layer in layers) h = layer.forward(h, memory, ctx)
+        return lmHead.forward(outNorm.forward(h, ctx), ctx)
+    }
+
+    /**
+     * Prefill export forward: returns logits plus the per-layer self/cross K/V as batched
+     * tensors (`selfK/V [1, nHeads, seq, headDim]`, `crossK/V [1, nHeads, frames, headDim]`) —
+     * matching the board's `decoder` graph outputs. Trace this to emit the KV-cached prefill
+     * graph; the returned tensors, being unconsumed, become graph outputs.
+     */
+    public fun forwardPrefill(
+        inputsEmbeds: Tensor<T, V>,
+        encoderMemory: Tensor<T, V>,
+        ctx: ExecutionContext,
+    ): MoonshinePrefillOutput<T, V> {
+        val ops = ctx.ops
+        val memory = encoderMemory.bind(ctx)
+        var h = inputsEmbeds.bind(ctx)
+        val selfK = ArrayList<Tensor<T, V>>(layers.size)
+        val selfV = ArrayList<Tensor<T, V>>(layers.size)
+        val crossK = ArrayList<Tensor<T, V>>(layers.size)
+        val crossV = ArrayList<Tensor<T, V>>(layers.size)
+        for (layer in layers) {
+            val kv = layer.forwardWithKV(h, memory, ctx)
+            h = kv.out
+            // add the batch dim so the exported shapes match the board's [1, nHeads, ·, headDim].
+            selfK += ops.unsqueeze(kv.selfK, 0)
+            selfV += ops.unsqueeze(kv.selfV, 0)
+            crossK += ops.unsqueeze(kv.crossK, 0)
+            crossV += ops.unsqueeze(kv.crossV, 0)
+        }
+        val logits = lmHead.forward(outNorm.forward(h, ctx), ctx)
+        return MoonshinePrefillOutput(logits, selfK, selfV, crossK, crossV)
+    }
+
+    /**
+     * `decoder_with_past` graph: one new [tokenEmbed] `[1,1,dim]` at [position], the incoming
+     * per-layer self cache ([selfKIn]/[selfVIn]) and the fixed cross cache ([crossKIn]/[crossVIn])
+     * → logits `[1,1,vocab]` + the per-layer extended self cache. Trace this to emit the second
+     * board graph; drive it in a loop after [forwardPrefill] for autoregressive decode.
+     */
+    public fun forwardWithPast(
+        tokenEmbed: Tensor<T, V>,
+        ropeCos: Tensor<T, V>,
+        ropeSin: Tensor<T, V>,
+        selfKIn: List<Tensor<T, V>>,
+        selfVIn: List<Tensor<T, V>>,
+        crossKIn: List<Tensor<T, V>>,
+        crossVIn: List<Tensor<T, V>>,
+        ctx: ExecutionContext,
+    ): MoonshineWithPastOutput<T, V> {
+        val ops = ctx.ops
+        var h = tokenEmbed.bind(ctx)
+        val nsk = ArrayList<Tensor<T, V>>(layers.size)
+        val nsv = ArrayList<Tensor<T, V>>(layers.size)
+        for ((i, layer) in layers.withIndex()) {
+            val r = layer.forwardWithPast(h, ropeCos, ropeSin, selfKIn[i], selfVIn[i], crossKIn[i], crossVIn[i], ctx)
+            h = r.out
+            // The extended cache also feeds this layer's SDPA, so it is not a graph sink. Route the
+            // exported copy through a shape-preserving reshape so it becomes a distinct output node
+            // (mirrors how the prefill graph's unsqueeze creates its KV output sinks). Identity at
+            // runtime; the compiler folds it.
+            nsk += ops.reshape(r.newSelfK, r.newSelfK.shape)
+            nsv += ops.reshape(r.newSelfV, r.newSelfV.shape)
+        }
+        val logits = lmHead.forward(outNorm.forward(h, ctx), ctx)
+        return MoonshineWithPastOutput(logits, nsk, nsv)
+    }
+
+    /**
+     * Build the RoPE cos/sin table tensors `[seqLen, headDim]` for [position], to feed
+     * [forwardWithPast]. The runtime supplies these because the decode position is dynamic
+     * (no in-graph gather); all layers share RoPE config so layer 0's tables apply to every layer.
+     */
+    public fun buildRopeCosSin(position: Int, seqLen: Int, ctx: ExecutionContext): Pair<Tensor<T, V>, Tensor<T, V>> {
+        val (c, s) = layers[0].selfRope.buildInterleavedCosSin(position, seqLen)
+        val shape = Shape(seqLen, cfg.headDim)
+        return ctx.fromFloatArray<T, V>(shape, dtype, c) to ctx.fromFloatArray<T, V>(shape, dtype, s)
+    }
+
+    override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> =
+        error("MoonshineDecoderModel requires encoder memory: call forward(inputsEmbeds, encoderMemory, ctx)")
+}
+
+/** `decoder_with_past` outputs: logits + per-layer extended self K/V. */
+public class MoonshineWithPastOutput<T : DType, V>(
+    public val logits: Tensor<T, V>,
+    public val selfK: List<Tensor<T, V>>,
+    public val selfV: List<Tensor<T, V>>,
+)
+
+/** Prefill graph outputs: logits + per-layer self/cross K/V (batched, board layout). */
+public class MoonshinePrefillOutput<T : DType, V>(
+    public val logits: Tensor<T, V>,
+    public val selfK: List<Tensor<T, V>>,
+    public val selfV: List<Tensor<T, V>>,
+    public val crossK: List<Tensor<T, V>>,
+    public val crossV: List<Tensor<T, V>>,
+)
+
+/**
+ * Build the Moonshine-tiny decoder in the NN DSL. Mirrors [moonshineEncoder]; returns
+ * the concrete [MoonshineDecoderModel] so callers can use its two-argument
+ * `forward(inputsEmbeds, encoderMemory, ctx)`.
+ */
+public fun <T : DType, V> moonshineDecoder(
+    cfg: MoonshineConfig,
+    dtype: KClass<T>,
+): MoonshineDecoderModel<T, V> = MoonshineDecoderModel(cfg, dtype)

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderBakeTest.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderBakeTest.kt
@@ -1,0 +1,82 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Phase B verification: bake the REAL moonshine-tiny decoder weights into
+ * [MoonshineDecoderModel] and confirm every DSL param maps to a checkpoint tensor with a
+ * matching shape (the name/shape half of Phase B — what catches almost all mapping bugs).
+ * Then trace with `embedConstants=true` and assert the weights fold to `stablehlo.constant`,
+ * leaving only the two data inputs (`inputs_embeds` + encoder memory).
+ *
+ * Gated on `DEC_CHECKPOINT=<dir of per-tensor .bin>` (from `convert_moonshine_weights.py`);
+ * the test is a no-op skip when it is unset so CI without the checkpoint stays green.
+ *
+ * NOTE: the full Phase-B "done means" — f32 CPU cos ≈ 1.0 vs the HF decoder on injected
+ * encoder memory — additionally needs a `transformers` reference and is tracked separately.
+ */
+class MoonshineDecoderBakeTest {
+    @Test
+    fun bakeRealDecoderWeights() {
+        val dir = System.getenv("DEC_CHECKPOINT") ?: run {
+            println("SKIP bakeRealDecoderWeights: set DEC_CHECKPOINT to the .bin weights dir")
+            return
+        }
+        val cfg = MoonshineConfig()
+        val model = moonshineDecoder<FP32, Float>(cfg, FP32::class)
+
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val baked = bakeDecoderWeights(model, DecDirBinWeightSource(dir), FP32::class, ctx as ExecutionContext)
+
+        // Every param baked (bakeDecoderWeights fail-fasts on any missing tensor / shape mismatch).
+        val paramCount = countParams(model)
+        assertEquals(paramCount, baked, "every decoder param must bake")
+        println("BAKED $baked decoder params from $dir")
+
+        // Trace with the baked constants folded in; only the 2 data inputs should remain.
+        val embeds = voidF32(Shape(1, 2, cfg.dim))   // seq=2 → general SDPA path (see decoder-dump caveat)
+        val memory = voidF32(Shape(1, cfg.maxFrames, cfg.dim))
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                model.forward(embeds, memory, this as ExecutionContext)
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(
+            synthesizeExternalInputs = true,
+            embedConstants = true,
+        )
+        val mlir = sk.ainet.compile.hlo.toStableHlo(graph, "moonshine_decoder").content
+        val argCount = Regex("""%arg\d+""").findAll(mlir.substringBefore(") ->")).map { it.value }.toSet().size
+        println("decoder MLIR entry args after embedConstants: $argCount")
+        assertTrue(mlir.contains("stablehlo.constant"), "baked weights should fold to constants")
+        assertEquals(2, argCount, "only inputs_embeds + encoder memory should remain as args")
+    }
+
+    private fun countParams(m: sk.ainet.lang.nn.Module<*, *>): Int =
+        m.params.size + m.modules.sumOf { countParams(it) }
+
+    private fun voidF32(shape: Shape): VoidOpsTensor<FP32, Float> =
+        VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = shape
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+}

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderE2ECpuTest.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderE2ECpuTest.kt
@@ -1,0 +1,184 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.apps.llm.tokenizer.GGUFTokenizer
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Phase C — fully in-stack CPU proof of the DSL DECODER (no HF, no vendor decoder binary).
+ *
+ * Greedy re-decode: our [moonshineDecoder] (real weights, eager on [DirectCpuExecutionContext])
+ * attends to the REFERENCE encoder memory for `test.wav` and must transcribe "One, two, three.".
+ * "Re-decode" = no KV cache; each step feeds the full token prefix `[1, t, dim]` and takes the
+ * last-position argmax (the simplest graph shape — KV-cache export is Phase D). The token
+ * embedding is looked up host-side from `decoder.embed_tokens.weight` (the board decoder likewise
+ * consumes `inputs_embeds`).
+ *
+ * The encoder memory is produced by the reference ONNX frontend+encoder (`enc_frontend`→
+ * `enc_xformer`) — this test isolates the DECODER; Phase C's encoder half swaps in our eager
+ * encoder. So the only Moonshine-specific compute under test here is OUR decoder + weights.
+ *
+ * Gated on env (skips cleanly if unset):
+ *   MOON_REF        dir with `memory.bin` (reference encoder memory `[1,165,288]` f32)
+ *   DEC_CHECKPOINT  dir with per-tensor `.bin` decoder weights (from convert_moonshine_weights.py)
+ *   MOON_TOKENIZER  path to moonshine-tiny `tokenizer.json`
+ */
+class MoonshineDecoderE2ECpuTest {
+    @Test
+    fun greedyDecodeReferenceMemoryTranscribes() {
+        val refDir = System.getenv("MOON_REF") ?: return skip("MOON_REF")
+        val ckpt = System.getenv("DEC_CHECKPOINT") ?: return skip("DEC_CHECKPOINT")
+        val tokJson = System.getenv("MOON_TOKENIZER") ?: return skip("MOON_TOKENIZER")
+
+        val cfg = MoonshineConfig()
+        val ctx = DirectCpuExecutionContext.create()
+        val decoder = moonshineDecoder<FP32, Float>(cfg, FP32::class)
+        val baked = bakeDecoderWeights(decoder, DecDirBinWeightSource(ckpt), FP32::class, ctx as ExecutionContext)
+        println("baked $baked decoder params")
+
+        // Reference encoder memory [1, frames, dim] (from the ONNX frontend+encoder).
+        val memData = readF32(File(refDir, "memory.bin"))
+        val frames = memData.size / cfg.dim
+        val memory = ctx.fromFloatArray<FP32, Float>(Shape(1, frames, cfg.dim), FP32::class, memData)
+
+        val text = decodeToText(decoder, memory, ckpt, tokJson, cfg, ctx)
+        println("OUR decoder (reference memory) → \"$text\"")
+        assertEquals("One, two, three.", text, "our DSL decoder must transcribe the reference audio")
+    }
+
+    /** Full in-stack: OUR encoder (eager) → OUR decoder (eager), no ONNX/HF/vendor in the model path. */
+    @Test
+    fun ourEncoderOurDecoderTranscribes() {
+        val refDir = System.getenv("MOON_REF") ?: return skip("MOON_REF")
+        val ckpt = System.getenv("DEC_CHECKPOINT") ?: return skip("DEC_CHECKPOINT")
+        val tokJson = System.getenv("MOON_TOKENIZER") ?: return skip("MOON_TOKENIZER")
+
+        val cfg = MoonshineConfig()
+        val ctx = DirectCpuExecutionContext.create()
+
+        // OUR encoder, real HF weights, eager on the reference conv-frontend features.
+        val encoder = moonshineEncoder<FP32, Float>(cfg, FP32::class)
+        bakeMoonshineWeights(encoder, DecDirBinWeightSource(ckpt), ::encoderHfNameFor, FP32::class, ctx as ExecutionContext)
+        val featData = readF32(File(refDir, "features.bin"))
+        val frames = featData.size / cfg.dim
+        val features = ctx.fromFloatArray<FP32, Float>(Shape(1, frames, cfg.dim), FP32::class, featData)
+        val ourMemory = encoder.forward(features, ctx)
+
+        // Sanity: our encoder memory matches the reference encoder (cosine ≈ 1.0).
+        val cos = cosine(ourMemory.data.copyToFloatArray(), readF32(File(refDir, "memory.bin")))
+        println("our-encoder vs reference memory cosine = $cos")
+        assertTrue(cos > 0.99, "our encoder memory must match the reference (cos=$cos)")
+
+        // OUR decoder on OUR memory.
+        val decoder = moonshineDecoder<FP32, Float>(cfg, FP32::class)
+        bakeDecoderWeights(decoder, DecDirBinWeightSource(ckpt), FP32::class, ctx)
+        val text = decodeToText(decoder, ourMemory, ckpt, tokJson, cfg, ctx)
+        println("OUR encoder+decoder → \"$text\"")
+        assertEquals("One, two, three.", text, "fully in-stack encoder+decoder must transcribe the audio")
+    }
+
+    /** Two-graph KV loop: prefill → decoder_with_past steps must reproduce the Phase C transcript. */
+    @Test
+    fun twoGraphKvLoopTranscribes() {
+        val refDir = System.getenv("MOON_REF") ?: return skip("MOON_REF")
+        val ckpt = System.getenv("DEC_CHECKPOINT") ?: return skip("DEC_CHECKPOINT")
+        val tokJson = System.getenv("MOON_TOKENIZER") ?: return skip("MOON_TOKENIZER")
+
+        val cfg = MoonshineConfig()
+        val ctx = DirectCpuExecutionContext.create()
+        val model = moonshineDecoder<FP32, Float>(cfg, FP32::class)
+        bakeDecoderWeights(model, DecDirBinWeightSource(ckpt), FP32::class, ctx as ExecutionContext)
+
+        val memData = readF32(File(refDir, "memory.bin"))
+        val frames = memData.size / cfg.dim
+        val memory = ctx.fromFloatArray<FP32, Float>(Shape(1, frames, cfg.dim), FP32::class, memData)
+        val embed = readF32(File(ckpt, "decoder.embed_tokens.weight.bin"))
+
+        val start = 1; val end = 2; val maxTokens = 16
+        // Prefill on the START token → logits + self/cross caches.
+        val prefill = model.forwardPrefill(embedRow(embed, start, cfg, ctx), memory, ctx)
+        var selfK = prefill.selfK; var selfV = prefill.selfV
+        val crossK = prefill.crossK; val crossV = prefill.crossV
+        var next = argmaxRow(prefill.logits.data.copyToFloatArray(), row = 0, cols = cfg.vocabSize)
+
+        val ids = mutableListOf(start)
+        var pos = 1
+        while (next != end && ids.size <= maxTokens) {
+            ids.add(next)
+            val (cos, sin) = model.buildRopeCosSin(pos, 1, ctx) // runtime-position RoPE tables, host-built
+            val past = model.forwardWithPast(embedRow(embed, next, cfg, ctx), cos, sin, selfK, selfV, crossK, crossV, ctx)
+            selfK = past.selfK; selfV = past.selfV
+            next = argmaxRow(past.logits.data.copyToFloatArray(), row = 0, cols = cfg.vocabSize)
+            pos++
+        }
+        val text = GGUFTokenizer.fromTokenizerJson(File(tokJson).readText()).decode(ids.drop(1).toIntArray()).trim()
+        println("two-graph KV loop → ids=${ids.drop(1)}  text=\"$text\"")
+        assertEquals("One, two, three.", text, "prefill + decoder_with_past loop must match the transcript")
+    }
+
+    private fun embedRow(embed: FloatArray, token: Int, cfg: MoonshineConfig, ctx: ExecutionContext): sk.ainet.lang.tensor.Tensor<FP32, Float> {
+        val row = FloatArray(cfg.dim)
+        System.arraycopy(embed, token * cfg.dim, row, 0, cfg.dim)
+        return ctx.fromFloatArray<FP32, Float>(Shape(1, 1, cfg.dim), FP32::class, row)
+    }
+
+    /** Greedy re-decode: [memory] is the encoder output; returns the detokenized transcript. */
+    private fun decodeToText(
+        decoder: MoonshineDecoderModel<FP32, Float>,
+        memory: sk.ainet.lang.tensor.Tensor<FP32, Float>,
+        ckpt: String,
+        tokJson: String,
+        cfg: MoonshineConfig,
+        ctx: ExecutionContext,
+    ): String {
+        val embed = readF32(File(ckpt, "decoder.embed_tokens.weight.bin")) // [vocab, dim]
+        val start = 1; val end = 2; val maxTokens = 16
+        val ids = mutableListOf(start)
+        for (step in 0 until maxTokens) {
+            val emb = FloatArray(ids.size * cfg.dim)
+            for ((i, t) in ids.withIndex()) System.arraycopy(embed, t * cfg.dim, emb, i * cfg.dim, cfg.dim)
+            val embeds = ctx.fromFloatArray<FP32, Float>(Shape(1, ids.size, cfg.dim), FP32::class, emb)
+            val logits = decoder.forward(embeds, memory, ctx)
+            val next = argmaxRow(logits.data.copyToFloatArray(), row = ids.size - 1, cols = cfg.vocabSize)
+            if (next == end) break
+            ids.add(next)
+        }
+        val tokenizer = GGUFTokenizer.fromTokenizerJson(File(tokJson).readText())
+        return tokenizer.decode(ids.drop(1).toIntArray()).trim()
+    }
+
+    private fun cosine(a: FloatArray, b: FloatArray): Double {
+        val n = minOf(a.size, b.size)
+        var dot = 0.0; var na = 0.0; var nb = 0.0
+        for (i in 0 until n) { dot += a[i] * b[i]; na += a[i] * a[i].toDouble(); nb += b[i] * b[i].toDouble() }
+        return dot / (kotlin.math.sqrt(na) * kotlin.math.sqrt(nb))
+    }
+
+    private fun skip(missing: String) = println("SKIP moonshine E2E: set $missing")
+
+    private fun argmaxRow(flat: FloatArray, row: Int, cols: Int): Int {
+        val base = row * cols
+        var best = 0
+        var bestV = flat[base]
+        for (c in 1 until cols) {
+            val v = flat[base + c]
+            if (v > bestV) { bestV = v; best = c }
+        }
+        return best
+    }
+
+    private fun readF32(f: File): FloatArray {
+        val b = f.readBytes()
+        return FloatArray(b.size / 4) { i ->
+            var bits = 0
+            for (k in 0 until 4) bits = bits or ((b[i * 4 + k].toInt() and 0xFF) shl (8 * k))
+            Float.fromBits(bits)
+        }
+    }
+}

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderMlirDumpTest.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderMlirDumpTest.kt
@@ -1,0 +1,115 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.BF16
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Phase A stub test: traces the Moonshine DECODER stack to StableHLO with TWO graph
+ * inputs — `inputs_embeds` `[·, seq, dim]` and encoder memory `[·, frames, dim]` — and
+ * asserts the wiring compiles (self-attn → cross-attn(memory) → GELU MLP → norm → lm_head)
+ * and the weights land as the configured dtype (bf16 by default, the Torq NPU requirement).
+ *
+ * This proves cross-attention threading only; numeric validation (weights, Phase B) and
+ * the two KV-cached decode graphs (Phase D) are not covered here.
+ *
+ * Phase D fix (landed): at DEC_SEQ=1 (the real one-token decode shape) the self-attention
+ * used to take [MultiHeadAttention]'s fused-decode fast path, whose buffer-direct ops don't
+ * record on the trace tape — leaking per-layer self K/V as dangling `[8,1,36]` outputs. That
+ * path is now guarded by `!ctx.isRecording`, so tracing falls through to the symbolic SDPA
+ * path and seq=1 exports one clean logits output. This test asserts that single output.
+ *
+ * Env knobs (mirror the encoder dump test):
+ *   DEC_LAYERS   decoder layer count      (default cfg.decoderLayers = 6)
+ *   DEC_SEQ      decoder query length     (default 1 — the real prefill/decode shape)
+ *   DEC_FRAMES   encoder memory frames    (default cfg.maxFrames = 165; board layout = 207)
+ *   DEC_DTYPE=FP32   trace an f32 decoder (numeric bring-up); default bf16
+ *   DEC_SKIP_DTYPE=1 leave the trace's mixed precision intact
+ *   MOONSHINE_MLIR_OUT  output path       (default build/build-mlir/moonshine-decoder.mlir)
+ */
+class MoonshineDecoderMlirDumpTest {
+    @Test
+    fun dumpDecoderBf16Mlir() {
+        val cfg = MoonshineConfig(
+            decoderLayers = System.getProperty("decLayers")?.toInt()
+                ?: (System.getenv("DEC_LAYERS")?.toInt() ?: 6),
+        )
+        val seq = System.getenv("DEC_SEQ")?.toInt() ?: 1
+        val frames = System.getenv("DEC_FRAMES")?.toInt() ?: cfg.maxFrames
+        val useF32 = System.getenv("DEC_DTYPE") == "FP32"
+
+        val mlir = if (useF32) {
+            traceDecoder(cfg, seq, frames, FP32::class, "FP32")
+        } else {
+            traceDecoder(cfg, seq, frames, BF16::class, "BF16")
+        }
+
+        val out = File(
+            System.getProperty("moonshineMlirOut")
+                ?: (System.getenv("MOONSHINE_MLIR_OUT") ?: "build/build-mlir/moonshine-decoder.mlir"),
+        )
+        out.parentFile?.mkdirs()
+        out.writeText(mlir)
+        println("WROTE_MLIR ${out.absolutePath} (${mlir.lines().size} lines)")
+
+        assertTrue(mlir.contains(if (useF32) "f32" else "bf16"), "decoder MLIR must carry $useF32-consistent weights")
+        assertTrue(mlir.contains("moonshine_decoder"), "decoder MLIR must name the entry function")
+        // The fused-decode guard means seq=1 traces cleanly: exactly ONE result (logits),
+        // no dangling per-head self K/V outputs.
+        val returns = Regex("""\)\s*->\s*\(([^)]*)\)""").find(mlir)?.groupValues?.get(1) ?: ""
+        val nResults = returns.split(",").count { it.contains("tensor<") }
+        assertTrue(nResults == 1, "seq=$seq decoder must have a single logits output, got $nResults: $returns")
+    }
+
+    private fun <T : DType> traceDecoder(
+        cfg: MoonshineConfig,
+        seq: Int,
+        frames: Int,
+        dtypeClass: KClass<T>,
+        floatDtype: String,
+    ): String {
+        val model = moonshineDecoder<T, Float>(cfg, dtypeClass)
+        val embeds = voidTensor(Shape(1, seq, cfg.dim), dtypeClass)
+        val memory = voidTensor(Shape(1, frames, cfg.dim), dtypeClass)
+
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                model.forward(embeds, memory, this as ExecutionContext)
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+        val rawGraph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
+        // Same HW-agnostic edge-dtype unification as the encoder dump; Torq tiling/bf16
+        // passes are applied downstream by the target build, not here.
+        val dtypeTarget = if (System.getenv("DEC_SKIP_DTYPE") == "1") null else floatDtype
+        val graph = sk.ainet.compile.opt.passes.DtypeForwardPropagationPass(targetFloatDtype = dtypeTarget)
+            .apply(rawGraph).graph
+        return sk.ainet.compile.hlo.toStableHlo(graph, "moonshine_decoder").content
+    }
+
+    private fun <T : DType> voidTensor(shape: Shape, dtypeClass: KClass<T>): VoidOpsTensor<T, Float> =
+        VoidOpsTensor(
+            object : TensorData<T, Float> {
+                override val shape = shape
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            dtypeClass,
+        )
+}

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderPrefillMlirDumpTest.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderPrefillMlirDumpTest.kt
@@ -1,0 +1,84 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.BF16
+import sk.ainet.lang.types.DType
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Phase D — the `decoder` PREFILL KV-cache export graph.
+ *
+ * Traces [MoonshineDecoderModel.forwardPrefill] and asserts it emits the board's `decoder`
+ * contract: logits `[1, seq, 32768]` + per layer `self_k/v [1, nHeads, seq, headDim]` and
+ * `cross_k/v [1, nHeads, frames, headDim]` (6 layers → 24 KV outputs, 25 total). The returned
+ * KV tensors, being unconsumed, surface as graph outputs — enabled by the fused-decode trace
+ * fix (seq==1 now traces the symbolic SDPA path, so K/V are real graph values not buffer reads).
+ *
+ * Env: DEC_FRAMES (encoder memory frames; default 207 = board), DEC_SEQ (default 1 = START token),
+ * DEC_DTYPE=FP32, MOONSHINE_MLIR_OUT.
+ */
+class MoonshineDecoderPrefillMlirDumpTest {
+    @Test
+    fun dumpPrefillKvGraph() {
+        val cfg = MoonshineConfig()
+        val seq = System.getenv("DEC_SEQ")?.toInt() ?: 1
+        val frames = System.getenv("DEC_FRAMES")?.toInt() ?: 207
+        val useF32 = System.getenv("DEC_DTYPE") == "FP32"
+
+        val mlir = if (useF32) trace(cfg, seq, frames, sk.ainet.lang.types.FP32::class, "FP32")
+        else trace(cfg, seq, frames, BF16::class, "BF16")
+
+        val out = File(System.getenv("MOONSHINE_MLIR_OUT") ?: "build/build-mlir/moonshine-decoder-prefill.mlir")
+        out.parentFile?.mkdirs()
+        out.writeText(mlir)
+        println("WROTE_MLIR ${out.absolutePath} (${mlir.lines().size} lines)")
+
+        val returns = Regex("""\)\s*->\s*\(([^)]*)\)""").find(mlir)?.groupValues?.get(1) ?: ""
+        val results = returns.split(",").map { it.trim() }.filter { it.contains("tensor<") }
+        val nHeads = cfg.nHeads; val hd = cfg.headDim
+        val logits = results.count { it.contains("x${cfg.vocabSize}x") }
+        val selfKv = results.count { it.contains("x${nHeads}x${seq}x${hd}x") }
+        val crossKv = results.count { it.contains("x${nHeads}x${frames}x${hd}x") }
+        println("prefill outputs: total=${results.size} logits=$logits selfKV=$selfKv crossKV=$crossKv")
+
+        assertEquals(1 + 4 * cfg.decoderLayers, results.size, "expect logits + 4·layers KV outputs")
+        assertEquals(1, logits, "one logits output [1,$seq,${cfg.vocabSize}]")
+        assertEquals(2 * cfg.decoderLayers, selfKv, "self k+v per layer, [1,$nHeads,$seq,$hd]")
+        assertEquals(2 * cfg.decoderLayers, crossKv, "cross k+v per layer, [1,$nHeads,$frames,$hd]")
+        assertTrue(mlir.contains("bf16") || useF32, "prefill weights should be bf16 by default")
+    }
+
+    private fun <T : DType> trace(cfg: MoonshineConfig, seq: Int, frames: Int, dtype: KClass<T>, f: String): String {
+        val model = moonshineDecoder<T, Float>(cfg, dtype)
+        val embeds = voidTensor(Shape(1, seq, cfg.dim), dtype)
+        val memory = voidTensor(Shape(1, frames, cfg.dim), dtype)
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try { model.forwardPrefill(embeds, memory, this as ExecutionContext) } finally { Execution.tapeStack.popTape() }
+        }.first
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
+        val dt = if (System.getenv("DEC_SKIP_DTYPE") == "1") null else f
+        val g = sk.ainet.compile.opt.passes.DtypeForwardPropagationPass(targetFloatDtype = dt).apply(graph).graph
+        return sk.ainet.compile.hlo.toStableHlo(g, "moonshine_decoder_prefill").content
+    }
+
+    private fun <T : DType> voidTensor(shape: Shape, dtype: KClass<T>): VoidOpsTensor<T, Float> =
+        VoidOpsTensor(object : TensorData<T, Float> {
+            override val shape = shape
+            override fun get(vararg indices: Int): Float = 0.0f
+            override fun set(vararg indices: Int, value: Float) {}
+        }, dtype)
+}

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderWeights.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderWeights.kt
@@ -1,0 +1,188 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.topology.ModuleParameter
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.data.DenseFloatArrayTensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.types.DType
+import java.io.File
+import kotlin.reflect.KClass
+
+/**
+ * Phase B — map/bake the Moonshine-tiny DECODER weights into [MoonshineDecoderModel].
+ *
+ * Source of truth is the HF safetensors checkpoint (`UsefulSensors/moonshine-tiny`), converted
+ * to per-tensor little-endian f32 `.bin` files by `convert_moonshine_weights.py` (raw HF layout,
+ * `model.` prefix stripped). The DSL projects through
+ * [sk.ainet.lang.nn.transformer.linearProject] = `x @ Wᵀ` with `W` in `[out, in]` — identical to
+ * HF `nn.Linear` — so raw HF `[out, in]` weights map **without transpose** (this differs from the
+ * encoder's ONNX-sourced mapping, whose initializers are `[in, out]` and need transpose=true).
+ *
+ * Verified against the checkpoint header (6 layers, dim 288, ffn 1152, vocab 32768):
+ *   self_attn / encoder_attn q,k,v,o .weight   [288,288]   (attention_bias=false → no bias)
+ *   mlp.fc1.weight [2304,288] + .bias [2304]    (fused value|gate)
+ *   mlp.fc2.weight [288,1152] + .bias [288]
+ *   input_layernorm / post_attention_layernorm / final_layernorm .weight [288]  (bias=false)
+ *   decoder.norm.weight [288];  decoder.embed_tokens.weight [32768,288]  (proj_out is TIED to it)
+ *
+ * The DSL LayerNorm carries a bias param; Moonshine LayerNorm has none, so bias maps to zeros
+ * (returned by [zerosFor]). `lm_head.weight` is fed `embed_tokens` (the tie).
+ */
+internal interface DecWeightSource {
+    /** Flat row-major f32 values for [hfName], or null if absent. */
+    fun weight(hfName: String): FloatArray?
+}
+
+/** Reads `$dir/<hfName>.bin` as little-endian f32 (matches `convert_moonshine_weights.py`). */
+internal class DecDirBinWeightSource(private val dir: String) : DecWeightSource {
+    override fun weight(hfName: String): FloatArray? {
+        val f = File(dir, "$hfName.bin")
+        if (!f.exists()) return null
+        val bytes = f.readBytes()
+        return FloatArray(bytes.size / 4) { i ->
+            var bits = 0
+            for (b in 0 until 4) bits = bits or ((bytes[i * 4 + b].toInt() and 0xFF) shl (8 * b))
+            Float.fromBits(bits)
+        }
+    }
+}
+
+private val DEC_LAYER = Regex("""^dec\.(\d+)\.(.+)$""")
+
+/**
+ * Map a DSL decoder param name → (HF tensor name, transpose?). Raw HF `[out,in]` weights need no
+ * transpose (see file header). `null` HF name means "synthesize zeros of the param's shape" (the
+ * absent LayerNorm biases). Returns `null` for a genuinely unmapped param (fail-fast upstream).
+ */
+internal fun decoderHfNameFor(dslName: String): DecMap? {
+    when (dslName) {
+        "dec_out_norm.weight" -> return DecMap("decoder.norm.weight", false)
+        "dec_out_norm.bias" -> return DecMap(null, false) // Moonshine final norm has no bias
+        // proj_out is tied to embed_tokens — feed the embedding table as the lm_head weight.
+        "lm_head.weight" -> return DecMap("decoder.embed_tokens.weight", false)
+        "lm_head.bias" -> return DecMap(null, false) // proj_out has bias=false
+    }
+    val m = DEC_LAYER.matchEntire(dslName) ?: return null
+    val l = m.groupValues[1]
+    return when (m.groupValues[2]) {
+        // norms (weight only; bias → zeros)
+        "self_attn_norm.weight" -> DecMap("decoder.layers.$l.input_layernorm.weight", false)
+        "self_attn_norm.bias" -> DecMap(null, false)
+        "cross_attn_norm.weight" -> DecMap("decoder.layers.$l.post_attention_layernorm.weight", false)
+        "cross_attn_norm.bias" -> DecMap(null, false)
+        "mlp_norm.weight" -> DecMap("decoder.layers.$l.final_layernorm.weight", false)
+        "mlp_norm.bias" -> DecMap(null, false)
+        // causal self-attention projections (no bias)
+        "self_attn.q_proj.weight" -> DecMap("decoder.layers.$l.self_attn.q_proj.weight", false)
+        "self_attn.k_proj.weight" -> DecMap("decoder.layers.$l.self_attn.k_proj.weight", false)
+        "self_attn.v_proj.weight" -> DecMap("decoder.layers.$l.self_attn.v_proj.weight", false)
+        "self_attn.o_proj.weight" -> DecMap("decoder.layers.$l.self_attn.o_proj.weight", false)
+        // cross-attention → encoder memory (HF `encoder_attn`)
+        "cross_attn.q_proj.weight" -> DecMap("decoder.layers.$l.encoder_attn.q_proj.weight", false)
+        "cross_attn.k_proj.weight" -> DecMap("decoder.layers.$l.encoder_attn.k_proj.weight", false)
+        "cross_attn.v_proj.weight" -> DecMap("decoder.layers.$l.encoder_attn.v_proj.weight", false)
+        "cross_attn.o_proj.weight" -> DecMap("decoder.layers.$l.encoder_attn.o_proj.weight", false)
+        // gated SiLU MLP (fused fc1 emits value|gate; both fc1/fc2 biased)
+        "mlp_fc1.weight" -> DecMap("decoder.layers.$l.mlp.fc1.weight", false)
+        "mlp_fc1.bias" -> DecMap("decoder.layers.$l.mlp.fc1.bias", false)
+        "mlp_fc2.weight" -> DecMap("decoder.layers.$l.mlp.fc2.weight", false)
+        "mlp_fc2.bias" -> DecMap("decoder.layers.$l.mlp.fc2.bias", false)
+        else -> null
+    }
+}
+
+internal data class DecMap(val hfName: String?, val transpose: Boolean)
+
+private val ENC_LAYER = Regex("""^enc\.(\d+)\.(.+)$""")
+
+/**
+ * Encoder HF-safetensors mapping (raw `[out,in]` → transpose=false, same reasoning as the decoder).
+ * NOTE this differs from the demo's `MoonshineWeights.hfNameFor`, which targets the ONNX-extracted
+ * source (`[in,out]`, transpose=true) and uses `self_attn_layer_norm`/`fc1` names. The HF safetensors
+ * names are `input_layernorm`/`post_attention_layernorm`/`mlp.fc1` (weight-only LNs, no attn bias).
+ */
+internal fun encoderHfNameFor(dslName: String): DecMap? {
+    when (dslName) {
+        "enc_out_norm.weight" -> return DecMap("encoder.layer_norm.weight", false)
+        "enc_out_norm.bias" -> return DecMap(null, false)
+    }
+    val m = ENC_LAYER.matchEntire(dslName) ?: return null
+    val l = m.groupValues[1]
+    return when (m.groupValues[2]) {
+        "attn_norm.weight" -> DecMap("encoder.layers.$l.input_layernorm.weight", false)
+        "attn_norm.bias" -> DecMap(null, false)
+        "attn.q_proj.weight" -> DecMap("encoder.layers.$l.self_attn.q_proj.weight", false)
+        "attn.k_proj.weight" -> DecMap("encoder.layers.$l.self_attn.k_proj.weight", false)
+        "attn.v_proj.weight" -> DecMap("encoder.layers.$l.self_attn.v_proj.weight", false)
+        "attn.o_proj.weight" -> DecMap("encoder.layers.$l.self_attn.o_proj.weight", false)
+        "ffn_norm.weight" -> DecMap("encoder.layers.$l.post_attention_layernorm.weight", false)
+        "ffn_norm.bias" -> DecMap(null, false)
+        "ffn_up.weight" -> DecMap("encoder.layers.$l.mlp.fc1.weight", false)
+        "ffn_up.bias" -> DecMap("encoder.layers.$l.mlp.fc1.bias", false)
+        "ffn_down.weight" -> DecMap("encoder.layers.$l.mlp.fc2.weight", false)
+        "ffn_down.bias" -> DecMap("encoder.layers.$l.mlp.fc2.bias", false)
+        else -> null
+    }
+}
+
+private fun <T : DType, V> walkParams(
+    m: Module<T, V>,
+    out: MutableList<ModuleParameter<*, *>> = mutableListOf(),
+): List<ModuleParameter<*, *>> {
+    out.addAll(m.params)
+    for (child in m.modules) walkParams(child, out)
+    return out
+}
+
+/** Overwrite every decoder parameter with real weights from [src]. Fail-fast on any gap. */
+internal fun <T : DType, V> bakeDecoderWeights(
+    model: Module<T, V>,
+    src: DecWeightSource,
+    dtypeClass: KClass<T>,
+    ctx: ExecutionContext,
+): Int = bakeMoonshineWeights(model, src, ::decoderHfNameFor, dtypeClass, ctx)
+
+/** Overwrite every parameter of [model] using [mapper] (encoder or decoder). Fail-fast on any gap. */
+internal fun <T : DType, V> bakeMoonshineWeights(
+    model: Module<T, V>,
+    src: DecWeightSource,
+    mapper: (String) -> DecMap?,
+    dtypeClass: KClass<T>,
+    ctx: ExecutionContext,
+): Int {
+    var baked = 0
+    for (p in walkParams(model)) {
+        val map = mapper(p.name)
+            ?: error("no HF mapping for DSL param '${p.name}'")
+        val shape = p.value.shape.dimensions
+        val nElems = shape.fold(1) { a, b -> a * b }
+
+        var data = if (map.hfName == null) {
+            FloatArray(nElems) // synthesized zeros (absent LayerNorm biases)
+        } else {
+            src.weight(map.hfName) ?: error("checkpoint missing tensor '${map.hfName}' for '${p.name}'")
+        }
+        if (map.transpose && shape.size == 2) data = transpose2d(data, rows = shape[1], cols = shape[0])
+        require(data.size == nElems) {
+            "tensor '${map.hfName}' size ${data.size} != DSL param '${p.name}' shape ${shape.toList()}"
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val tensor = ctx.fromData(
+            DenseFloatArrayTensorData<T>(Shape(*shape), data) as TensorData<T, V>,
+            dtypeClass,
+        )
+        @Suppress("UNCHECKED_CAST")
+        (p as ModuleParameter<T, V>).value = tensor
+        baked++
+    }
+    return baked
+}
+
+private fun transpose2d(src: FloatArray, rows: Int, cols: Int): FloatArray {
+    val dst = FloatArray(src.size)
+    for (r in 0 until rows) for (c in 0 until cols) dst[c * rows + r] = src[r * cols + c]
+    return dst
+}

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderWithPastMlirDumpTest.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderWithPastMlirDumpTest.kt
@@ -1,0 +1,93 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.BF16
+import sk.ainet.lang.types.DType
+import sk.ainet.tape.Execution
+import java.io.File
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Phase D — the `decoder_with_past` KV-cache export graph.
+ *
+ * Traces [MoonshineDecoderModel.forwardWithPast] and asserts the board contract: inputs = one token
+ * `[1,1,dim]` + per-layer self cache in `[1,nHeads,pos,headDim]` + cross cache in `[1,nHeads,frames,headDim]`;
+ * outputs = logits `[1,1,vocab]` + per-layer extended self cache `[1,nHeads,pos+1,headDim]` (6 layers →
+ * 12 self-KV outputs, 13 total; cross cache is passed through, not re-emitted).
+ *
+ * RoPE position is a RUNTIME input: the per-step cos/sin tables `[1, headDim]` enter as graph inputs
+ * (host-built via `buildInterleavedCosSin`, mirroring host-side token embedding) — so ONE vmfb serves
+ * every position, no in-graph gather. The graph therefore also has `cos`/`sin` `[1,headDim]` inputs.
+ *
+ * Env: DEC_PAST (incoming self-cache length, default 1), DEC_FRAMES (default 207), DEC_DTYPE=FP32.
+ */
+class MoonshineDecoderWithPastMlirDumpTest {
+    @Test
+    fun dumpWithPastKvGraph() {
+        val cfg = MoonshineConfig()
+        val past = System.getenv("DEC_PAST")?.toInt() ?: 1
+        val frames = System.getenv("DEC_FRAMES")?.toInt() ?: 207
+        val useF32 = System.getenv("DEC_DTYPE") == "FP32"
+
+        val mlir = if (useF32) trace(cfg, past, frames, sk.ainet.lang.types.FP32::class, "FP32")
+        else trace(cfg, past, frames, BF16::class, "BF16")
+
+        val out = File(System.getenv("MOONSHINE_MLIR_OUT") ?: "build/build-mlir/moonshine-decoder-with-past.mlir")
+        out.parentFile?.mkdirs()
+        out.writeText(mlir)
+        println("WROTE_MLIR ${out.absolutePath} (${mlir.lines().size} lines)")
+
+        val returns = Regex("""\)\s*->\s*\(([^)]*)\)""").find(mlir)?.groupValues?.get(1) ?: ""
+        val results = returns.split(",").map { it.trim() }.filter { it.contains("tensor<") }
+        val nHeads = cfg.nHeads; val hd = cfg.headDim
+        val logits = results.count { it.contains("x${cfg.vocabSize}x") }
+        val selfOut = results.count { it.contains("x${nHeads}x${past + 1}x${hd}x") }
+        println("with_past outputs: total=${results.size} logits=$logits extendedSelfKV=$selfOut")
+
+        assertEquals(1 + 2 * cfg.decoderLayers, results.size, "expect logits + 2·layers extended self-KV")
+        assertEquals(1, logits, "one logits output")
+        assertEquals(2 * cfg.decoderLayers, selfOut, "extended self k+v per layer, [1,$nHeads,${past + 1},$hd]")
+        // cross-cache inputs must be present (consumed, not re-projected): [1,nHeads,frames,headDim].
+        assertTrue(mlir.contains("x${nHeads}x${frames}x${hd}x"), "cross cache [1,$nHeads,$frames,$hd] must be a graph input")
+    }
+
+    private fun <T : DType> trace(cfg: MoonshineConfig, past: Int, frames: Int, dtype: KClass<T>, f: String): String {
+        val model = moonshineDecoder<T, Float>(cfg, dtype)
+        val token = void(Shape(1, 1, cfg.dim), dtype)
+        val cos = void(Shape(1, cfg.headDim), dtype) // runtime-position RoPE tables, graph inputs
+        val sin = void(Shape(1, cfg.headDim), dtype)
+        val selfK = List(cfg.decoderLayers) { void(Shape(1, cfg.nHeads, past, cfg.headDim), dtype) }
+        val selfV = List(cfg.decoderLayers) { void(Shape(1, cfg.nHeads, past, cfg.headDim), dtype) }
+        val crossK = List(cfg.decoderLayers) { void(Shape(1, cfg.nHeads, frames, cfg.headDim), dtype) }
+        val crossV = List(cfg.decoderLayers) { void(Shape(1, cfg.nHeads, frames, cfg.headDim), dtype) }
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                model.forwardWithPast(token, cos, sin, selfK, selfV, crossK, crossV, this as ExecutionContext)
+            } finally { Execution.tapeStack.popTape() }
+        }.first
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
+        val dt = if (System.getenv("DEC_SKIP_DTYPE") == "1") null else f
+        val g = sk.ainet.compile.opt.passes.DtypeForwardPropagationPass(targetFloatDtype = dt).apply(graph).graph
+        return sk.ainet.compile.hlo.toStableHlo(g, "moonshine_decoder_with_past").content
+    }
+
+    private fun <T : DType> void(shape: Shape, dtype: KClass<T>): Tensor<T, Float> =
+        VoidOpsTensor(object : TensorData<T, Float> {
+            override val shape = shape
+            override fun get(vararg indices: Int): Float = 0.0f
+            override fun set(vararg indices: Int, value: Float) {}
+        }, dtype)
+}

--- a/transformer-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
+++ b/transformer-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/MultiHeadAttention.kt
@@ -41,6 +41,16 @@ import kotlin.reflect.KClass
  * @param bias whether Q/K/V/O projections have bias (true for BERT, false for Llama)
  * @param name module name
  */
+/**
+ * Attention output plus the reshaped K/V it computed (`[nKVHeads, seq, headDim]`, heads-first,
+ * post-RoPE for self-attention). Returned by [MultiHeadAttention.forwardWithKV] for KV-cache export.
+ */
+public class AttentionKV<T : DType, V>(
+    public val output: Tensor<T, V>,
+    public val k: Tensor<T, V>,
+    public val v: Tensor<T, V>,
+)
+
 public class MultiHeadAttention<T : DType, V>(
     public val dim: Int,
     public val nHeads: Int,
@@ -181,7 +191,32 @@ public class MultiHeadAttention<T : DType, V>(
         }
 
     override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> =
-        attentionImpl(qInput = input, kvInput = input, isCrossAttention = false, ctx = ctx)
+        attentionImpl(qInput = input, kvInput = input, isCrossAttention = false, ctx = ctx).output
+
+    /**
+     * Like [forward], but also returns the reshaped K/V this attention computed
+     * (`[nKVHeads, seq, headDim]`, heads-first, post-RoPE for self-attention). Used by
+     * encoder-decoder KV-cache export (e.g. the Moonshine prefill graph) to surface the
+     * self/cross K/V as graph outputs without duplicating the projection/RoPE/reshape.
+     * The K/V are pre-GQA-expansion (one entry per KV head). Cross-attention (`encoderMemory
+     * != null`) returns the memory-projected K/V with no RoPE.
+     */
+    public fun forwardWithKV(
+        input: Tensor<T, V>,
+        encoderMemory: Tensor<T, V>?,
+        ctx: ExecutionContext,
+    ): AttentionKV<T, V> {
+        val boundInput = input.bind(ctx)
+        return if (encoderMemory == null) {
+            attentionImpl(qInput = boundInput, kvInput = boundInput, isCrossAttention = false, ctx = ctx)
+        } else {
+            require(kvCache == null && slidingWindow == null) {
+                "MultiHeadAttention.forwardWithKV: cross-attention supports neither kvCache nor slidingWindow."
+            }
+            val boundMemory = encoderMemory.bind(ctx)
+            attentionImpl(qInput = boundInput, kvInput = boundMemory, isCrossAttention = true, ctx = ctx)
+        }
+    }
 
     /**
      * Forward entry that supports cross-attention. When [encoderMemory] is `null`
@@ -210,7 +245,7 @@ public class MultiHeadAttention<T : DType, V>(
         val boundInput = input.bind(ctx)
         val boundMemory = encoderMemory.bind(ctx)
         return sk.ainet.lang.nn.hooks.withForwardHooks(ctx, this, boundInput) {
-            attentionImpl(qInput = boundInput, kvInput = boundMemory, isCrossAttention = true, ctx = ctx)
+            attentionImpl(qInput = boundInput, kvInput = boundMemory, isCrossAttention = true, ctx = ctx).output
         }
     }
 
@@ -219,7 +254,7 @@ public class MultiHeadAttention<T : DType, V>(
         kvInput: Tensor<T, V>,
         isCrossAttention: Boolean,
         ctx: ExecutionContext,
-    ): Tensor<T, V> {
+    ): AttentionKV<T, V> {
         val ops = ctx.ops
         val scale = attentionScale ?: (1.0f / sqrt(headDim.toFloat()))
 
@@ -343,12 +378,19 @@ public class MultiHeadAttention<T : DType, V>(
         // jstack profile (docs/upstream/A2-PROFILE.md) showed dominate decode.
         // Numerically identical to the general path below for seqLen 1 (same
         // max-stable softmax, same GQA head mapping head h → kv head h/nRep).
-        if (qSeqLen == 1 && !isCrossAttention && slidingWindow == null) {
+        //
+        // Skipped while RECORDING a graph: fusedDecodeAttention reads concrete float
+        // buffers (`q.data.copyToFloatArray()`) and rewraps a fresh constant tensor, so
+        // it detaches from the trace tape (q/k/v would dangle, the result would be a
+        // disconnected constant). When `ctx.isRecording`, fall through to the symbolic
+        // `ops.*` SDPA path below, which exports cleanly. This is exactly the eager
+        // fast-path / traceable-path split `ExecutionContext.isRecording` documents.
+        if (qSeqLen == 1 && !isCrossAttention && slidingWindow == null && !ctx.isRecording) {
             val merged = fusedDecodeAttention(q, fullK, fullV, scale, ctx)
             var output = linearProject(ops, merged, wO)
             if (bias) output = ops.add(output, params[oWIdx + 1].value)
             if (mhaDump) mhaDumpStat("[blk.0.mha post-fused-decode ]", output)
-            return output
+            return AttentionKV(output, fullK, fullV)
         }
 
         // Expand KV heads for GQA if needed
@@ -406,7 +448,7 @@ public class MultiHeadAttention<T : DType, V>(
         if (bias) {
             output = ops.add(output, params[oWIdx + 1].value)
         }
-        return output
+        return AttentionKV(output, fullK, fullV)
     }
 
     /**

--- a/transformer-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/RoPE.kt
+++ b/transformer-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/RoPE.kt
@@ -324,42 +324,8 @@ public class RoPE<T : DType, V>(
      * pass through unchanged (Moonshine rotates 32 of 36). Traceable (pure tensor ops).
      */
     private fun applyRoPEInterleavedOps(input: Tensor<T, V>, position: Int, ctx: ExecutionContext): Tensor<T, V> {
-        val ops = ctx.ops
-        val rank = input.rank
-        val lastDim = input.shape[rank - 1]
-        require(lastDim == headDim) { "RoPE input last dim ($lastDim) != headDim ($headDim)" }
-        val seqLen = input.shape[rank - 2]
-
-        // Implement RoPE as a FULL-HEAD rotation, the way the reference ONNX does:
-        //   out = x * cos_full + rotate(x) * sin_full
-        // where rotate(x) maps each interleaved pair (x0, x1) -> (-x1, x0), and
-        // cos_full / sin_full repeat each pair's cos/sin twice so the multiply is a single
-        // full-head elementwise op. This is numerically IDENTICAL to rotating even/odd
-        // separately and re-interleaving (out0 = x0·cos − x1·sin, out1 = x1·cos + x0·sin),
-        // but the "rotate-halves-then-recombine" form is mis-laid-out by the Torq NPU (the
-        // recombine reshape scrambles once rotation ops sit between the split and the merge,
-        // skewing the rotated Q/K). The full-head form compiles bit-exact on Torq (verified
-        // on the SL2610 sim). Tail pairs (i >= halfRotary) carry cos=1/sin=0 so they pass
-        // through. Everything runs in f32 (a bf16 sin/cos table truncates the trig); the
-        // result casts back to the model dtype. Non-rotated V, which skips this path, stays
-        // bit-exact either way.
-        val halfHead = headDim / 2
-        // cos_full / sin_full: [seqLen, headDim]; pair (2i, 2i+1) shares cos/sin[i].
-        val cosFull = FloatArray(seqLen * headDim)
-        val sinFull = FloatArray(seqLen * headDim)
-        for (s in 0 until seqLen) {
-            val pos = position + s
-            for (i in 0 until halfHead) {
-                val c = if (i < halfRotary) cosTable[pos * halfRotary + i] else 1.0f
-                val sn = if (i < halfRotary) sinTable[pos * halfRotary + i] else 0.0f
-                cosFull[s * headDim + 2 * i] = c; cosFull[s * headDim + 2 * i + 1] = c
-                // Sign of the 2D rotation is baked into sin here (even lane negated), so the
-                // graph needs only a pair-SWAP below — no per-element negate op. This keeps
-                // the full-head form bit-exact while avoiding a mulScalar node the OPTIMIZED
-                // DAG runtime drops (0-outputs) on interleaved models like LLaMA.
-                sinFull[s * headDim + 2 * i] = -sn; sinFull[s * headDim + 2 * i + 1] = sn
-            }
-        }
+        val seqLen = input.shape[input.rank - 2]
+        val (cosFull, sinFull) = buildInterleavedCosSin(position, seqLen)
         val fullShape = Shape(seqLen, headDim)
         @Suppress("UNCHECKED_CAST")
         val cosTensor: Tensor<FP32, V> = ctx.fromData(
@@ -371,16 +337,81 @@ public class RoPE<T : DType, V>(
             sk.ainet.lang.tensor.data.DenseFloatArrayTensorData<FP32>(fullShape, sinFull) as sk.ainet.lang.tensor.data.TensorData<FP32, V>,
             FP32::class,
         )
+        return applyInterleavedRotation(input, cosTensor, sinTensor, ctx)
+    }
 
+    /**
+     * Build the sign-baked, pair-repeated cos/sin tables `[seqLen, headDim]` for interleaved
+     * full-head RoPE at [position] (see [applyInterleavedRotation] for the layout: pair (2i, 2i+1)
+     * shares cos/sin[i]; the rotation's sign is folded into the even lane of sin; tail pairs
+     * i >= halfRotary pass through with cos=1/sin=0).
+     *
+     * Public so a runtime that supplies cos/sin as graph INPUTS — e.g. Moonshine's
+     * `decoder_with_past`, whose position is a runtime value, not a compile-time constant — can
+     * produce byte-identical tables host-side and feed them to [forwardWithCosSin]. (No in-graph
+     * gather op is needed; this mirrors how token embeddings are looked up host-side.)
+     */
+    public fun buildInterleavedCosSin(position: Int, seqLen: Int): Pair<FloatArray, FloatArray> {
+        val halfHead = headDim / 2
+        val cosFull = FloatArray(seqLen * headDim)
+        val sinFull = FloatArray(seqLen * headDim)
+        for (s in 0 until seqLen) {
+            val pos = position + s
+            for (i in 0 until halfHead) {
+                val c = if (i < halfRotary) cosTable[pos * halfRotary + i] else 1.0f
+                val sn = if (i < halfRotary) sinTable[pos * halfRotary + i] else 0.0f
+                cosFull[s * headDim + 2 * i] = c; cosFull[s * headDim + 2 * i + 1] = c
+                sinFull[s * headDim + 2 * i] = -sn; sinFull[s * headDim + 2 * i + 1] = sn
+            }
+        }
+        return cosFull to sinFull
+    }
+
+    /**
+     * Interleaved full-head RoPE with cos/sin supplied as TENSORS (already sign-baked,
+     * pair-repeated `[seqLen, headDim]` per [buildInterleavedCosSin]) rather than derived from a
+     * compile-time position — so the position can be a runtime graph input. Numerically identical
+     * to [forward]; the rotation runs in f32.
+     */
+    public fun forwardWithCosSin(
+        input: Tensor<T, V>,
+        cosFull: Tensor<T, V>,
+        sinFull: Tensor<T, V>,
+        ctx: ExecutionContext,
+    ): Tensor<T, V> {
+        val ops = ctx.ops
+        @Suppress("UNCHECKED_CAST")
+        val cosF: Tensor<FP32, V> = if (cosFull.dtype == FP32::class) cosFull as Tensor<FP32, V> else ops.convert(cosFull, FP32)
+        @Suppress("UNCHECKED_CAST")
+        val sinF: Tensor<FP32, V> = if (sinFull.dtype == FP32::class) sinFull as Tensor<FP32, V> else ops.convert(sinFull, FP32)
+        return sk.ainet.lang.nn.hooks.withForwardHooks(ctx, this, input) {
+            applyInterleavedRotation(input, cosF, sinF, ctx)
+        }
+    }
+
+    /**
+     * The position-independent interleaved rotation `out = x * cos_full + swap(x) * sin_full`.
+     * `swap(x)` maps each pair (x0, x1) -> (x1, x0); the rotation's sign lives in `sin_full`
+     * (even lane negated) so this needs only a pair-SWAP, no negate node (the OPTIMIZED DAG
+     * runtime drops a mulScalar here to 0-outputs on interleaved models). This is the FULL-HEAD
+     * form the reference ONNX uses — numerically identical to rotating even/odd separately and
+     * re-interleaving, but the recombine reshape mis-lays-out on the Torq NPU while this compiles
+     * bit-exact (SL2610 sim). Extracted so the compile-time-position and runtime-cos/sin paths
+     * share identical math. cos/sin are `[seqLen, headDim]`, broadcasting over the leading dims.
+     */
+    private fun applyInterleavedRotation(
+        input: Tensor<T, V>,
+        cosTensor: Tensor<FP32, V>,
+        sinTensor: Tensor<FP32, V>,
+        ctx: ExecutionContext,
+    ): Tensor<T, V> {
+        val ops = ctx.ops
+        val rank = input.rank
+        require(input.shape[rank - 1] == headDim) { "RoPE input last dim (${input.shape[rank - 1]}) != headDim ($headDim)" }
+        val halfHead = headDim / 2
         val isF32 = input.dtype == FP32::class
         @Suppress("UNCHECKED_CAST")
         val xF: Tensor<FP32, V> = if (isF32) input as Tensor<FP32, V> else ops.convert(input, FP32)
-
-        // swap(x): pair (x0, x1) -> (x1, x0). even = pairs[...,0], odd = pairs[...,1];
-        // interleave (odd, even) back to a full head [..., headDim]. The rotation's sign
-        // lives in sin_full (even lane negated above), so this is a pure swap — no negate
-        // node, which is what the OPTIMIZED DAG runtime needs (a mulScalar here traced to a
-        // 0-output node on interleaved models). Numerically identical to (-odd, even)·sin.
         val leading = IntArray(rank - 1) { input.shape[it] }
         val pairedShape = Shape(*leading, halfHead, 2)
         val planeShape = Shape(*leading, halfHead)
@@ -392,9 +423,6 @@ public class RoPE<T : DType, V>(
             ops.concat(listOf(ops.unsqueeze(odd, rank), ops.unsqueeze(even, rank)), dim = rank),
             input.shape,
         )
-
-        // Full-head: out = x * cos_full + swap(x) * sin_full  (sign folded into sin_full;
-        // cos/sin broadcast over the leading head/batch dims).
         val outF = ops.add(ops.multiply(xF, cosTensor), ops.multiply(swapped, sinTensor))
         val modelDtype: DType = if (input.dtype == FP16::class) FP16 else BF16
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## transformer-core primitives (reusable; commit 1)
- **MultiHeadAttention**
  - Fix the seq==1 fused-decode fast path breaking graph export — it read concrete buffers and rewrapped a fresh constant, detaching from the trace tape. Guarded with `!ctx.isRecording` (the eager-vs-traceable split `ExecutionContext.isRecording` documents); eager unchanged.
  - Add `forwardWithKV -> AttentionKV(output, k, v)` so KV-cache export reuses the exact attention K/V instead of duplicating projection/RoPE/reshape.
- **RoPE** — split for runtime position: `buildInterleavedCosSin(position, seqLen)` + `forwardWithCosSin(input, cos, sin, ctx)` + extracted `applyInterleavedRotation`. Lets a decoder feed the position as a graph input (no in-graph gather), numerically identical to the existing path.

## Moonshine decoder (commit 2)
- `moonshineDecoder()`: pre-norm layers (causal RoPE self-attn, cross-attn into encoder memory, gated SiLU MLP matching HF `MoonshineDecoderMLP`), final norm, `proj_out` LM head **tied** to `embed_tokens`.
- `forwardPrefill()` and `forwardWithPast()` emit the two board KV-cache graphs (self `[1,8,pos,36]`, cross `[1,8,207,36]`); cross-attn in the past graph consumes cached cross K/V directly.
- HF-safetensors weight mapping (transpose=false; tied lm_head). Bake test: **112 params** map from the real moonshine-tiny checkpoint.

## Verification (all green)
- Eager CPU E2E: decoder on reference memory, our-encoder→our-decoder, and the **prefill + decoder_with_past two-graph loop** all transcribe "One, two, three.".
- MLIR dumps match the board contract: decoder (1 output), prefill (25), with_past (13, cos/sin as inputs).
- No regression: Gemma KV-cache + MLIR-dump tests and the Moonshine encoder dump unaffected.

## Not included / follow-ups (toolchain-gated)
iree-compile of the decode graphs (CPU then Torq NPU) and rewiring the demo runtime to our vmfbs while deleting the vendor decoder — these need the IREE/Torq toolchain + board.