### PR TITLE
feat(kgemma): FunctionGemma facade + compiled export (self-compile from DSL)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-skainet = "0.34.0"
+skainet = "0.35.0"
 agp = "9.2.1"
 jacksonDatabind = "2.22.0"
 jsonSchemaValidator = "3.0.5"

--- a/llm-runtime/kgemma/build.gradle.kts
+++ b/llm-runtime/kgemma/build.gradle.kts
@@ -92,6 +92,12 @@ kotlin {
 
         val jvmMain by getting {
             dependencies {
+                // FunctionGemma compiled export: DSL -> StableHLO (external params).
+                // JVM-only (skainet-compile-hlo/-dag publish no JS).
+                implementation(libs.skainet.compile.hlo)
+                implementation(libs.skainet.compile.dag)
+                // FunctionGemma facade: CompactCodec (<tool_N> -> ToolCall) + ToolCall.
+                implementation(project(":llm-runtime:gemma-iree"))
                 implementation(project(":llm-runtime:kllama"))
                 // Direct dep on llm-agent for the --agent CLI flag.
                 // kllama's `implementation(project(":llm-agent"))` isn't
@@ -154,4 +160,20 @@ tasks.withType<JavaExec>().configureEach {
     jvmArgs("--enable-preview", "--add-modules", "jdk.incubator.vector", "-XX:MaxDirectMemorySize=36g")
     minHeapSize = "4g"
     maxHeapSize = "24g"
+}
+
+// FunctionGemma compiled export entry point (driven by the demo's scripts/compile-gemma.sh):
+//   GEMMA_GGUF=…Q5_K_M.gguf GEMMA_OUT_DIR=… \
+//     ./gradlew -PuseLocalSkainet=true :llm-runtime:kgemma:exportFunctionGemma
+// Inherits the --add-modules jdk.incubator.vector + heap config from withType<JavaExec> above.
+tasks.register<JavaExec>("exportFunctionGemma") {
+    group = "bridge"
+    description = "Export FunctionGemma -> gemma-gen.mlir + bf16 gemma.safetensors from the GGUF."
+    val jvmMainComp = kotlin.jvm().compilations.getByName("main")
+    dependsOn(jvmMainComp.compileTaskProvider)
+    classpath = jvmMainComp.output.allOutputs + jvmMainComp.runtimeDependencyFiles
+    mainClass.set("sk.ainet.apps.kgemma.FunctionGemmaExportMainKt")
+    listOf("GEMMA_GGUF", "GEMMA_OUT_DIR", "GEN_SEQ", "PARTIAL_ROTARY", "GEMMA_DTYPE").forEach { k ->
+        System.getenv(k)?.let { environment(k, it) }
+    }
 }

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/FunctionGemma.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/FunctionGemma.kt
@@ -1,0 +1,99 @@
+package sk.ainet.apps.kgemma
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.apps.kllama.GGUFTokenizer
+import sk.ainet.apps.llm.InferenceRuntime
+import sk.ainet.apps.llm.OptimizedLLMMode
+import sk.ainet.apps.llm.OptimizedLLMRuntime
+import sk.ainet.apps.llm.generate
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.gemma.Gemma4WeightLoader
+import sk.ainet.models.gemma.GemmaNetworkLoader
+import sk.ainet.transformers.gemma.iree.CompactCodec
+import sk.ainet.transformers.gemma.iree.ToolCall
+import kotlin.random.Random
+
+/**
+ * FunctionGemma — one-line function-calling from the SKaiNET DSL, in BOTH execution modes.
+ *
+ * ```
+ * val fg = FunctionGemma.fromGguf("…functiongemma…Q5_K_M.gguf")
+ * fg.call("turn the light on")     // EAGER (DirectCpu, no iree) -> ToolCall(set_lights, {state=on})
+ * fg.exportCompiled("build/mlir")  // COMPILED (edge) -> gemma-gen.mlir + bf16 gemma.safetensors
+ * ```
+ *
+ * One `gemmaNetwork()` DSL definition, HW selected by the SKaiNET seams: the **execution
+ * context** (eager — runs anywhere on CPU) or the **compile target** (compiled — the SL2610
+ * edge vmfb, via [FunctionGemmaExport]). Eager dequantizes Q5_K → FP32 ("works, moderate
+ * speed"); the compiled path is the edge-perf artifact.
+ */
+public class FunctionGemma private constructor(
+    private val ggufPath: String,
+    private val runtime: InferenceRuntime<FP32>,
+    private val tokenizer: GGUFTokenizer,
+    private val bos: Int,
+    private val eot: Int,
+    private val eos: Int,
+) {
+    public data class Turn(val text: String, val calls: List<ToolCall>)
+
+    /**
+     * EAGER function-calling: apply the Octopus-v2 chat template, greedily generate the compact
+     * tool call, and parse it — entirely in-process (no iree-compile, no board).
+     */
+    public fun call(userText: String, maxTokens: Int = 24): Turn {
+        val prompt = "<start_of_turn>user\n$userText<end_of_turn>\n<start_of_turn>model\n"
+        val ptoks = tokenizer.encode(prompt) // generate() prepends bos
+        val gen = ArrayList<Int>(maxTokens)
+        var stopped = false
+        runtime.generate(prompt = ptoks, steps = maxTokens, temperature = 0f, bosToken = bos) { id ->
+            if (!stopped) {
+                if (id == eot || id == eos) stopped = true else gen.add(id)
+            }
+        }
+        val text = tokenizer.decode(gen.toIntArray())
+        return Turn(text, CompactCodec.parse(text))
+    }
+
+    /**
+     * COMPILED export for the edge: trace `gemmaNetwork()` (DSL argMax tail) → StableHLO with bf16
+     * external params. Produces `gemma-gen.mlir` + `gemma.safetensors`; `compile-gemma.sh` turns
+     * them into `gemma-gen.vmfb` + `gemma-gen.irpa`.
+     */
+    public fun exportCompiled(outDir: String, seq: Int = 24, bf16: Boolean = true): FunctionGemmaExport.Result =
+        FunctionGemmaExport.export(gguf = ggufPath, outDir = outDir, seq = seq, bf16 = bf16)
+
+    public companion object {
+        /**
+         * Load FunctionGemma from a GGUF checkpoint for EAGER use. Tokenizer + weights come from the
+         * GGUF; global-layer RoPE is forced to full rotary ([partialRotary] = 1.0 — the gemma3
+         * convention the gguf omits, which the loader would otherwise default to 0.25 and mis-rotate).
+         */
+        public fun fromGguf(gguf: String, partialRotary: Float = 1.0f): FunctionGemma = runBlocking {
+            val tok = GGUFTokenizer.fromRandomAccessSource(JvmRandomAccessSource.open(gguf))
+            val ctx = DirectCpuExecutionContext.create()
+            val weights = Gemma4WeightLoader(
+                randomAccessProvider = { JvmRandomAccessSource.open(gguf) },
+                quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+            ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+            val patched = weights.copy(
+                metadata = weights.metadata.copy(
+                    ropeParametersFull = weights.metadata.ropeParametersFull.copy(partialRotaryFactor = partialRotary),
+                ),
+            )
+            val model = GemmaNetworkLoader.fromWeights(ctx, patched, FP32::class)
+            val runtime = OptimizedLLMRuntime(model, ctx, OptimizedLLMMode.DIRECT, FP32::class, random = Random.Default)
+            FunctionGemma(
+                ggufPath = gguf,
+                runtime = runtime,
+                tokenizer = tok,
+                bos = tok.bosTokenId,
+                eot = tok.encode("<end_of_turn>").single(),
+                eos = tok.eosTokenId,
+            )
+        }
+    }
+}

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/FunctionGemmaExport.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/FunctionGemmaExport.kt
@@ -1,0 +1,187 @@
+package sk.ainet.apps.kgemma
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.compile.hlo.ConstantMaterializationPolicy
+import sk.ainet.compile.hlo.StableHloConverterFactory
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.transformer.MultiHeadAttention
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.Bf16TensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.tensor.storage.BufferHandle
+import sk.ainet.lang.types.FP32
+import sk.ainet.models.gemma.Gemma4WeightLoader
+import sk.ainet.models.gemma.GemmaNetworkLoader
+import sk.ainet.tape.Execution
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * FunctionGemma compiled-export: author `gemmaNetwork()` from the real GGUF checkpoint,
+ * trace ONE fixed-prefill pass that ends in the DSL argMax tail, and emit portable
+ * StableHLO with EXTERNAL params (the 270M weights live in an `.irpa`, not baked).
+ *
+ * Promotes the former `RealGemmaBakeIrpaTest` into a runnable library step and folds the
+ * ex-Python rewrites INTO the DSL/export (skainet philosophy — no Python):
+ *  - the per-position argmax tail is now `ops.argMax(logits, -1)` (a real DSL op), so the
+ *    emitted `func @gemma` already returns `tensor<seqxi32>` — retires `add_argmax_perpos.py`.
+ *  - weights are emitted as **bf16** externals (globals + a bf16 safetensors, f32 compute via a
+ *    `stablehlo.convert bf16->f32` on load), halving the archive — retires `make_f16.py`. bf16 is
+ *    a bit-exact drop-in for the f16 vmfb (verified board A/B).
+ *
+ * Writes `<outDir>/gemma-gen.mlir` + `<outDir>/gemma.safetensors`. `scripts/compile-gemma.sh`
+ * turns these into `gemma-gen.vmfb` (iree-compile llvm-cpu) + `gemma-gen.irpa`
+ * (iree-convert-parameters). Entry function stays `gemma` (no `@main` rename).
+ */
+public object FunctionGemmaExport {
+
+    public data class Result(
+        val mlirPath: String,
+        val safetensorsPath: String,
+        val externalParamCount: Int,
+        val weightMiB: Long,
+        val seq: Int,
+    )
+
+    public fun export(
+        gguf: String,
+        outDir: String,
+        seq: Int = 24,
+        partialRotary: Float = 1.0f,
+        bf16: Boolean = true,
+    ): Result = runBlocking {
+        val ctx = DirectCpuExecutionContext.create()
+        val weights = Gemma4WeightLoader(
+            randomAccessProvider = { JvmRandomAccessSource.open(gguf) },
+            quantPolicy = QuantPolicy.DEQUANTIZE_TO_FP32,
+        ).loadToMapStreaming<FP32, Float>(ctx, FP32::class)
+        // gemma3 uses FULL rotary; the gguf omits rope.partial_rotary_factor (loader defaults to a
+        // Gemma-4 0.25 that mis-rotates global layers). Force it.
+        val patched = weights.copy(
+            metadata = weights.metadata.copy(
+                ropeParametersFull = weights.metadata.ropeParametersFull.copy(partialRotaryFactor = partialRotary),
+            ),
+        )
+        val model = GemmaNetworkLoader.fromWeights(ctx, patched, FP32::class)
+
+        // Drop per-layer KV caches before tracing (KVCache.update() is non-traceable under
+        // VoidTensorOps -> 36 zero frozen params that kill RoPE/attention). One prefill pass
+        // needs no cache: K/V are computed fresh for every position.
+        fun stripKvCache(m: Module<*, *>) {
+            if (m is MultiHeadAttention<*, *>) m.kvCache = null
+            m.modules.forEach { stripKvCache(it) }
+        }
+        stripKvCache(model)
+
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(1, seq)
+                override fun get(vararg indices: Int): Float = 0.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+        val tapeCtx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = tapeCtx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                val ectx = this as ExecutionContext
+                val logits = model.forward(input, ectx)      // [1, seq, vocab] f32
+                val idx = ectx.ops.argMax(logits, dim = -1)  // [1, seq] i32  (the real DSL argMax op)
+                ectx.ops.squeeze(idx, 0)                     // [seq] i32 — the gemma-gen runtime contract
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(
+            synthesizeExternalInputs = true, embedConstants = true,
+        )
+        val module = StableHloConverterFactory
+            .createBasic(ConstantMaterializationPolicy.ExternalAlways(scope = "model"))
+            .convert(graph, "gemma")
+
+        val out = File(outDir).apply { mkdirs() }
+        val ext = module.externalParameters
+        val mlir = if (bf16) rewriteGlobalsToBf16(module.content) else module.content
+        val mlirFile = File(out, "gemma-gen.mlir").apply { writeText(mlir) }
+
+        val stFile = File(out, "gemma.safetensors")
+        val dtype = if (bf16) "BF16" else "F32"
+        val bpe = if (bf16) 2 else 4
+        var off = 0L
+        val hdr = StringBuilder("{")
+        ext.forEachIndexed { i, e ->
+            val count = e.source.sizeInBytes / 4          // f32 element count
+            val len = count * bpe
+            if (i > 0) hdr.append(",")
+            hdr.append("\"${e.key}\":{\"dtype\":\"$dtype\",\"shape\":[$count],\"data_offsets\":[$off,${off + len}]}")
+            off += len
+        }
+        hdr.append("}")
+        val headerBytes = hdr.toString().encodeToByteArray()
+        BufferedOutputStream(FileOutputStream(stFile), 1 shl 20).use { os ->
+            os.write(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(headerBytes.size.toLong()).array())
+            os.write(headerBytes)
+            for (e in ext) {
+                val src = e.source as BufferHandle.Owned
+                if (bf16) {
+                    val data = src.data
+                    val base = src.offset
+                    val n = src.sizeInBytes.toInt() / 4
+                    val obuf = ByteArray(n * 2)
+                    for (j in 0 until n) {
+                        val o = base + j * 4
+                        val fb = (data[o].toInt() and 0xFF) or
+                            ((data[o + 1].toInt() and 0xFF) shl 8) or
+                            ((data[o + 2].toInt() and 0xFF) shl 16) or
+                            ((data[o + 3].toInt() and 0xFF) shl 24)
+                        val bf = Bf16TensorData.floatToBf16Bits(Float.fromBits(fb)) // truncation = core parity
+                        obuf[j * 2] = (bf and 0xFF).toByte()
+                        obuf[j * 2 + 1] = ((bf ushr 8) and 0xFF).toByte()
+                    }
+                    os.write(obuf)
+                } else {
+                    os.write(src.data, src.offset, src.sizeInBytes.toInt())
+                }
+            }
+        }
+
+        val totalF32 = ext.sumOf { it.source.sizeInBytes }
+        Result(
+            mlirPath = mlirFile.absolutePath,
+            safetensorsPath = stFile.absolutePath,
+            externalParamCount = ext.size,
+            weightMiB = (if (bf16) totalF32 / 2 else totalF32) / (1024 * 1024),
+            seq = seq,
+        )
+    }
+
+    /** f32 weight `util.global`s -> bf16 + a `stablehlo.convert bf16->f32` on each load (compute stays f32). */
+    private fun rewriteGlobalsToBf16(mlir: String): String {
+        var m = mlir
+        m = Regex("""(util\.global private @\w+ = #flow\.parameter\.named<"[^"]*"::"[^"]*"> : tensor<[0-9x]*x)f32>""")
+            .replace(m) { it.groupValues[1] + "bf16>" }
+        m = Regex("""(%\w+) = util\.global\.load @(\w+) : tensor<([0-9x]*)xf32>""")
+            .replace(m) { r ->
+                val ssa = r.groupValues[1]
+                val g = r.groupValues[2]
+                val shape = r.groupValues[3]
+                "${ssa}_h = util.global.load @$g : tensor<${shape}xbf16>\n" +
+                    "    $ssa = stablehlo.convert ${ssa}_h : (tensor<${shape}xbf16>) -> tensor<${shape}xf32>"
+            }
+        return m
+    }
+}

--- a/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/FunctionGemmaExportMain.kt
+++ b/llm-runtime/kgemma/src/jvmMain/kotlin/sk/ainet/apps/kgemma/FunctionGemmaExportMain.kt
@@ -1,0 +1,23 @@
+package sk.ainet.apps.kgemma
+
+/**
+ * CLI entry for the FunctionGemma compiled export — driven by `scripts/compile-gemma.sh`.
+ *
+ *   GEMMA_GGUF=…Q5_K_M.gguf GEMMA_OUT_DIR=build/mlir \
+ *     ./gradlew -PuseLocalSkainet=true :llm-runtime:kgemma:exportFunctionGemma
+ *
+ * Env: GEMMA_GGUF (required), GEMMA_OUT_DIR (default build/mlir), GEN_SEQ (24),
+ * PARTIAL_ROTARY (1.0), GEMMA_DTYPE (bf16 default; set FP32 for numeric bring-up).
+ */
+public fun main(args: Array<String>) {
+    val gguf = System.getenv("GEMMA_GGUF") ?: error("set GEMMA_GGUF to the FunctionGemma Q5_K_M .gguf")
+    val outDir = System.getenv("GEMMA_OUT_DIR") ?: args.getOrNull(0) ?: "build/mlir"
+    val seq = System.getenv("GEN_SEQ")?.toInt() ?: 24
+    val partial = System.getenv("PARTIAL_ROTARY")?.toFloat() ?: 1.0f
+    val bf16 = !System.getenv("GEMMA_DTYPE").equals("FP32", ignoreCase = true)
+    val r = FunctionGemmaExport.export(gguf = gguf, outDir = outDir, seq = seq, partialRotary = partial, bf16 = bf16)
+    println(
+        "[functiongemma-export] wrote ${r.mlirPath} + ${r.safetensorsPath} " +
+            "(${r.externalParamCount} params, ${r.weightMiB} MiB, seq=${r.seq}, dtype=${if (bf16) "bf16" else "f32"})",
+    )
+}

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/FunctionGemmaEagerTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/FunctionGemmaEagerTest.kt
@@ -1,0 +1,33 @@
+package sk.ainet.apps.kgemma
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration: the one-line EAGER FunctionGemma facade transcribes an instruction into a tool call
+ * by running gemmaNetwork() on the CPU (no iree). Self-skips without the GGUF. Run with:
+ *   ./gradlew -PuseLocalSkainet=true -PkgemmaTestMaxHeap=12g \
+ *     :llm-runtime:kgemma:jvmTest --tests "*FunctionGemmaEagerTest*"
+ */
+class FunctionGemmaEagerTest {
+    private val gguf = System.getenv("GEMMA_GGUF")
+        ?: "/home/miso/projects/coral/SKaiNET-embedded/sl2610-function-calling/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+
+    @Test
+    fun eager_call_turn_the_light_on() {
+        if (!File(gguf).exists()) {
+            println("SKIP FunctionGemmaEagerTest: GGUF not present at $gguf")
+            return
+        }
+        val fg = FunctionGemma.fromGguf(gguf)
+        val turn = fg.call("turn the light on")
+        println("EAGER text='${turn.text}' calls=${turn.calls}")
+
+        assertTrue(turn.calls.isNotEmpty(), "expected a tool call, got text='${turn.text}'")
+        val c = turn.calls.first()
+        assertEquals("set_lights", c.tool, "tool")
+        assertEquals("on", c.args["state"], "state arg")
+    }
+}

--- a/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/FunctionGemmaExportTest.kt
+++ b/llm-runtime/kgemma/src/jvmTest/kotlin/sk/ainet/apps/kgemma/FunctionGemmaExportTest.kt
@@ -1,0 +1,55 @@
+package sk.ainet.apps.kgemma
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Integration: run the real FunctionGemma-270M compiled export and assert the emitted
+ * StableHLO is the gemma-gen contract with the DSL argMax tail + bf16 externals.
+ * Self-skips when the GGUF checkpoint isn't present (CI). Run with:
+ *   ./gradlew -PuseLocalSkainet=true -PkgemmaTestMaxHeap=12g \
+ *     :llm-runtime:kgemma:jvmTest --tests "*FunctionGemmaExportTest*"
+ */
+class FunctionGemmaExportTest {
+    private val gguf = System.getenv("GEMMA_GGUF")
+        ?: "/home/miso/projects/coral/SKaiNET-embedded/sl2610-function-calling/models/functiongemma-physical-ai-v10-Q5_K_M.gguf"
+
+    @Test
+    fun exports_gemma_gen_mlir_with_argmax_tail_and_bf16_externals() {
+        if (!File(gguf).exists()) {
+            println("SKIP FunctionGemmaExportTest: GGUF not present at $gguf")
+            return
+        }
+        val outDir = File(System.getProperty("java.io.tmpdir"), "fgemma-export").absolutePath
+        val r = FunctionGemmaExport.export(gguf = gguf, outDir = outDir, seq = 24, bf16 = true)
+        println("EXPORT extParams=${r.externalParamCount} weightMiB=${r.weightMiB} mlir=${r.mlirPath}")
+
+        assertTrue(r.externalParamCount > 100, "270M weights should lift to many external params")
+
+        val mlir = File(r.mlirPath).readText()
+
+        // Entry + argMax tail: func @gemma returns rank-1 i32 token ids for seq=24.
+        assertTrue(mlir.contains("func.func @gemma("), "entry func @gemma present")
+        assertTrue(mlir.contains("24xi32>"), "argMax+squeeze tail -> 24xi32")
+        assertTrue(
+            mlir.contains("stablehlo.iota") &&
+                mlir.contains("stablehlo.maximum") &&
+                mlir.contains("stablehlo.minimum"),
+            "argMax lowering (iota + reduce-max + reduce-min) present",
+        )
+
+        // bf16 externals: weight globals are bf16 with a convert-on-load; no f32 weight globals remain.
+        assertTrue(mlir.contains("xbf16>"), "bf16 weight globals present")
+        assertTrue(mlir.contains("stablehlo.convert"), "convert-on-load present")
+        val f32Global = Regex(
+            """util\.global private @\w+ = #flow\.parameter\.named<[^>]*> : tensor<[0-9x]*xf32>""",
+        ).find(mlir)
+        assertTrue(f32Global == null, "no f32 weight globals should remain after the bf16 fold")
+
+        val st = File(r.safetensorsPath)
+        assertTrue(st.exists() && st.length() > 0L, "bf16 safetensors written")
+        // bf16 (2 bytes) halves the f32 archive -> ~831 MiB, matching the proven f16 .irpa size.
+        assertTrue(r.weightMiB in 700..900, "bf16 weight archive ~831 MiB, got ${r.weightMiB} MiB")
+    }
+}


### PR DESCRIPTION
Packages **FunctionGemma** as a reusable, one-dependency library with both SKaiNET
execution modes — mirroring the Moonshine self-compile approach.

```kotlin
val fg = FunctionGemma.fromGguf("…functiongemma…Q5_K_M.gguf")
fg.call("turn the light on")     // EAGER (DirectCpu, no iree) -> ToolCall(set_lights,{state=on})
fg.exportCompiled("build/mlir")  // COMPILED (edge) -> gemma-gen.mlir + bf16 gemma.safetensors
```

### What
- **`FunctionGemma.call()`** — Octopus-v2 template → `OptimizedLLMRuntime(DIRECT)` greedy
  generation (with the `partialRotary=1.0` gemma3 fix) → `CompactCodec.parse`. Runs anywhere on
  CPU, no iree.
- **`FunctionGemmaExport.export()`** — promotes `RealGemmaBakeIrpaTest` into a library step:
  trace `gemmaNetwork()` ending in `ops.argMax(logits,-1)` (the new DSL op, retiring
  `add_argmax_perpos.py`) → StableHLO with `ExternalAlways` + **bf16 external globals** +
  bf16 safetensors (f32 compute via convert-on-load, retiring `make_f16.py`). Entry stays `@gemma`.
- `exportFunctionGemma` gradle task + main (driven by the demo's `scripts/compile-gemma.sh`).
- kgemma jvmMain deps: `skainet-compile-hlo`/`-dag` + `gemma-iree` (CompactCodec).

Depends on the `argMax` op in SKaiNET (build with `-PuseLocalSkainet=true`).

### Verified (real FunctionGemma-270M GGUF)
- Eager `call("turn the light on")` → `set_lights(state="on")`.
- Export → `func @gemma(1x24xi32)->24xi32` with bf16 externals that iree-compiles to a vmfb.
- **On the SL2610 board**: full greedy loop → `[262146,236769,3255,718,498,1373,262152,106]`
  = `<tool_0>(state="on")<end>`, token-for-token identical to llama.cpp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)