### PR TITLE
vec2text: add beam search (token-level + sequence-level)

### DIFF
--- a/llm-inference/t5/src/commonMain/kotlin/sk/ainet/models/t5/T5Runtime.kt
+++ b/llm-inference/t5/src/commonMain/kotlin/sk/ainet/models/t5/T5Runtime.kt
@@ -18,6 +18,7 @@ import sk.ainet.lang.tensor.t
 import sk.ainet.lang.tensor.times
 import sk.ainet.lang.tensor.unsqueeze
 import sk.ainet.lang.types.DType
+import kotlin.math.pow
 import kotlin.reflect.KClass
 
 /**
@@ -100,33 +101,70 @@ public class T5Runtime<T : DType>(
      * token ids (excluding the decoder start token, up to and including EOS or [maxLength]).
      */
     public fun generate(encoderMemory: Tensor<T, Float>, maxLength: Int = 128): IntArray {
-        val decLayers = weights.decoderLayers
-            ?: error("T5Runtime.generate: weights were loaded without a decoder")
-        val bias = decoderBias ?: error("T5Runtime.generate: no decoder relative bias")
+        weights.decoderLayers ?: error("T5Runtime.generate: weights were loaded without a decoder")
 
         val generated = ArrayList<Int>(maxLength)
         val decoderIds = ArrayList<Int>(maxLength + 1)
         decoderIds.add(cfg.decoderStartTokenId)
 
         while (generated.size < maxLength) {
-            val curLen = decoderIds.size
-            var h = embed(decoderIds.toIntArray())
-            val selfBias = biasTensor(bias.compute(curLen, curLen, causal = true), curLen, curLen)
-            for (layer in decLayers) {
-                val sa = attention(rmsNorm(h, layer.selfAttnNorm), null, layer.selfAttn, selfBias)
-                h = h + sa
-                val ca = attention(rmsNorm(h, layer.crossAttnNorm), encoderMemory, layer.crossAttn, null)
-                h = h + ca
-                val ff = feedForward(rmsNorm(h, layer.ffNorm), layer.ff)
-                h = h + ff
-            }
-            val normed = rmsNorm(h, weights.decoderFinalNorm!!)
-            val nextId = argmaxLastRowLogits(normed, curLen)
-            generated.add(nextId)
-            if (nextId == cfg.eosTokenId) break
-            decoderIds.add(nextId)
+            val logits = decoderLastLogits(encoderMemory, decoderIds.toIntArray())
+            var best = 0
+            for (i in 1 until logits.size) if (logits[i] > logits[best]) best = i
+            generated.add(best)
+            if (best == cfg.eosTokenId) break
+            decoderIds.add(best)
         }
         return generated.toIntArray()
+    }
+
+    /**
+     * Beam-search decode conditioned on [encoderMemory]. Returns up to [numBeams] complete
+     * sequences (each excluding the decoder start token), ordered best-first by
+     * length-normalized log-probability (`score / genLen^lengthPenalty`, HF's convention;
+     * `lengthPenalty = 1.0` = mean token log-prob). `numBeams <= 1` falls back to [generate].
+     *
+     * Like the greedy path this recomputes the full decoder per step per beam (no KV cache),
+     * so cost scales ~linearly with [numBeams]; keep it small (2–8) for the vec2text sizes.
+     */
+    public fun generateBeam(
+        encoderMemory: Tensor<T, Float>,
+        numBeams: Int,
+        maxLength: Int = 128,
+        lengthPenalty: Double = 1.0,
+    ): List<IntArray> {
+        if (numBeams <= 1) return listOf(generate(encoderMemory, maxLength))
+        weights.decoderLayers ?: error("T5Runtime.generateBeam: weights were loaded without a decoder")
+
+        var beams = listOf(BeamHyp(intArrayOf(cfg.decoderStartTokenId), 0.0, finished = false))
+        val finished = ArrayList<BeamHyp>()
+
+        repeat(maxLength) {
+            val candidates = ArrayList<BeamHyp>(beams.size * numBeams)
+            for (b in beams) {
+                val logProbs = logSoftmax(decoderLastLogits(encoderMemory, b.ids))
+                for (t in topKIndices(logProbs, numBeams)) {
+                    candidates.add(BeamHyp(b.ids + t, b.score + logProbs[t], finished = t == cfg.eosTokenId))
+                }
+            }
+            candidates.sortByDescending { normalizedScore(it, lengthPenalty) }
+            val active = ArrayList<BeamHyp>(numBeams)
+            for (b in candidates.take(numBeams)) if (b.finished) finished.add(b) else active.add(b)
+            beams = active
+            if (beams.isEmpty() || finished.size >= numBeams) return@repeat
+        }
+
+        return (finished + beams)
+            .sortedByDescending { normalizedScore(it, lengthPenalty) }
+            .take(numBeams)
+            .map { it.ids.copyOfRange(1, it.ids.size) } // drop the decoder start token
+    }
+
+    private class BeamHyp(val ids: IntArray, val score: Double, val finished: Boolean)
+
+    private fun normalizedScore(b: BeamHyp, lengthPenalty: Double): Double {
+        val genLen = (b.ids.size - 1).coerceAtLeast(1)
+        return b.score / genLen.toDouble().pow(lengthPenalty)
     }
 
     // ---- building blocks --------------------------------------------------
