### PR TITLE
moonshine: author the audio-frontend preprocessor in the NN DSL

### DIFF
--- a/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshinePreprocessor.kt
+++ b/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshinePreprocessor.kt
@@ -36,6 +36,10 @@ import kotlin.reflect.KClass
 public class MoonshinePreprocessor<T : DType, V>(
     cfg: MoonshineConfig,
     dtype: KClass<T>,
+    // When true, emit the conv output `[1, dim, frames]` WITHOUT the final transpose — the layout the
+    // board pipeline feeds to the (board-layout) encoder, so this is a drop-in for the vendor
+    // `preprocessor_cpu.vmfb`. Default false = `[1, frames, dim]` (matches `enc_frontend.onnx`).
+    private val boardLayout: Boolean = false,
 ) : Module<T, V>() {
 
     override val name: String = "moonshine_preprocessor"
@@ -83,6 +87,7 @@ public class MoonshinePreprocessor<T : DType, V>(
         x = groupNorm1(x, ctx)                       // [1, dim, L1]
         x = conv2.forward(x, ctx).gelu()             // [1, 2·dim, L2]
         x = conv3.forward(x, ctx).gelu()             // [1, dim, frames]
+        if (boardLayout) return x                    // board feeds [1, dim, frames] to the encoder
         // [1, dim, frames] → [1, frames, dim] via a 2D swap (rank-3 ops.transpose reverses all dims).
         return ops.unsqueeze(ops.transpose(ops.squeeze(x, 0)), 0)
     }
@@ -109,4 +114,5 @@ public class MoonshinePreprocessor<T : DType, V>(
 public fun <T : DType, V> moonshinePreprocessor(
     cfg: MoonshineConfig,
     dtype: KClass<T>,
-): MoonshinePreprocessor<T, V> = MoonshinePreprocessor(cfg, dtype)
+    boardLayout: Boolean = false,
+): MoonshinePreprocessor<T, V> = MoonshinePreprocessor(cfg, dtype, boardLayout)

--- a/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshinePreprocessor.kt
+++ b/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshinePreprocessor.kt
@@ -1,0 +1,112 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.Conv1d
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.normalization.GroupNormalization
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.gelu
+import sk.ainet.lang.tensor.operators.bind
+import sk.ainet.lang.tensor.tanh
+import sk.ainet.lang.types.DType
+import kotlin.reflect.KClass
+
+/**
+ * Moonshine-tiny audio FRONTEND (preprocessor) in the SKaiNET NN DSL — the last piece needed for a
+ * solely-SKaiNET pipeline (was a vendor ONNX graph). Verified against `enc_frontend.onnx`:
+ *
+ *   input `[1, samples]`
+ *     → unsqueeze → `[1, 1, samples]`
+ *     → conv1 (1→dim,   k=127, s=64, no bias) → tanh
+ *     → groupnorm (1 group, affine, eps=1e-5)
+ *     → conv2 (dim→2·dim, k=7, s=3) → gelu
+ *     → conv3 (2·dim→dim, k=3, s=2) → gelu
+ *     → transpose → `[1, frames, dim]`  (the encoder's input; 80000 samples → 207 frames)
+ *
+ * (The ONNX `Reshape+InstanceNormalization+Reshape+Mul+Add` is exactly `nn.GroupNorm(1, dim)` +
+ * affine; the `Div/Erf/Add/Mul/Mul` blocks are erf-GELU — the DSL GELU is the tanh approximation,
+ * a ~1e-3 difference the downstream encoder tolerates.)
+ *
+ * Weights (from the HF encoder checkpoint): `encoder.conv{1,2,3}.weight`, `conv{2,3}.bias`,
+ * `encoder.groupnorm.weight/bias`. Build with the model dtype; bake before tracing to export.
+ */
+public class MoonshinePreprocessor<T : DType, V>(
+    cfg: MoonshineConfig,
+    dtype: KClass<T>,
+) : Module<T, V>() {
+
+    override val name: String = "moonshine_preprocessor"
+    private val dim = cfg.dim
+
+    private fun void(shape: Shape, dtype: KClass<T>): Tensor<T, V> = VoidOpsTensor(
+        object : TensorData<T, V> {
+            override val shape: Shape = shape
+            @Suppress("UNCHECKED_CAST")
+            override fun get(vararg indices: Int): V = 0.0f as V
+            override fun set(vararg indices: Int, value: V) {}
+        },
+        dtype,
+    )
+
+    private val conv1 = Conv1d<T, V>(
+        inChannels = 1, outChannels = dim, kernelSize = cfg.conv1Kernel, stride = cfg.conv1Stride,
+        bias = false, name = "conv1", initWeights = void(Shape(dim, 1, cfg.conv1Kernel), dtype),
+    )
+    private val groupnorm = GroupNormalization<T, V>(
+        numGroups = 1, numChannels = dim, eps = cfg.layerNormEps.toDouble(), affine = true,
+        name = "groupnorm", dtype = dtype,
+    )
+    private val conv2 = Conv1d<T, V>(
+        inChannels = dim, outChannels = cfg.conv2Out, kernelSize = cfg.conv2Kernel, stride = cfg.conv2Stride,
+        bias = true, name = "conv2",
+        initWeights = void(Shape(cfg.conv2Out, dim, cfg.conv2Kernel), dtype), initBias = void(Shape(cfg.conv2Out), dtype),
+    )
+    private val conv3 = Conv1d<T, V>(
+        inChannels = cfg.conv2Out, outChannels = dim, kernelSize = cfg.conv3Kernel, stride = cfg.conv3Stride,
+        bias = true, name = "conv3",
+        initWeights = void(Shape(dim, cfg.conv2Out, cfg.conv3Kernel), dtype), initBias = void(Shape(dim), dtype),
+    )
+
+    override val modules: List<Module<T, V>> = listOf(conv1, groupnorm, conv2, conv3)
+
+    private val eps = cfg.layerNormEps
+
+    /** Raw audio `[1, samples]` → encoder features `[1, frames, dim]`. */
+    override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> {
+        val ops = ctx.ops
+        val x0 = input.bind(ctx)
+        var x = ops.unsqueeze(x0, 1)                 // [1, 1, samples]
+        x = conv1.forward(x, ctx).tanh()             // [1, dim, L1]
+        x = groupNorm1(x, ctx)                       // [1, dim, L1]
+        x = conv2.forward(x, ctx).gelu()             // [1, 2·dim, L2]
+        x = conv3.forward(x, ctx).gelu()             // [1, dim, frames]
+        // [1, dim, frames] → [1, frames, dim] via a 2D swap (rank-3 ops.transpose reverses all dims).
+        return ops.unsqueeze(ops.transpose(ops.squeeze(x, 0)), 0)
+    }
+
+    // GroupNorm(1 group): normalise over (channels, length) jointly, then per-channel affine. The core
+    // GroupNormalization.forward is a stub (reshapeForGroups NotImplemented), so compute it with ops;
+    // gamma/beta stay in the [groupnorm] module so they bake by name.
+    private fun groupNorm1(x: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> {
+        val ops = ctx.ops
+        val c = x.shape[1]
+        val l = x.shape[2]
+        val flat = ops.reshape(x, Shape(1, c * l))
+        val mean = ops.unsqueeze(ops.mean(flat, dim = 1), 1)                       // [1,1]
+        val centered = ops.subtract(flat, mean)
+        val variance = ops.unsqueeze(ops.mean(ops.multiply(centered, centered), dim = 1), 1)
+        val normed = ops.reshape(ops.divide(centered, ops.sqrt(ops.addScalar(variance, eps))), Shape(1, c, l))
+        val gamma = ops.reshape(groupnorm.params[0].value, Shape(1, c, 1))
+        val beta = ops.reshape(groupnorm.params[1].value, Shape(1, c, 1))
+        return ops.add(ops.multiply(normed, gamma), beta)
+    }
+}
+
+/** Build the Moonshine-tiny audio frontend in the NN DSL. */
+public fun <T : DType, V> moonshinePreprocessor(
+    cfg: MoonshineConfig,
+    dtype: KClass<T>,
+): MoonshinePreprocessor<T, V> = MoonshinePreprocessor(cfg, dtype)

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderWeights.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshineDecoderWeights.kt
@@ -95,6 +95,19 @@ internal fun decoderHfNameFor(dslName: String): DecMap? {
 
 internal data class DecMap(val hfName: String?, val transpose: Boolean)
 
+/** Preprocessor (audio frontend) param → HF encoder conv/groupnorm tensor. Conv weights [out,in,k] map
+ *  directly (no transpose). */
+internal fun preprocessorHfNameFor(dslName: String): DecMap? = when (dslName) {
+    "conv1.weight" -> DecMap("encoder.conv1.weight", false)
+    "conv2.weight" -> DecMap("encoder.conv2.weight", false)
+    "conv2.bias" -> DecMap("encoder.conv2.bias", false)
+    "conv3.weight" -> DecMap("encoder.conv3.weight", false)
+    "conv3.bias" -> DecMap("encoder.conv3.bias", false)
+    "groupnorm.weight" -> DecMap("encoder.groupnorm.weight", false)
+    "groupnorm.bias" -> DecMap("encoder.groupnorm.bias", false)
+    else -> null
+}
+
 private val ENC_LAYER = Regex("""^enc\.(\d+)\.(.+)$""")
 
 /**

--- a/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshinePreprocessorTest.kt
+++ b/llm-inference/moonshine/src/jvmTest/kotlin/sk/ainet/models/moonshine/MoonshinePreprocessorTest.kt
@@ -1,0 +1,58 @@
+package sk.ainet.models.moonshine
+
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+import java.io.File
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Validate the DSL audio frontend [moonshinePreprocessor] against the reference `enc_frontend.onnx`:
+ * raw audio `[1, 64000]` → features `[1, 165, 288]`, eager on CPU with real weights.
+ *
+ * Gated on env: PP_CHECKPOINT (HF `.bin` weights dir), PP_INPUT (`[1,64000]` f32), PP_REF (`[1,165,288]` f32).
+ */
+class MoonshinePreprocessorTest {
+    @Test
+    fun preprocessorMatchesOnnxFrontend() {
+        val ckpt = System.getenv("PP_CHECKPOINT") ?: return skip("PP_CHECKPOINT")
+        val inPath = System.getenv("PP_INPUT") ?: return skip("PP_INPUT")
+        val refPath = System.getenv("PP_REF") ?: return skip("PP_REF")
+
+        val cfg = MoonshineConfig()
+        val ctx = DirectCpuExecutionContext.create()
+        val model = moonshinePreprocessor<FP32, Float>(cfg, FP32::class)
+        val baked = bakeMoonshineWeights(model, DecDirBinWeightSource(ckpt), ::preprocessorHfNameFor, FP32::class, ctx as ExecutionContext)
+        println("baked $baked preprocessor params")
+
+        val samples = readF32(File(inPath))
+        val input = ctx.fromFloatArray<FP32, Float>(Shape(1, samples.size), FP32::class, samples)
+        val out = model.forward(input, ctx)
+        val ours = out.data.copyToFloatArray()
+        val ref = readF32(File(refPath))
+        val cos = cosine(ours, ref)
+        println("preprocessor output shape=${out.shape.dimensions.toList()} cos vs onnx frontend = $cos")
+        assertTrue(cos > 0.99, "DSL frontend must match the ONNX frontend (cos=$cos)")
+    }
+
+    private fun skip(m: String) = println("SKIP preprocessorMatchesOnnxFrontend: set $m")
+
+    private fun cosine(a: FloatArray, b: FloatArray): Double {
+        val n = minOf(a.size, b.size)
+        var d = 0.0; var na = 0.0; var nb = 0.0
+        for (i in 0 until n) { d += a[i] * b[i]; na += a[i].toDouble() * a[i]; nb += b[i].toDouble() * b[i] }
+        return d / (sqrt(na) * sqrt(nb))
+    }
+
+    private fun readF32(f: File): FloatArray {
+        val b = f.readBytes()
+        return FloatArray(b.size / 4) { i ->
+            var bits = 0
+            for (k in 0 until 4) bits = bits or ((b[i * 4 + k].toInt() and 0xFF) shl (8 * k))
+            Float.fromBits(bits)
+        }
+    }
+}


### PR DESCRIPTION
Completes the Moonshine model in the SKaiNET DSL — the conv **audio frontend** was the last stage still only available as a vendor ONNX graph. **All three neural stages (preprocessor, encoder, decoder) now exist in the DSL.**

## `MoonshinePreprocessor`
Raw audio `[1, samples]` → features `[1, frames, dim]`:
`unsqueeze → conv1(1→dim, k127 s64, no bias) → tanh → GroupNorm(1) → conv2(dim→2·dim, k7 s3) → gelu → conv3(2·dim→dim, k3 s2) → gelu → transpose`.

- Uses the DSL `Conv1d` (exports to `stablehlo.convolution`).
- `GroupNorm(1 group)` is computed inline with ops — the core `GroupNormalization.forward` is a stub (`reshapeForGroups` NotImplemented) — normalising over (channels, length) jointly with per-channel affine; gamma/beta stay in the module so they bake by name.

## Validation
Eager on CPU with real weights (`MoonshinePreprocessorTest`) vs `enc_frontend.onnx`: **cos 0.9970**, output `[1,165,288]`. The ~3e-3 residual is the DSL tanh-GELU vs the ONNX erf-GELU. Weight mapping `preprocessorHfNameFor`: `encoder.conv{1,2,3}.weight/bias` + `groupnorm.weight/bias` (7 params).

## Follow-up
Board integration (compile the preprocessor to a CPU vmfb + deploy as the drop-in `preprocessor_cpu.vmfb`) is mechanical — same export/compile/deploy path as the encoder/decoder — and lands in the demo repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)