### PR TITLE
release: 0.35.0 — FunctionGemma self-compile (against engine 0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ version line is kept in lock-step with the underlying SKaiNET engine
 The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.0] — 2026-07-09
+
+Ships against **SKaiNET engine 0.35.0**, whose new `argMax` op this release uses to fold the LLM
+`logits → token-ids` tail into the DSL trace.
+
+### Added
+
+- **FunctionGemma self-compile from the SKaiNET DSL** (`sk.ainet.transformers:…-kgemma`). One reusable
+  dependency for the FunctionGemma-270M function-calling sLLM, in **both** SKaiNET execution modes:
+  - `FunctionGemma.fromGguf(gguf).call("turn the light on")` → `ToolCall(set_lights, {state="on"})` —
+    **eager** (DirectCpu + `OptimizedLLMRuntime(DIRECT)` + Octopus-v2 template + `CompactCodec`), runs
+    anywhere on CPU, no iree. (The `partialRotary = 1.0` gemma3 rotary fix is applied.)
+  - `FunctionGemma.exportCompiled(outDir)` / `FunctionGemmaExport.export(…)` — **compiled** edge path:
+    traces `gemmaNetwork()` ending in `ops.argMax(logits, -1)` (the engine op), emits StableHLO with
+    **bf16 external params** (bf16 globals + convert-on-load + bf16 safetensors). Promotes the former
+    `RealGemmaBakeIrpaTest` and retires the Python argmax/f16 MLIR rewrites. Verified token-for-token
+    against llama.cpp on the SL2610 board.
+  - `exportFunctionGemma` Gradle task (for `scripts/compile-gemma.sh`); `kgemma` jvm deps gain
+    `skainet-compile-hlo`/`-dag` + `gemma-iree` (`CompactCodec`).
+
+### Changed
+
+- **Engine → 0.35.0.** Adopts the new engine line; the compiled FunctionGemma export depends on the
+  engine's new `argMax` op. (engine 0.35.0)
+
 ## [0.34.1] — 2026-07-05
 
 Patch on **0.34.0** (same SKaiNET engine 0.34.0). Fixes Moonshine encoder parameter naming.

--- a/README.md
+++ b/README.md
@@ -103,9 +103,17 @@ Honest status — see the project-status note at the top of this README.
 
 ## Current release
 
-The current release is **0.34.1** (against **SKaiNET 0.34.0**) — a patch that layer-qualifies the
+The current release is **0.35.0** (against **SKaiNET 0.35.0**) — it adds **FunctionGemma**
+self-compiled from the SKaiNET NN DSL: a one-dependency function-calling sLLM
+(`skainet-transformers-runtime-kgemma`) with an eager one-line API
+(`FunctionGemma.fromGguf(gguf).call("turn the light on")` → `ToolCall(set_lights, {state="on"})`, runs
+anywhere on CPU, no iree) **and** a no-Python compiled edge export (`FunctionGemma.exportCompiled` /
+`compile-gemma.sh`) verified token-for-token against llama.cpp on the SL2610 board. It uses the engine's
+new `argMax` op to fold the `logits → token-ids` argmax tail into the DSL trace.
+
+It builds on **0.34.1** — a patch that layer-qualifies the
 Moonshine encoder's attention/LayerNorm parameter names so by-name weight loading can tell the
-layers apart (no public API change). It builds on **0.34.0**, which adds the first **Moonshine**
+layers apart (no public API change) — and on **0.34.0**, which adds the first **Moonshine**
 speech-to-text encoder authored entirely in the SKaiNET NN DSL (`skainet-transformers-inference-moonshine`,
 bf16-native) — it emits portable StableHLO and transcribes correctly on both CPU and the Synaptics Torq
 NPU. Supporting this, `transformer-core` RoPE now computes its rotation and `cos`/`sin` tables in **f32**
@@ -130,7 +138,7 @@ The recommended way to consume is via the BOM. It pins every published `skainet-
 
 ```kotlin
 dependencies {
-    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.32.1"))
+    implementation(platform("sk.ainet.transformers:skainet-transformers-bom:0.35.0"))
 
     // Versions resolved from the BOM:
     implementation("sk.ainet.transformers:skainet-transformers-core")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.transformers
-VERSION_NAME=0.34.1
+VERSION_NAME=0.35.0
 
 POM_DESCRIPTION=SKaiNET-transformers
 


### PR DESCRIPTION
- Bump VERSION_NAME 0.34.1 -> 0.35.0 (lock-step with SKaiNET engine 0.35.0; the pin skainet=0.35.0 landed via #216).
- CHANGELOG: new [0.35.0] section — FunctionGemma facade + compiled export in kgemma (eager .call() + .exportCompiled()), using the engine's new argMax op; retires the Python argmax/f16 rewrites; board-verified vs llama.cpp.
- README: Current-release lead + BOM snippet updated to 0.35.0.