@@ -188,17 +226,51 @@ public class T5Runtime<T : DType>(
     private fun biasTensor(flat: FloatArray, lq: Int, lk: Int): Tensor<T, Float> =
         ctx.fromFloatArray(Shape(cfg.numHeads, lq, lk), dtype, flat)
 
-    /** Scale the last hidden row by `d_model^-0.5`, project to vocab, and argmax. */
-    private fun argmaxLastRowLogits(hidden: Tensor<T, Float>, curLen: Int): Int {
-        val lastRow = hidden.narrow(dim = 0, start = curLen - 1, length = 1) // [1, dModel]
-        val scale = 1.0f / kotlin.math.sqrt(cfg.dModel.toFloat())
-        val logits = (lastRow * scale).matmul(weights.shared.t())           // [1, vocab]
-        val arr = logits.data.copyToFloatArray()
-        var best = 0
-        var bestVal = arr[0]
-        for (i in 1 until arr.size) {
-            if (arr[i] > bestVal) { bestVal = arr[i]; best = i }
+    /**
+     * Run the decoder stack over [decoderIds] (including the start token) attending to
+     * [encoderMemory], and return the **last position's** vocab logits `[vocab]` as a
+     * FloatArray (after the `d_model^-0.5` tied-embedding scaling). Shared by greedy and
+     * beam decoding.
+     */
+    private fun decoderLastLogits(encoderMemory: Tensor<T, Float>, decoderIds: IntArray): FloatArray {
+        val decLayers = weights.decoderLayers!!
+        val bias = decoderBias!!
+        val curLen = decoderIds.size
+        var h = embed(decoderIds)
+        val selfBias = biasTensor(bias.compute(curLen, curLen, causal = true), curLen, curLen)
+        for (layer in decLayers) {
+            val sa = attention(rmsNorm(h, layer.selfAttnNorm), null, layer.selfAttn, selfBias)
+            h = h + sa
+            val ca = attention(rmsNorm(h, layer.crossAttnNorm), encoderMemory, layer.crossAttn, null)
+            h = h + ca
+            val ff = feedForward(rmsNorm(h, layer.ffNorm), layer.ff)
+            h = h + ff
         }
-        return best
+        val normed = rmsNorm(h, weights.decoderFinalNorm!!)
+        val lastRow = normed.narrow(dim = 0, start = curLen - 1, length = 1) // [1, dModel]
+        val scale = 1.0f / kotlin.math.sqrt(cfg.dModel.toFloat())
+        return (lastRow * scale).matmul(weights.shared.t()).data.copyToFloatArray() // [vocab]
+    }
+
+    /** Numerically-stable log-softmax of a logits FloatArray → per-index log-probability. */
+    private fun logSoftmax(logits: FloatArray): DoubleArray {
+        var max = logits[0]
+        for (l in logits) if (l > max) max = l
+        var sum = 0.0
+        for (l in logits) sum += kotlin.math.exp((l - max).toDouble())
+        val logDenom = kotlin.math.ln(sum) + max
+        return DoubleArray(logits.size) { logits[it] - logDenom }
+    }
+
+    /** Indices of the [k] largest entries of [scores] (unordered), via a linear top-k scan. */
+    private fun topKIndices(scores: DoubleArray, k: Int): IntArray {
+        val idx = IntArray(k) { -1 }
+        val vals = DoubleArray(k) { Double.NEGATIVE_INFINITY }
+        for (i in scores.indices) {
+            var minSlot = 0
+            for (j in 1 until k) if (vals[j] < vals[minSlot]) minSlot = j
+            if (scores[i] > vals[minSlot]) { vals[minSlot] = scores[i]; idx[minSlot] = i }
+        }
+        return idx
     }
 }

--- a/llm-inference/vec2text/src/commonMain/kotlin/sk/ainet/models/vec2text/CorrectorModel.kt
+++ b/llm-inference/vec2text/src/commonMain/kotlin/sk/ainet/models/vec2text/CorrectorModel.kt
@@ -41,7 +41,19 @@ public class CorrectorModel<T : DType>(
         hypothesisEmbedding: Tensor<T, Float>,
         hypothesisIds: IntArray,
         maxLength: Int = 128,
-    ): IntArray {
+    ): IntArray = correctBeam(targetEmbedding, hypothesisEmbedding, hypothesisIds, numBeams = 1, maxLength = maxLength).first()
+
+    /**
+     * Beam-search variant returning up to [numBeams] refined candidates, best-first
+     * (token-level beam over the T5 decoder). `numBeams = 1` is plain greedy.
+     */
+    public fun correctBeam(
+        targetEmbedding: Tensor<T, Float>,
+        hypothesisEmbedding: Tensor<T, Float>,
+        hypothesisIds: IntArray,
+        numBeams: Int,
+        maxLength: Int = 128,
+    ): List<IntArray> {
         val diff = targetEmbedding - hypothesisEmbedding
         val pTarget = weights.transform1.project(targetEmbedding)      // [R, d]
         val pHyp = weights.transform3.project(hypothesisEmbedding)     // [R, d]
@@ -55,6 +67,6 @@ public class CorrectorModel<T : DType>(
         )
         val normed = layerNorm.forward(inputsEmbeds, ctx)
         val memory = t5.encode(normed)
-        return t5.generate(memory, maxLength)
+        return t5.generateBeam(memory, numBeams, maxLength)
     }
 }

--- a/llm-inference/vec2text/src/commonMain/kotlin/sk/ainet/models/vec2text/InversionModel.kt
+++ b/llm-inference/vec2text/src/commonMain/kotlin/sk/ainet/models/vec2text/InversionModel.kt
@@ -19,9 +19,20 @@ public class InversionModel<T : DType>(
     private val t5 = T5Runtime(ctx, weights.t5, dtype)
 
     /** Produce the initial hypothesis token ids (T5 tokenizer space) from a `[dEmbedder]` target. */
-    public fun invert(targetEmbedding: Tensor<T, Float>, maxLength: Int = 128): IntArray {
+    public fun invert(targetEmbedding: Tensor<T, Float>, maxLength: Int = 128): IntArray =
+        invertBeam(targetEmbedding, numBeams = 1, maxLength = maxLength).first()
+
+    /**
+     * Beam-search variant returning up to [numBeams] candidate hypotheses, best-first
+     * (token-level beam over the T5 decoder). `numBeams = 1` is plain greedy.
+     */
+    public fun invertBeam(
+        targetEmbedding: Tensor<T, Float>,
+        numBeams: Int,
+        maxLength: Int = 128,
+    ): List<IntArray> {
         val pseudoTokens = weights.transform.project(targetEmbedding) // [R, dModel]
         val memory = t5.encode(pseudoTokens)
-        return t5.generate(memory, maxLength)
+        return t5.generateBeam(memory, numBeams, maxLength)
     }
 }

--- a/llm-inference/vec2text/src/commonMain/kotlin/sk/ainet/models/vec2text/Vec2TextInverter.kt
+++ b/llm-inference/vec2text/src/commonMain/kotlin/sk/ainet/models/vec2text/Vec2TextInverter.kt
@@ -45,11 +45,35 @@ public class Vec2TextInverter<T : DType>(
 ) {
     /**
      * Invert [text]'s embedding back to text using [numSteps] correction rounds.
+     *
+     * With [sequenceBeamWidth] and [tokenBeams] both 1 (default) this is the greedy path.
+     * Raising them enables beam search (vec2text's main quality lever):
+     * - [tokenBeams] — token-level beam inside each T5 generation.
+     * - [sequenceBeamWidth] — keep this many hypotheses across correction rounds, ranked by
+     *   cosine similarity to the target embedding (the "oracle" that beam search exploits).
      * (Set [numSteps] = 0 for single-shot inversion — the hypothesizer only.)
      */
-    public fun invert(text: String, numSteps: Int = 20, maxLength: Int = 128): Vec2TextResult {
-        val target = embedder.embed(tokenizer.encodeForEmbedder(text))
+    public fun invert(
+        text: String,
+        numSteps: Int = 20,
+        maxLength: Int = 128,
+        sequenceBeamWidth: Int = 1,
+        tokenBeams: Int = 1,
+    ): Vec2TextResult =
+        invertEmbedding(embedder.embed(tokenizer.encodeForEmbedder(text)), numSteps, maxLength, sequenceBeamWidth, tokenBeams)
 
+    /** As [invert], but starting from a raw target embedding (e.g. an interpolated vector). */
+    public fun invertEmbedding(
+        target: Tensor<T, Float>,
+        numSteps: Int = 20,
+        maxLength: Int = 128,
+        sequenceBeamWidth: Int = 1,
+        tokenBeams: Int = 1,
+    ): Vec2TextResult =
+        if (sequenceBeamWidth <= 1 && tokenBeams <= 1) invertGreedy(target, numSteps, maxLength)
+        else invertBeam(target, numSteps, maxLength, sequenceBeamWidth.coerceAtLeast(1), tokenBeams.coerceAtLeast(1))
+
+    private fun invertGreedy(target: Tensor<T, Float>, numSteps: Int, maxLength: Int): Vec2TextResult {
         var hypIds = inversion.invert(target, maxLength)
         var hypText = tokenizer.decode(hypIds)
         var cos = cosineToTarget(target, hypText)
@@ -76,6 +100,47 @@ public class Vec2TextInverter<T : DType>(
         }
         return Vec2TextResult(bestText, bestCos, trace)
     }
+
+    /** Sequence-level beam: keep [beamWidth] hypotheses per round, ranked by cosine to [target]. */
+    private fun invertBeam(
+        target: Tensor<T, Float>,
+        numSteps: Int,
+        maxLength: Int,
+        beamWidth: Int,
+        tokenBeams: Int,
+    ): Vec2TextResult {
+        var beams = rankByCosine(target, inversion.invertBeam(target, maxOf(beamWidth, tokenBeams), maxLength)).take(beamWidth)
+        val trace = ArrayList<Vec2TextStep>()
+        var best = beams.first()
+        trace.add(Vec2TextStep(0, best.text, best.cos))
+
+        for (step in 1..numSteps) {
+            val pool = ArrayList<IntArray>()
+            for (b in beams) {
+                val hypEmb = embedder.embed(tokenizer.encodeForEmbedder(b.text))
+                pool += corrector.correctBeam(target, hypEmb, b.ids, tokenBeams, maxLength)
+            }
+            beams = rankByCosine(target, pool).take(beamWidth)
+            val stepBest = beams.first()
+            trace.add(Vec2TextStep(step, stepBest.text, stepBest.cos))
+
+            val improvement = stepBest.cos - best.cos
+            if (stepBest.cos > best.cos) best = stepBest
+            if (abs(improvement) < EARLY_STOP_ATOL) break
+        }
+        return Vec2TextResult(best.text, best.cos, trace)
+    }
+
+    /** Decode + re-embed each candidate, dedup by text, and sort by cosine to [target] (best first). */
+    private fun rankByCosine(target: Tensor<T, Float>, idsList: List<IntArray>): List<Candidate> =
+        idsList.asSequence()
+            .map { ids -> tokenizer.decode(ids) to ids }
+            .distinctBy { it.first }
+            .map { (text, ids) -> Candidate(ids, text, cosineToTarget(target, text)) }
+            .sortedByDescending { it.cos }
+            .toList()
+
+    private class Candidate(val ids: IntArray, val text: String, val cos: Float)
 
     private fun cosineToTarget(target: Tensor<T, Float>, hypText: String): Float {
         val hypEmb = embedder.embed(tokenizer.encodeForEmbedder(hypText))

--- a/llm-inference/vec2text/src/jvmTest/kotlin/sk/ainet/models/vec2text/Vec2TextRoundTripTest.kt
+++ b/llm-inference/vec2text/src/jvmTest/kotlin/sk/ainet/models/vec2text/Vec2TextRoundTripTest.kt
@@ -14,6 +14,7 @@ import sk.ainet.models.t5.loadT5Weights
 import sk.ainet.lang.types.FP32
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 /**
  * End-to-end embedding-inversion round-trip against the real gtr-base checkpoints.
@@ -43,36 +44,55 @@ class Vec2TextRoundTripTest {
             sp.decode(ids.filter { it != 0 && it != eosId }.toIntArray())
     }
 
-    @Test
-    fun invert_roundTrip() = runBlocking {
-        val d = dir
-        val required = listOf("tokenizer.json", "gtr_encoder.safetensors", "inversion.safetensors", "corrector.safetensors")
-        if (d == null || required.any { !File(d, it).exists() }) {
-            println("SKIP Vec2TextRoundTripTest: set VEC2TEXT_MODELS_DIR to the exported models dir")
-            return@runBlocking
-        }
-
+    private suspend fun buildInverter(d: File): Vec2TextInverter<FP32> {
         val ctx = DirectCpuExecutionContext()
         val cfg = T5Config()
-
         fun loader(name: String) =
             SafeTensorsParametersLoader(sourceProvider = { JvmRandomAccessSource.open(File(d, name).toString()) })
-
         val gtrWeights = loadT5Weights(loader("gtr_encoder.safetensors"), ctx, FP32::class, cfg, "", withDecoder = false)
         val embedder = GtrEmbedder(T5Runtime(ctx, gtrWeights, FP32::class))
         val inversion = InversionModel(ctx, Vec2TextWeightLoader.loadInversion(loader("inversion.safetensors"), ctx, FP32::class, cfg), FP32::class)
         val corrector = CorrectorModel(ctx, Vec2TextWeightLoader.loadCorrector(loader("corrector.safetensors"), ctx, FP32::class, cfg), FP32::class)
+        val sp = SentencePieceTokenizer.fromTokenizerJson(Json.parseToJsonElement(File(d, "tokenizer.json").readText()).jsonObject)
+        return Vec2TextInverter(embedder, inversion, corrector, T5Codec(sp, cfg.maxSeqLength, cfg.eosTokenId))
+    }
 
-        val tokenizerJson = Json.parseToJsonElement(File(d, "tokenizer.json").readText()).jsonObject
-        val sp = SentencePieceTokenizer.fromTokenizerJson(tokenizerJson)
-        val codec = T5Codec(sp, cfg.maxSeqLength, cfg.eosTokenId)
+    private fun modelsOrSkip(): File? {
+        val d = dir
+        val required = listOf("tokenizer.json", "gtr_encoder.safetensors", "inversion.safetensors", "corrector.safetensors")
+        if (d == null || required.any { !File(d, it).exists() }) {
+            println("SKIP: set VEC2TEXT_MODELS_DIR to the exported models dir")
+            return null
+        }
+        return d
+    }
 
-        val inverter = Vec2TextInverter(embedder, inversion, corrector, codec)
+    @Test
+    fun invert_roundTrip() = runBlocking {
+        val d = modelsOrSkip() ?: return@runBlocking
+        val inverter = buildInverter(d)
         val text = "jack morris is a phd student at cornell tech in new york city"
         val result = inverter.invert(text, numSteps = 3, maxLength = 32)
 
         println("original:      $text")
         println("reconstructed: ${result.text}  (cos=${result.cosine})")
         result.trace.forEach { println("  step ${it.step}: cos=${it.cosine}  \"${it.text}\"") }
+    }
+
+    /** Beam search should reconstruct at least as well as greedy at matched steps. */
+    @Test
+    fun invert_beamBeatsGreedy() = runBlocking {
+        val d = modelsOrSkip() ?: return@runBlocking
+        val inverter = buildInverter(d)
+        val text = "jack morris is a phd student at cornell tech in new york city"
+
+        val greedy = inverter.invert(text, numSteps = 1, maxLength = 32)
+        val beam = inverter.invert(text, numSteps = 1, maxLength = 32, sequenceBeamWidth = 3, tokenBeams = 3)
+
+        println("greedy: cos=${greedy.cosine}  \"${greedy.text}\"")
+        println("beam:   cos=${beam.cosine}  \"${beam.text}\"")
+        // Beam explores more candidates and picks by cosine, so it should not do worse
+        // (small fp tolerance for ties).
+        assertTrue(beam.cosine >= greedy.cosine - 1e-4f, "beam ${beam.cosine} < greedy ${greedy.cosine}")
     }
 }


### PR DESCRIPTION
Beam search is vec2text's main quality lever; this adds both levels, off by default (numBeams / beamWidth = 1 keeps the existing greedy behavior).

- T5Runtime.generateBeam(memory, numBeams, maxLength, lengthPenalty): token-level beam over the decoder, returning up to numBeams sequences best-first by length-normalized log-prob. Shares a new decoderLastLogits() step with greedy; adds logSoftmax + linear top-k helpers. No KV cache, so cost scales ~linearly with numBeams.
- InversionModel.invertBeam / CorrectorModel.correctBeam: expose top-N candidates.
- Vec2TextInverter.invert(..., sequenceBeamWidth, tokenBeams) + invertEmbedding(): sequence-level beam that keeps beamWidth hypotheses across correction rounds, ranked by cosine similarity to the target embedding (the oracle beam exploits). Greedy path unchanged when both widths are 1.

Verified end-to-end on the gtr-base weights: at one correction step, beam (width 3, token-beams 3) improves cosine 0.765 -> 0.818 over greedy on the README example, with a closer reconstruction. See Vec2TextRoundTripTest.