### PR TITLE
Moonshine: androidNative via eager TransformerBlock in transformer-core (#239)

### DIFF
--- a/llm-inference/moonshine/build.gradle.kts
+++ b/llm-inference/moonshine/build.gradle.kts
@@ -6,11 +6,18 @@ plugins {
 // Moonshine-tiny ASR (encoder-decoder) authored in the SKaiNET NN DSL, bf16-native
 // so the DSL->StableHLO export keeps bf16 weights at the matmul (required by the
 // Torq NPU: fp32 weights crash the torq compiler's getWeightMemoryFormat — see the
-// demo docs/torq-npu-weight-crash.md). Targets mirror the board/host path only
-// (jvm for authoring/export tests, linux{X64,Arm64} for the device); the wide
-// gemma target set is unnecessary here.
+// demo docs/torq-npu-weight-crash.md).
+//
+// commonMain depends ONLY on lang-core + transformer-core (both androidNative-capable), so the
+// model runs on the edge NPU / phone target set as well as the host. The encoder uses
+// transformer-core's eager `TransformerBlock` (not llm-core's compile-capable
+// `HybridTransformerBlock`), which is why llm-core / io / compile drop out of commonMain — they
+// were only ever used by the jvmTest MLIR-dump / GGUFTokenizer path. (GH #239.)
 kotlin {
     jvm()
+    androidNativeArm32()
+    androidNativeArm64()
+    iosArm64()
     linuxX64()
     linuxArm64()
 
@@ -18,22 +25,15 @@ kotlin {
         commonMain.dependencies {
             implementation(project.dependencies.platform(project(":llm-bom")))
             implementation(libs.skainet.lang.core)
-            implementation(libs.skainet.io.core)
-            implementation(libs.skainet.io.safetensors)
-            implementation(libs.skainet.compile.core)
-            implementation(project(":llm-core")) // brings transformer-core transitively
-            implementation(libs.kotlinx.io.core)
-        }
-        commonTest.dependencies {
-            implementation(libs.kotlin.test)
-            implementation(libs.skainet.backend.cpu)
+            implementation(project(":transformer-core"))
         }
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotlin.test)
                 implementation(libs.skainet.backend.cpu)
+                implementation(project(":llm-core"))     // GGUFTokenizer for the E2E decode test
                 // DSL -> ComputeGraph -> StableHLO export (host tooling), for the
-                // MLIR-dump test that proves the encoder traces to bf16 StableHLO.
+                // MLIR-dump tests that prove the encoder/decoder trace to bf16 StableHLO.
                 implementation(libs.skainet.compile.dag)
                 implementation(libs.skainet.compile.hlo)
                 implementation(libs.skainet.compile.opt)

--- a/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshineEncoder.kt
+++ b/llm-inference/moonshine/src/commonMain/kotlin/sk/ainet/models/moonshine/MoonshineEncoder.kt
@@ -1,6 +1,6 @@
 package sk.ainet.models.moonshine
 
-import sk.ainet.apps.llm.HybridTransformerBlock
+import sk.ainet.lang.nn.transformer.TransformerBlock
 import sk.ainet.lang.nn.DefaultNeuralNetworkExecutionContext
 import sk.ainet.lang.nn.Module
 import sk.ainet.lang.nn.activations.GELU
@@ -75,7 +75,7 @@ public fun <T : DType, V> moonshineEncoder(
         stage.modules += VoidDense<T, V>("enc.$layer.ffn_down", dim, cfg.ffnDim, dtype, addBias = true)
         stage.residual()
 
-        dsl.modules += HybridTransformerBlock(stage.modules.toList(), name = "enc.$layer")
+        dsl.modules += TransformerBlock(stage.modules.toList(), name = "enc.$layer")
     }
 
     dsl.layerNorm(intArrayOf(dim), eps.toDouble(), id = "enc_out_norm")

--- a/transformer-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/TransformerBlock.kt
+++ b/transformer-core/src/commonMain/kotlin/sk/ainet/lang/nn/transformer/TransformerBlock.kt
@@ -1,0 +1,57 @@
+package sk.ainet.lang.nn.transformer
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+
+/**
+ * Eager transformer block: a residual-aware container over an ordered list of sub-modules.
+ *
+ * A block is a flat module list punctuated by [ResidualAdd] markers, e.g.
+ * `[norm, attn, residual(), norm, ffn, residual()]`. On [onForward] the input to each residual
+ * sub-block is captured at the sub-block's start and handed to that block's [ResidualAdd] so it
+ * can add the skip connection — exactly the wiring the network DSL's `residual()` expects.
+ *
+ * This depends only on `lang-core` + `transformer-core` (no compiler, no io, no platform
+ * diagnostics), so it builds on the full KMP matrix **including androidNative** — the on-device
+ * (edge NPU / phone) target set. It is the eager core that `HybridTransformerBlock` (llm-core)
+ * wraps with its optional JVM/linux compiled fast-path; models that only need eager execution
+ * (and export unchanged to StableHLO) should use this directly.
+ */
+public open class TransformerBlock<T : DType, V>(
+    private val modulesList: List<Module<T, V>>,
+    override val name: String = "TransformerBlock",
+) : Module<T, V>() {
+
+    override val modules: List<Module<T, V>>
+        get() = modulesList
+
+    // For each ResidualAdd at index i, the index at which its residual sub-block began (the module
+    // after the previous ResidualAdd, or 0). The block's input is the skip added at that residual.
+    private val residualBlockStarts: Map<Int, Int> = buildMap {
+        var blockStart = 0
+        for (i in modulesList.indices) {
+            if (modulesList[i] is ResidualAdd<*, *>) {
+                put(i, blockStart)
+                blockStart = i + 1
+            }
+        }
+    }
+
+    override fun onForward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> {
+        val outputs = arrayOfNulls<Any>(modulesList.size + 1)
+        outputs[0] = input
+        var tmp = input
+        for (i in modulesList.indices) {
+            val module = modulesList[i]
+            residualBlockStarts[i]?.let { blockStart ->
+                @Suppress("UNCHECKED_CAST")
+                (module as ResidualAdd<T, V>).savedInput = outputs[blockStart] as Tensor<T, V>
+            }
+            tmp = module.forward(tmp, ctx)
+            outputs[i + 1] = tmp
+        }
+        return tmp
+    }
+}


### PR DESCRIPTION
Fixes #239.

## What

Unblocks androidNative for the Moonshine ASR model by extracting the eager transformer-block
container out of `llm-core`'s `HybridTransformerBlock` into `transformer-core`.

## Why

`llm-inference/moonshine` was pinned to jvm/linux. An audit of its `commonMain` shows the **only**
non-`lang-core` / non-`transformer-core` dependency is:

```
import sk.ainet.apps.llm.HybridTransformerBlock   // llm-core → compile-opt/-dag → no androidNative
```

Moonshine uses it purely as an eager, residual-aware module container (`directForward`). The
`compile()` / `hybridForward` fast-path — the only reason `HybridTransformerBlock` needs the
compiler — is never called by Moonshine (the on-device path runs the compiled IREE vmfb, not this
in-Kotlin hybrid compile).

## Changes

- **`transformer-core`**: new `TransformerBlock` — the eager residual-block container
  (`residualBlockStarts` bookkeeping + child iteration setting `ResidualAdd.savedInput`), depending
  only on `lang-core` + `transformer-core`, so it builds on the full KMP matrix incl.
  androidNative. `HybridTransformerBlock` stays in `llm-core` as the compile-capable wrapper (it
  could later `extends TransformerBlock` to de-duplicate the residual logic).
- **`llm-inference/moonshine`**: `MoonshineEncoder` uses `TransformerBlock`; targets widened to
  `androidNativeArm32/Arm64` + `iosArm64`; `llm-core` / `io-*` / `compile-*` moved from
  `commonMain` to `jvmTest` (only ever used by the MLIR-dump / `GGUFTokenizer` tests).

## Verification

- All 9 `:llm-inference:moonshine:jvmTest` pass — including the StableHLO MLIR-dump tests (so
  `TransformerBlock` traces/exports identically) and the `MoonshineDecoderE2ECpuTest`
  ("One, two, three.").
- `:transformer-core` and `:llm-inference:moonshine` compile for `androidNativeArm32`,
  `androidNativeArm64`, and `iosArm64`.

## Follow-up (not in this PR)

On-device weight loading (`io-safetensors`) and tokenizer decode (`io-core`) still lack
androidNative. The compiled cartridge bakes weights into the vmfb (no on-device SafeTensors), and
BPE decode is pure table lookup that could move to a `lang-core`-only module — tracked separately.
